### PR TITLE
common: detect pmemvlt support in libpmemobj

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,8 +281,31 @@ add_cppstyle("include-detail" ${CMAKE_CURRENT_SOURCE_DIR}/include/libpmemobj++/d
 add_check_whitespace("include" ${CMAKE_CURRENT_SOURCE_DIR}/include/libpmemobj++/*.hpp)
 add_check_whitespace("include-detail" ${CMAKE_CURRENT_SOURCE_DIR}/include/libpmemobj++/detail/*.hpp)
 
-install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-	FILES_MATCHING PATTERN "*.hpp")
+if(PKG_CONFIG_FOUND)
+	pkg_check_modules(PMEMOBJ REQUIRED libpmemobj>=1.4)
+else()
+	find_package(PMEMOBJ REQUIRED 1.4)
+endif()
+
+# Check for existence of pmemvlt (introduced after 1.4 release)
+set(SAVED_CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES})
+set(CMAKE_REQUIRED_INCLUDES ${PMEMOBJ_INCLUDE_DIRS})
+CHECK_CXX_SOURCE_COMPILES(
+	"#include <libpmemobj.h>
+	struct pmemvlt vlt;
+	int main() {}"
+	PMEMVLT_PRESENT)
+set(CMAKE_REQUIRED_INCLUDES ${SAVED_CMAKE_REQUIRED_INCLUDES})
+
+if(PMEMVLT_PRESENT)
+	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+		FILES_MATCHING PATTERN "*.hpp")
+else()
+	message(WARNING "pmemvlt support in libpmemobj not found (to enable - use libpmemobj version > 1.4")
+	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+		FILES_MATCHING PATTERN "*.hpp"
+		PATTERN "v.hpp" EXCLUDE)
+endif()
 
 install(DIRECTORY examples/ DESTINATION ${CMAKE_INSTALL_DOCDIR}/examples
 	FILES_MATCHING PATTERN "*.*pp")
@@ -301,12 +324,6 @@ configure_file(
 
 add_custom_target(uninstall
 	COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
-
-if(PKG_CONFIG_FOUND)
-	pkg_check_modules(PMEMOBJ REQUIRED libpmemobj>=1.4)
-else()
-	find_package(PMEMOBJ REQUIRED 1.4)
-endif()
 
 if(PKG_CONFIG_FOUND)
 	pkg_check_modules(VALGRIND QUIET valgrind)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -105,8 +105,9 @@ endif()
 add_example(map_cli map_cli/map_cli.cpp)
 target_link_libraries(example-map_cli ${PMEMOBJ_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
-#XXX : fix compile error on clang
-#add_library(doc_snippets_persistent OBJECT doc_snippets/persistent.cpp)
+if(PMEMVLT_PRESENT)
+	add_library(doc_snippets_persistent OBJECT doc_snippets/persistent.cpp)
+endif()
 add_library(doc_snippets_make_persistent OBJECT doc_snippets/make_persistent.cpp)
 add_library(doc_snippets_mutex OBJECT doc_snippets/mutex.cpp)
 add_library(doc_snippets_pool OBJECT doc_snippets/pool.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,7 +122,10 @@ build_test(ptr_arith ptr_arith/ptr_arith.cpp)
 if(WIN32)
 	build_test(pool_win pool_win/pool_win.cpp)
 endif()
-#build_test(v v/v.cpp) XXX: fix compile error
+
+if(PMEMVLT_PRESENT)
+	build_test(v v/v.cpp)
+endif()
 
 if(NO_CHRONO_BUG)
 	build_test(cond_var cond_var/cond_var.cpp)


### PR DESCRIPTION
Current required version of libpmemobj is 1.4 which does not have
pmemvlt support. This patch turns off installing v.hpp (and building
tests and examples using it) if pmemvlt is not provided by libpmemobj.