### PR TITLE
Remove unnecessary free in make persistent

### DIFF
--- a/include/libpmemobj++/make_persistent.hpp
+++ b/include/libpmemobj++/make_persistent.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,6 +68,7 @@ namespace obj
  * @throw transaction_scope_error if called outside of an active
  * transaction
  * @throw transaction_alloc_error on transactional allocation failure.
+ * @throw rethrow exception from T constructor
  */
 template <typename T, typename... Args>
 typename detail::pp_if_not_array<T>::type
@@ -84,13 +85,8 @@ make_persistent(Args &&... args)
 	if (ptr == nullptr)
 		throw transaction_alloc_error("failed to allocate "
 					      "persistent memory object");
-	try {
-		detail::create<T, Args...>(ptr.get(),
-					   std::forward<Args>(args)...);
-	} catch (...) {
-		pmemobj_tx_free(*ptr.raw_ptr());
-		throw;
-	}
+
+	detail::create<T, Args...>(ptr.get(), std::forward<Args>(args)...);
 
 	return ptr;
 }

--- a/tests/make_persistent/make_persistent.cpp
+++ b/tests/make_persistent/make_persistent.cpp
@@ -86,8 +86,24 @@ public:
 	nvobj::p<char> arr[TEST_ARR_SIZE];
 };
 
+struct big_struct {
+	char data[PMEMOBJ_MIN_POOL];
+};
+
+struct struct_throwing {
+	struct_throwing()
+	{
+		throw magic_number;
+	}
+
+	char data[8];
+	static constexpr int magic_number = 42;
+};
+
 struct root {
 	nvobj::persistent_ptr<foo> pfoo;
+	nvobj::persistent_ptr<big_struct> bstruct;
+	nvobj::persistent_ptr<struct_throwing> throwing;
 };
 
 /*
@@ -196,6 +212,70 @@ test_additional_delete(nvobj::pool<struct root> &pop)
 
 	UT_ASSERT(r->pfoo == nullptr);
 }
+
+/*
+ * test_exceptions_handling -- (internal) test proper handling of exceptions
+ * inside make_persistent
+ */
+void
+test_exceptions_handling(nvobj::pool<struct root> &pop)
+{
+	nvobj::persistent_ptr<root> r = pop.get_root();
+
+	bool scope_error_thrown = false;
+	try {
+		/* Run outside of a transaction, expect error */
+		r->pfoo = nvobj::make_persistent<foo>();
+		UT_ASSERT(0);
+	} catch (pmem::transaction_scope_error &) {
+		scope_error_thrown = true;
+	}
+	UT_ASSERT(scope_error_thrown);
+
+	bool alloc_error_thrown = false;
+	try {
+		nvobj::transaction::exec_tx(pop, [&] {
+			UT_ASSERT(r->bstruct == nullptr);
+
+			r->bstruct = nvobj::make_persistent<big_struct>();
+			UT_ASSERT(0);
+		});
+	} catch (pmem::transaction_alloc_error &) {
+		alloc_error_thrown = true;
+	}
+	UT_ASSERT(alloc_error_thrown);
+
+	bool scope_error_delete_thrown = false;
+	try {
+		nvobj::transaction::exec_tx(pop, [&] {
+			UT_ASSERT(r->pfoo == nullptr);
+
+			r->pfoo = nvobj::make_persistent<foo>();
+		});
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+	try {
+		/* Run outside of a transaction, expect error */
+		nvobj::delete_persistent<foo>(r->pfoo);
+		UT_ASSERT(0);
+	} catch (pmem::transaction_scope_error &) {
+		scope_error_delete_thrown = true;
+	}
+	UT_ASSERT(scope_error_delete_thrown);
+
+	try {
+		nvobj::transaction::exec_tx(pop, [&] {
+			UT_ASSERT(r->throwing == nullptr);
+
+			r->throwing = nvobj::make_persistent<struct_throwing>();
+			UT_ASSERT(0);
+		});
+	} catch (int &e) {
+		UT_ASSERT(e == struct_throwing::magic_number);
+	}
+	UT_ASSERT(r->throwing == nullptr);
+}
 }
 
 int
@@ -220,6 +300,7 @@ main(int argc, char *argv[])
 	test_make_no_args(pop);
 	test_make_args(pop);
 	test_additional_delete(pop);
+	test_exceptions_handling(pop);
 
 	pop.close();
 }

--- a/tests/make_persistent_array/make_persistent_array.cpp
+++ b/tests/make_persistent_array/make_persistent_array.cpp
@@ -81,8 +81,29 @@ public:
 	nvobj::p<char> arr[TEST_ARR_SIZE];
 };
 
