### PR TITLE
common: fix finding libpmemobj

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,12 +196,6 @@ add_check_whitespace(include-detail ${CMAKE_CURRENT_SOURCE_DIR}/include/libpmemo
 add_check_whitespace(cmake-main ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt)
 add_check_whitespace(cmake-helpers ${CMAKE_CURRENT_SOURCE_DIR}/cmake/*.cmake)
 
-if(PKG_CONFIG_FOUND)
-	pkg_check_modules(PMEMOBJ REQUIRED libpmemobj>=1.4)
-else()
-	find_package(PMEMOBJ REQUIRED 1.4)
-endif()
-
 # Check for existence of pmemvlt (introduced after 1.4 release)
 set(SAVED_CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES})
 set(CMAKE_REQUIRED_INCLUDES ${PMEMOBJ_INCLUDE_DIRS})


### PR DESCRIPTION
Code for finding libpmemobj was not properly removed due to rebase conflict.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/23)
<!-- Reviewable:end -->
