### PR TITLE
workaround for old gcc version issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,9 +260,23 @@ if(NOT MSVC_VERSION)
 		}"
 		NO_GCC_VARIADIC_TEMPLATE_BUG)
 
+	# Check for issues with older gcc compilers if "inline" aggregate initialization
+	# works for array class members https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65815
+	CHECK_CXX_SOURCE_COMPILES(
+		"struct array {
+			int data[2];
+		};
+		struct X {
+			array a = { 1, 2 };
+		};
+		int main() {
+			return 0;
+		}"
+		NO_GCC_AGGREGATE_INITIALIZATION_BUG)
 	set(CMAKE_REQUIRED_FLAGS ${SAVED_CMAKE_REQUIRED_FLAGS})
 else()
 	set(NO_GCC_VARIADIC_TEMPLATE_BUG TRUE)
+	set(NO_GCC_AGGREGATE_INITIALIZATION_BUG TRUE)
 endif()
 
 include_directories(include)

--- a/tests/array_algorithms/array_algorithms.cpp
+++ b/tests/array_algorithms/array_algorithms.cpp
@@ -43,8 +43,11 @@
 namespace pmemobj_exp = pmem::obj::experimental;
 
 struct TestSort {
+#ifdef NO_GCC_AGGREGATE_INITIALIZATION_BUG
 	pmemobj_exp::array<double, 10> c = {10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
-
+#else
+	pmemobj_exp::array<double, 10> c = {{10, 9, 8, 7, 6, 5, 4, 3, 2, 1}};
+#endif
 	void
 	sort_single_element_snapshot()
 	{


### PR DESCRIPTION
Check if "inline" aggregate initialization works for array
class members. Use double braces initialization as a workaround.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/59)
<!-- Reviewable:end -->
