### PR TITLE
common: fix array behaviour when its size is zero.

### DIFF
--- a/tests/external/libcxx/array/size_and_alignment.pass.cpp
+++ b/tests/external/libcxx/array/size_and_alignment.pass.cpp
@@ -41,7 +41,7 @@ void
 test_zero_sized()
 {
 	typedef pmem_exp::array<T, 0> ArrayT;
-	static_assert(sizeof(ArrayT) == sizeof(T *), "");
+	static_assert(sizeof(ArrayT) == sizeof(T), "");
 }
 
 template <class T>


### PR DESCRIPTION
This patch fixes 2 things:
 - Double braced initialization of scalar types (e.g. int x = {{}};) is not allowed in C++
   so previous version, where underlying type for zero sized array
   was pointer prevented proper zero-sized array initlizatation.
   (Only some compilers complained about this)
 - Standard states that begin() and end() should return some unique value,
   now it is done by returning address of the array itself. To achive that
   alignment of zero-sized array is equal to alignment of type its holding.
   This approach is also taken by libstdc++.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/61)
<!-- Reviewable:end -->