+int ctor_number = 0;
+
+struct struct_throwing {
+	struct_throwing()
+	{
+		if (ctor_number == throw_after)
+			throw magic_number;
+
+		ctor_number++;
+	}
+
+	char data[8];
+	static constexpr int magic_number = 42;
+	static constexpr int throw_after = 5;
+};
+
 struct root {
 	nvobj::persistent_ptr<foo[]> pfoo;
+	nvobj::persistent_ptr<struct_throwing[]> throwing;
+
+	nvobj::persistent_ptr<foo[10]> pfoo_sized;
+	nvobj::persistent_ptr<foo[PMEMOBJ_MIN_POOL]> pfoo_sized_big;
+	nvobj::persistent_ptr<struct_throwing[10]> throwing_sized;
 };
 
 /*
@@ -217,6 +238,140 @@ test_abort_revert(nvobj::pool_base &pop)
 
 	UT_ASSERT(r->pfoo == nullptr);
 }
+
+/*
+ * test_exceptions_handling -- (internal) test proper handling of exceptions
+ * inside make_persistent
+ */
+void
+test_exceptions_handling(nvobj::pool<struct root> &pop)
+{
+	nvobj::persistent_ptr<root> r = pop.get_root();
+
+	bool scope_error_thrown = false;
+	try {
+		/* Run outside of a transaction, expect error */
+		r->pfoo = nvobj::make_persistent<foo[]>(5);
+		UT_ASSERT(0);
+	} catch (pmem::transaction_scope_error &) {
+		scope_error_thrown = true;
+	}
+	UT_ASSERT(scope_error_thrown);
+
+	bool alloc_error_thrown = false;
+	try {
+		nvobj::transaction::exec_tx(pop, [&] {
+			UT_ASSERT(r->pfoo == nullptr);
+
+			r->pfoo =
+				nvobj::make_persistent<foo[]>(PMEMOBJ_MIN_POOL);
+			UT_ASSERT(0);
+		});
+	} catch (pmem::transaction_alloc_error &) {
+		alloc_error_thrown = true;
+	}
+	UT_ASSERT(alloc_error_thrown);
+
+	bool scope_error_delete_thrown = false;
+	try {
+		nvobj::transaction::exec_tx(pop, [&] {
+			UT_ASSERT(r->pfoo == nullptr);
+
+			r->pfoo = nvobj::make_persistent<foo[]>(5);
+		});
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+	try {
+		/* Run outside of a transaction, expect error */
+		nvobj::delete_persistent<foo[]>(r->pfoo, 5);
+		UT_ASSERT(0);
+	} catch (pmem::transaction_scope_error &) {
+		scope_error_delete_thrown = true;
+	}
+	UT_ASSERT(scope_error_delete_thrown);
+
+	ctor_number = 0;
+
+	try {
+		nvobj::transaction::exec_tx(pop, [&] {
+			UT_ASSERT(r->throwing == nullptr);
+
+			r->throwing =
+				nvobj::make_persistent<struct_throwing[]>(10);
+			UT_ASSERT(0);
+		});
+	} catch (int &e) {
+		UT_ASSERT(e == struct_throwing::magic_number);
+	}
+}
+
+/*
+ * test_exceptions_handling -- (internal) test proper handling of exceptions
+ * inside make_persistent, version for sized array
+ */
+void
+test_exceptions_handling_sized(nvobj::pool<struct root> &pop)
+{
+	nvobj::persistent_ptr<root> r = pop.get_root();
+
+	bool scope_error_thrown = false;
+	try {
+		/* Run outside of a transaction, expect error */
+		r->pfoo_sized = nvobj::make_persistent<foo[10]>();
+		UT_ASSERT(0);
+	} catch (pmem::transaction_scope_error &) {
+		scope_error_thrown = true;
+	}
+	UT_ASSERT(scope_error_thrown);
+
+	bool alloc_error_thrown = false;
+	try {
+		nvobj::transaction::exec_tx(pop, [&] {
+			UT_ASSERT(r->pfoo_sized == nullptr);
+
+			r->pfoo_sized_big =
+				nvobj::make_persistent<foo[PMEMOBJ_MIN_POOL]>();
+			UT_ASSERT(0);
+		});
+	} catch (pmem::transaction_alloc_error &) {
+		alloc_error_thrown = true;
+	}
+	UT_ASSERT(alloc_error_thrown);
+
+	bool scope_error_delete_thrown = false;
+	try {
+		nvobj::transaction::exec_tx(pop, [&] {
+			UT_ASSERT(r->pfoo_sized == nullptr);
+
+			r->pfoo_sized = nvobj::make_persistent<foo[10]>();
+		});
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+	try {
+		/* Run outside of a transaction, expect error */
+		nvobj::delete_persistent<foo[10]>(r->pfoo_sized);
+		UT_ASSERT(0);
+	} catch (pmem::transaction_scope_error &) {
+		scope_error_delete_thrown = true;
+	}
+	UT_ASSERT(scope_error_delete_thrown);
+
+	ctor_number = 0;
+
+	try {
+		nvobj::transaction::exec_tx(pop, [&] {
+			UT_ASSERT(r->throwing_sized == nullptr);
+
+			r->throwing_sized =
+				nvobj::make_persistent<struct_throwing[10]>();
+			UT_ASSERT(0);
+		});
+	} catch (int &e) {
+		UT_ASSERT(e == struct_throwing::magic_number);
+	}
+}
 }
 
 int
@@ -241,6 +396,8 @@ main(int argc, char *argv[])
 	test_make_one_d(pop);
 	test_make_N_d(pop);
 	test_abort_revert(pop);
+	test_exceptions_handling(pop);
+	test_exceptions_handling_sized(pop);
 
 	pop.close();
 }


### PR DESCRIPTION
Do not perform manual recovery in make_persistent_array

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/68)
<!-- Reviewable:end -->
