### PR TITLE
common: use explicit conversions

### DIFF
--- a/include/libpmemobj++/detail/persistent_ptr_base.hpp
+++ b/include/libpmemobj++/detail/persistent_ptr_base.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@
 #ifndef PMEMOBJ_PERSISTENT_PTR_BASE_HPP
 #define PMEMOBJ_PERSISTENT_PTR_BASE_HPP
 
+#include <cstdint>
 #include <type_traits>
 
 #include "libpmemobj++/detail/common.hpp"
@@ -124,7 +125,8 @@ public:
 	persistent_ptr_base(persistent_ptr_base<U> const &r) noexcept
 		: oid(r.oid)
 	{
-		this->oid.off += calculate_offset<U>();
+		this->oid.off +=
+			static_cast<std::uint64_t>(calculate_offset<U>());
 		verify_type();
 	}
 
@@ -144,7 +146,8 @@ public:
 	persistent_ptr_base(persistent_ptr_base<U> const &r) noexcept
 		: oid(r.oid)
 	{
-		this->oid.off += calculate_offset<U>();
+		this->oid.off +=
+			static_cast<std::uint64_t>(calculate_offset<U>());
 		verify_type();
 	}
 

--- a/include/libpmemobj++/persistent_ptr.hpp
+++ b/include/libpmemobj++/persistent_ptr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017, Intel Corporation
+ * Copyright 2015-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -213,7 +213,7 @@ public:
 	operator+=(std::ptrdiff_t s)
 	{
 		detail::conditional_add_to_tx(this);
-		this->oid.off += s * sizeof(T);
+		this->oid.off += static_cast<std::uint64_t>(s) * sizeof(T);
 
 		return *this;
 	}
@@ -225,7 +225,7 @@ public:
 	operator-=(std::ptrdiff_t s)
 	{
 		detail::conditional_add_to_tx(this);
-		this->oid.off -= s * sizeof(T);
+		this->oid.off -= static_cast<std::uint64_t>(s) * sizeof(T);
 
 		return *this;
 	}
@@ -573,7 +573,8 @@ operator+(persistent_ptr<T> const &lhs, std::ptrdiff_t s)
 {
 	PMEMoid noid;
 	noid.pool_uuid_lo = lhs.raw().pool_uuid_lo;
-	noid.off = lhs.raw().off + (s * sizeof(T));
+	noid.off = lhs.raw().off + static_cast<std::uint64_t>(s) * sizeof(T);
+
 	return persistent_ptr<T>(noid);
 }
 
@@ -586,7 +587,8 @@ operator-(persistent_ptr<T> const &lhs, std::ptrdiff_t s)
 {
 	PMEMoid noid;
 	noid.pool_uuid_lo = lhs.raw().pool_uuid_lo;
-	noid.off = lhs.raw().off - (s * sizeof(T));
+	noid.off = lhs.raw().off - static_cast<std::uint64_t>(s) * sizeof(T);
+
 	return persistent_ptr<T>(noid);
 }
 
@@ -605,9 +607,9 @@ inline ptrdiff_t
 operator-(persistent_ptr<T> const &lhs, persistent_ptr<Y> const &rhs)
 {
 	assert(lhs.raw().pool_uuid_lo == rhs.raw().pool_uuid_lo);
-	ptrdiff_t d = lhs.raw().off - rhs.raw().off;
+	auto d = static_cast<std::ptrdiff_t>(lhs.raw().off - rhs.raw().off);
 
-	return d / sizeof(T);
+	return d / static_cast<std::ptrdiff_t>(sizeof(T));
 }
 
 /**


### PR DESCRIPTION
Based on well-defined unsinged overflow arithmetic and standard guarantees about integer
conversions:

[conv.integral]
If the destination type is unsigned, the resulting value is the least unsigned integer congruent to the source
integer (modulo 2
n where n is the number of bits used to represent the unsigned type).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/16)
<!-- Reviewable:end -->
