### PR TITLE
common: simplify names of a few common functions

### DIFF
--- a/examples/array/array.cpp
+++ b/examples/array/array.cpp
@@ -113,7 +113,7 @@ public:
 				  << std::endl;
 			print_usage(array_op::ALLOC, "./example-array");
 		} else {
-			transaction::exec_tx(pop, [&] {
+			transaction::run(pop, [&] {
 				auto new_array = make_persistent<array_list>();
 
 				strcpy(new_array->name, name);
@@ -157,7 +157,7 @@ public:
 			cur_arr = prev_arr->next;
 		}
 
-		transaction::exec_tx(pop, [&] {
+		transaction::run(pop, [&] {
 			if (head == cur_arr)
 				head = cur_arr->next;
 			else
@@ -200,7 +200,7 @@ public:
 				  << std::endl;
 			print_usage(array_op::REALLOC, prog_name);
 		} else {
-			transaction::exec_tx(pop, [&] {
+			transaction::run(pop, [&] {
 				persistent_ptr<int[]> new_array =
 					make_persistent<int[]>(size);
 
@@ -328,7 +328,7 @@ main(int argc, char *argv[])
 	else
 		pop = pool<examples::pmem_array>::open(file, LAYOUT);
 
-	persistent_ptr<examples::pmem_array> arr = pop.get_root();
+	persistent_ptr<examples::pmem_array> arr = pop.root();
 
 	array_op op = parse_array_op(argv[2]);
 

--- a/examples/doc_snippets/make_persistent.cpp
+++ b/examples/doc_snippets/make_persistent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,10 +72,10 @@ make_persistent_example()
 
 	// create a pmemobj pool
 	auto pop = pool<root>::create("poolfile", "layout", PMEMOBJ_MIN_POOL);
-	auto proot = pop.get_root();
+	auto proot = pop.root();
 
 	// typical usage schemes
-	transaction::exec_tx(pop, [&] {
+	transaction::run(pop, [&] {
 		// allocation with constructor argument passing
 		proot->comp = make_persistent<compound_type>(1, 2.0);
 
@@ -126,10 +126,10 @@ make_persistent_array_example()
 
 	// create a pmemobj pool
 	auto pop = pool<root>::create("poolfile", "layout", PMEMOBJ_MIN_POOL);
-	auto proot = pop.get_root();
+	auto proot = pop.root();
 
 	// typical usage schemes
-	transaction::exec_tx(pop, [&] {
+	transaction::run(pop, [&] {
 		// allocate an array of 20 objects - compound_type must be
 		// default constructible
 		proot->comp = make_persistent<compound_type[]>(20);
@@ -185,7 +185,7 @@ make_persistent_atomic_example()
 
 	// create a pmemobj pool
 	auto pop = pool<root>::create("poolfile", "layout", PMEMOBJ_MIN_POOL);
-	auto proot = pop.get_root();
+	auto proot = pop.root();
 
 	// typical usage schemes
 
@@ -196,7 +196,7 @@ make_persistent_atomic_example()
 	delete_persistent<compound_type>(proot->comp);
 
 	// error prone cases
-	transaction::exec_tx(pop, [&] {
+	transaction::run(pop, [&] {
 		// possible invalid state in case of transaction abort
 		make_persistent_atomic<compound_type>(pop, proot->comp, 1, 1.3);
 		delete_persistent_atomic<compound_type>(proot->comp);
@@ -241,7 +241,7 @@ make_persistent_array_atomic_example()
 
 	// create a pmemobj pool
 	auto pop = pool<root>::create("poolfile", "layout", PMEMOBJ_MIN_POOL);
-	auto proot = pop.get_root();
+	auto proot = pop.root();
 
 	// typical usage schemes
 
@@ -257,7 +257,7 @@ make_persistent_array_atomic_example()
 	delete_persistent_atomic<compound_type[42]>(arr);
 
 	// error prone cases
-	transaction::exec_tx(pop, [&] {
+	transaction::run(pop, [&] {
 		// possible invalid state in case of transaction abort
 		make_persistent_atomic<compound_type[]>(pop, proot->comp, 30);
 		delete_persistent_atomic<compound_type[]>(proot->comp, 30);

--- a/examples/doc_snippets/mutex.cpp
+++ b/examples/doc_snippets/mutex.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,7 +53,7 @@ unique_guard_example()
 	// create a pmemobj pool
 	auto pop = nvobj::pool<root>::create("poolfile", "layout",
 					     PMEMOBJ_MIN_POOL);
-	auto proot = pop.get_root();
+	auto proot = pop.root();
 
 	// typical usage schemes
 	std::lock_guard<nvobj::mutex> guard(proot->pmutex);
@@ -81,7 +81,7 @@ shared_mutex_example()
 	// create a pmemobj pool
 	auto pop = nvobj::pool<root>::create("poolfile", "layout",
 					     PMEMOBJ_MIN_POOL);
-	auto proot = pop.get_root();
+	auto proot = pop.root();
 
 	// typical usage schemes
 	proot->pmutex.lock_shared();
@@ -109,7 +109,7 @@ timed_mutex_example()
 	// create a pmemobj pool
 	auto pop = nvobj::pool<root>::create("poolfile", "layout",
 					     PMEMOBJ_MIN_POOL);
-	auto proot = pop.get_root();
+	auto proot = pop.root();
 
 	const auto timeout = std::chrono::milliseconds(100);
 
@@ -145,7 +145,7 @@ cond_var_example()
 	auto pop = nvobj::pool<root>::create("poolfile", "layout",
 					     PMEMOBJ_MIN_POOL);
 
-	auto proot = pop.get_root();
+	auto proot = pop.root();
 
 	// run worker to bump up the counter
 	std::thread worker([&] {

--- a/examples/doc_snippets/persistent.cpp
+++ b/examples/doc_snippets/persistent.cpp
@@ -68,7 +68,7 @@ p_property_example()
 	auto pop = pool<root>::create("poolfile", "layout", PMEMOBJ_MIN_POOL);
 
 	// typical usage schemes
-	transaction::exec_tx(pop, [&] {
+	transaction::run(pop, [&] {
 		proot.counter = 12; // atomic
 		// one way to change `whoops`
 		proot.whoops.get_rw().set_some_variable(2);
@@ -115,7 +115,7 @@ persistent_ptr_example()
 	auto pop = pool<root>::create("poolfile", "layout", PMEMOBJ_MIN_POOL);
 
 	// typical usage schemes
-	transaction::exec_tx(pop, [&] {
+	transaction::run(pop, [&] {
 		proot.comp = make_persistent<compound_type>(); // allocation
 		proot.comp->set_some_variable(12);	     // call function
 		proot.comp->some_other_variable = 2.3;	 // set variable

--- a/examples/doc_snippets/pool.cpp
+++ b/examples/doc_snippets/pool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,7 +63,7 @@ pool_example()
 	pop = pool<root>::open("poolfile", "layout");
 
 	// typical usage schemes
-	auto root_obj = pop.get_root();
+	auto root_obj = pop.root();
 
 	// low-level memory manipulation
 	root_obj->some_variable = 3.2;

--- a/examples/doc_snippets/transaction.cpp
+++ b/examples/doc_snippets/transaction.cpp
@@ -77,12 +77,12 @@ general_tx_example()
 
 	// create a pmemobj pool
 	auto pop = pool<root>::create("poolfile", "layout", PMEMOBJ_MIN_POOL);
-	auto proot = pop.get_root();
+	auto proot = pop.root();
 
 	// typical usage schemes
 	try {
 		// take locks and start a transaction
-		transaction::exec_tx(pop,
+		transaction::run(pop,
 				     [&]() {
 					     // atomically allocate objects
 					     proot->another_root =
@@ -128,7 +128,7 @@ manual_tx_example()
 	// create a pmemobj pool
 	auto pop = pool<root>::create("poolfile", "layout", PMEMOBJ_MIN_POOL);
 
-	auto proot = pop.get_root();
+	auto proot = pop.root();
 
 	try {
 		transaction::manual tx(pop, proot->pmutex,
@@ -153,7 +153,7 @@ manual_tx_example()
 
 	// In complex cases with library calls, remember to check the status of
 	// the previous transaction.
-	return transaction::get_last_tx_error();
+	return transaction::error();
 }
 //! [manual_tx_example]
 
@@ -181,7 +181,7 @@ automatic_tx_example()
 
 	// create a pmemobj pool
 	auto pop = pool<root>::create("poolfile", "layout", PMEMOBJ_MIN_POOL);
-	auto proot = pop.get_root();
+	auto proot = pop.root();
 
 	try {
 		transaction::automatic tx(pop, proot->pmutex,
@@ -204,6 +204,6 @@ automatic_tx_example()
 
 	// In complex cases with library calls, remember to check the status of
 	// the previous transaction.
-	return transaction::get_last_tx_error();
+	return transaction::error();
 }
 //! [automatic_tx_example]

--- a/examples/doc_snippets/v.cpp
+++ b/examples/doc_snippets/v.cpp
@@ -60,7 +60,7 @@ v_property_example()
 
 	// create a pmemobj pool
 	auto pop = pool<root>::create("poolfile", "layout", PMEMOBJ_MIN_POOL);
-	auto proot = pop.get_root();
+	auto proot = pop.root();
 
 	assert(proot->f.get().counter == 10);
 

--- a/examples/map_cli/ctree_map_persistent.hpp
+++ b/examples/map_cli/ctree_map_persistent.hpp
@@ -79,7 +79,7 @@ public:
 	{
 		auto pop = nvobj::pool_by_vptr(this);
 
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			this->root = nvobj::make_persistent<entry>();
 		});
 	}
@@ -105,7 +105,7 @@ public:
 
 		entry e(key, value);
 		auto pop = nvobj::pool_by_vptr(this);
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			if (dest_entry->key == 0 || dest_entry->key == key) {
 				nvobj::delete_persistent<T>(dest_entry->value);
 				*dest_entry = e;
@@ -134,7 +134,7 @@ public:
 	insert_new(key_type key, const Args &... args)
 	{
 		auto pop = nvobj::pool_by_vptr(this);
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			return insert(key, nvobj::make_persistent<T>(args...));
 		});
 
@@ -162,7 +162,7 @@ public:
 		auto ret = leaf->value;
 
 		auto pop = nvobj::pool_by_vptr(this);
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			if (parent == nullptr) {
 				leaf->key = 0;
 				leaf->value = nullptr;
@@ -193,7 +193,7 @@ public:
 	remove_free(key_type key)
 	{
 		auto pop = nvobj::pool_by_vptr(this);
-		nvobj::transaction::exec_tx(
+		nvobj::transaction::run(
 			pop, [&] { nvobj::delete_persistent<T>(remove(key)); });
 		return 0;
 	}
@@ -205,7 +205,7 @@ public:
 	clear()
 	{
 		auto pop = nvobj::pool_by_vptr(this);
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			if (this->root->inode) {
 				this->root->inode->clear();
 				nvobj::delete_persistent<node>(

--- a/examples/map_cli/map_cli.cpp
+++ b/examples/map_cli/map_cli.cpp
@@ -141,8 +141,7 @@ remove<persistent_ptr<pmap>>(pool_base pop, persistent_ptr<pmap> &map,
 	auto val = map->remove(atoll(argv[argn++]));
 	if (val) {
 		std::cout << *val << std::endl;
-		transaction::exec_tx(pop,
-				     [&] { delete_persistent<value_t>(val); });
+		transaction::run(pop, [&] { delete_persistent<value_t>(val); });
 	} else {
 		std::cout << "Entry not found\n";
 	}
@@ -156,7 +155,7 @@ void
 insert<persistent_ptr<pmap>>(pool_base pop, persistent_ptr<pmap> &map,
 			     char *argv[], int &argn)
 {
-	transaction::exec_tx(pop, [&] {
+	transaction::run(pop, [&] {
 		map->insert(atoll(argv[argn]),
 			    make_persistent<value_t>(atoll(argv[argn + 1])));
 	});
@@ -237,7 +236,7 @@ main(int argc, char *argv[])
 
 	persistent_ptr<root> q;
 	try {
-		q = pop.get_root();
+		q = pop.root();
 	} catch (std::exception &e) {
 		std::cerr << e.what() << std::endl;
 		pop.close();
@@ -246,7 +245,7 @@ main(int argc, char *argv[])
 
 	if (!q->ptree) {
 		try {
-			transaction::exec_tx(pop, [&] {
+			transaction::run(pop, [&] {
 				q->ptree = make_persistent<pmap>();
 			});
 		} catch (pmem::transaction_error &e) {

--- a/examples/panaconda/panaconda.cpp
+++ b/examples/panaconda/panaconda.cpp
@@ -786,11 +786,11 @@ void
 game::init(void)
 {
 	int ret = 0;
-	persistent_ptr<game_state> r = state.get_root();
+	persistent_ptr<game_state> r = state.root();
 
 	if (r->get_board() == nullptr) {
 
-		transaction::exec_tx(state, [&r, &ret, this]() {
+		transaction::run(state, [&r, &ret, this]() {
 			r->init();
 			if (params->use_maze)
 				ret = parse_conf_create_dynamic_layout();
@@ -813,8 +813,8 @@ void
 game::process_step(void)
 {
 	snake_event ret_event = EV_OK;
-	persistent_ptr<game_state> r = state.get_root();
-	transaction::exec_tx(state, [&]() {
+	persistent_ptr<game_state> r = state.root();
+	transaction::run(state, [&]() {
 		ret_event = r->get_board()->move_snake(direction_key);
 		if (EV_COLLISION == ret_event) {
 			r->get_player()->set_state(play_state::STATE_GAMEOVER);
@@ -877,8 +877,8 @@ game::process_key(const int lastkey)
 void
 game::clean_pool(void)
 {
-	persistent_ptr<game_state> r = state.get_root();
-	transaction::exec_tx(state, [&]() { r->clean_pool(); });
+	persistent_ptr<game_state> r = state.root();
+	transaction::run(state, [&]() { r->clean_pool(); });
 }
 
 void
@@ -896,14 +896,14 @@ game::clear_screen(void)
 void
 game::game_over(void)
 {
-	persistent_ptr<game_state> r = state.get_root();
+	persistent_ptr<game_state> r = state.root();
 	r->get_board()->print_game_over(r->get_player()->get_score());
 }
 
 bool
 game::is_game_over(void)
 {
-	persistent_ptr<game_state> r = state.get_root();
+	persistent_ptr<game_state> r = state.root();
 	return (r->get_player()->get_state() == play_state::STATE_GAMEOVER);
 }
 
@@ -927,13 +927,13 @@ game::parse_conf_create_dynamic_layout(void)
 	if (cfg_file == nullptr)
 		return -1;
 
-	persistent_ptr<game_state> r = state.get_root();
+	persistent_ptr<game_state> r = state.root();
 	while ((col_no = getline(&line, &len, cfg_file)) != -1) {
 		if (i == 0)
 			r->get_board()->set_size_col(col_no - 1);
 
 		try {
-			transaction::exec_tx(state, [&]() {
+			transaction::run(state, [&]() {
 				r->get_board()->creat_dynamic_layout(i, line);
 			});
 		} catch (transaction_error &err) {

--- a/examples/pman/pman.cpp
+++ b/examples/pman/pman.cpp
@@ -1220,7 +1220,7 @@ main(int argc, char *argv[])
 		nodelay(stdscr, true);
 		curs_set(0);
 		keypad(stdscr, true);
-		persistent_ptr<examples::state> r = pop.get_root();
+		persistent_ptr<examples::state> r = pop.root();
 
 		if ((r != nullptr) && (r->init(map_path) != false))
 			r->game();

--- a/examples/pmpong/Ball.cpp
+++ b/examples/pmpong/Ball.cpp
@@ -44,7 +44,7 @@ Ball::Ball(int x, int y)
 
 Ball::~Ball()
 {
-	pmem::obj::transaction::exec_tx(
+	pmem::obj::transaction::run(
 		Pool::getGamePool()->getPoolToTransaction(),
 		[&] { pmem::obj::delete_persistent<sf::Vector2f>(velocity); });
 }
@@ -85,41 +85,39 @@ Ball::increaseVelocity()
 void
 Ball::setX(int xArg)
 {
-	pmem::obj::transaction::exec_tx(
-		Pool::getGamePool()->getPoolToTransaction(), [&] { x = xArg; });
+	pmem::obj::transaction::run(Pool::getGamePool()->getPoolToTransaction(),
+				    [&] { x = xArg; });
 }
 
 void
 Ball::setY(int yArg)
 {
-	pmem::obj::transaction::exec_tx(
-		Pool::getGamePool()->getPoolToTransaction(), [&] { y = yArg; });
+	pmem::obj::transaction::run(Pool::getGamePool()->getPoolToTransaction(),
+				    [&] { y = yArg; });
 }
 
 void
 Ball::setVelocityX(float xArg)
 {
-	pmem::obj::transaction::exec_tx(
-		Pool::getGamePool()->getPoolToTransaction(),
-		[&] { velocity->x = xArg; });
+	pmem::obj::transaction::run(Pool::getGamePool()->getPoolToTransaction(),
+				    [&] { velocity->x = xArg; });
 }
 
 void
 Ball::setVelocityY(float yArg)
 {
-	pmem::obj::transaction::exec_tx(
-		Pool::getGamePool()->getPoolToTransaction(),
-		[&] { velocity->y = yArg; });
+	pmem::obj::transaction::run(Pool::getGamePool()->getPoolToTransaction(),
+				    [&] { velocity->y = yArg; });
 }
 
 void
 Ball::setXY(int xArg, int yArg)
 {
-	pmem::obj::transaction::exec_tx(
-		Pool::getGamePool()->getPoolToTransaction(), [&] {
-			x = xArg;
-			y = yArg;
-		});
+	pmem::obj::transaction::run(Pool::getGamePool()->getPoolToTransaction(),
+				    [&] {
+					    x = xArg;
+					    y = yArg;
+				    });
 }
 
 void

--- a/examples/pmpong/GameController.cpp
+++ b/examples/pmpong/GameController.cpp
@@ -40,7 +40,7 @@ GameController::GameController()
 
 GameController::~GameController()
 {
-	pmem::obj::transaction::exec_tx(
+	pmem::obj::transaction::run(
 		Pool::getGamePool()->getPoolToTransaction(), [&] {
 			pmem::obj::delete_persistent<PongGameStatus>(
 				gameStatus);
@@ -221,7 +221,7 @@ GameController::gameMatchSimulation(sf::RenderWindow *gameWindow, View *view)
 void
 GameController::resetGameStatus()
 {
-	pmem::obj::transaction::exec_tx(
+	pmem::obj::transaction::run(
 		Pool::getGamePool()->getPoolToTransaction(), [&] {
 			pmem::obj::delete_persistent<PongGameStatus>(
 				gameStatus);

--- a/examples/pmpong/Paddle.cpp
+++ b/examples/pmpong/Paddle.cpp
@@ -134,21 +134,20 @@ Paddle::getPaddleShape()
 void
 Paddle::setPoints(int pointsArg)
 {
-	pmem::obj::transaction::exec_tx(
-		Pool::getGamePool()->getPoolToTransaction(),
-		[&] { points = pointsArg; });
+	pmem::obj::transaction::run(Pool::getGamePool()->getPoolToTransaction(),
+				    [&] { points = pointsArg; });
 }
 
 void
 Paddle::setY(int yArg)
 {
-	pmem::obj::transaction::exec_tx(
-		Pool::getGamePool()->getPoolToTransaction(), [&] { y = yArg; });
+	pmem::obj::transaction::run(Pool::getGamePool()->getPoolToTransaction(),
+				    [&] { y = yArg; });
 }
 
 void
 Paddle::setX(int xArg)
 {
-	pmem::obj::transaction::exec_tx(
-		Pool::getGamePool()->getPoolToTransaction(), [&] { x = xArg; });
+	pmem::obj::transaction::run(Pool::getGamePool()->getPoolToTransaction(),
+				    [&] { x = xArg; });
 }

--- a/examples/pmpong/PongGameStatus.cpp
+++ b/examples/pmpong/PongGameStatus.cpp
@@ -49,7 +49,7 @@ PongGameStatus::PongGameStatus()
 
 PongGameStatus::~PongGameStatus()
 {
-	pmem::obj::transaction::exec_tx(
+	pmem::obj::transaction::run(
 		Pool::getGamePool()->getPoolToTransaction(), [&] {
 			pmem::obj::delete_persistent<Paddle>(player1);
 			pmem::obj::delete_persistent<Paddle>(player2);
@@ -119,25 +119,22 @@ PongGameStatus::simulate()
 void
 PongGameStatus::setMenuItem(int numb)
 {
-	pmem::obj::transaction::exec_tx(
-		Pool::getGamePool()->getPoolToTransaction(),
-		[&] { this->menuItem = numb; });
+	pmem::obj::transaction::run(Pool::getGamePool()->getPoolToTransaction(),
+				    [&] { this->menuItem = numb; });
 }
 
 void
 PongGameStatus::setIsGameToResume(bool isGameToRes)
 {
-	pmem::obj::transaction::exec_tx(
-		Pool::getGamePool()->getPoolToTransaction(),
-		[&] { isGameToResume = isGameToRes; });
+	pmem::obj::transaction::run(Pool::getGamePool()->getPoolToTransaction(),
+				    [&] { isGameToResume = isGameToRes; });
 }
 
 void
 PongGameStatus::setGameState(game_state state)
 {
-	pmem::obj::transaction::exec_tx(
-		Pool::getGamePool()->getPoolToTransaction(),
-		[&] { this->actualGameState = state; });
+	pmem::obj::transaction::run(Pool::getGamePool()->getPoolToTransaction(),
+				    [&] { this->actualGameState = state; });
 }
 
 int

--- a/examples/pmpong/Pool.cpp
+++ b/examples/pmpong/Pool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Intel Corporation
+ * Copyright 2017-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -69,10 +69,10 @@ Pool::getGamePool()
 pmem::obj::persistent_ptr<GameController>
 Pool::getGameController()
 {
-	pmem::obj::persistent_ptr<GameStruct> root = pool.get_root();
+	pmem::obj::persistent_ptr<GameStruct> root = pool.root();
 	if (root != nullptr) {
 		if (root->gam == nullptr)
-			pmem::obj::transaction::exec_tx(pool, [&] {
+			pmem::obj::transaction::run(pool, [&] {
 				root->gam = pmem::obj::make_persistent<
 					GameController>();
 			});

--- a/examples/queue/queue.cpp
+++ b/examples/queue/queue.cpp
@@ -115,7 +115,7 @@ public:
 	void
 	push(pool_base &pop, uint64_t value)
 	{
-		transaction::exec_tx(pop, [&] {
+		transaction::run(pop, [&] {
 			auto n = make_persistent<pmem_entry>();
 
 			n->value = value;
@@ -137,7 +137,7 @@ public:
 	pop(pool_base &pop)
 	{
 		uint64_t ret = 0;
-		transaction::exec_tx(pop, [&] {
+		transaction::run(pop, [&] {
 			if (head == nullptr)
 				transaction::abort(EINVAL);
 
@@ -193,7 +193,7 @@ main(int argc, char *argv[])
 		pop = pool<examples::pmem_queue>::open(path, LAYOUT);
 	}
 
-	auto q = pop.get_root();
+	auto q = pop.root();
 	switch (op) {
 		case QUEUE_PUSH:
 			q->push(pop, std::stoull(argv[3]));

--- a/include/libpmemobj++/detail/common.hpp
+++ b/include/libpmemobj++/detail/common.hpp
@@ -42,6 +42,14 @@
 #include "libpmemobj/tx_base.h"
 #include <typeinfo>
 
+#if defined(__GNUC__) || defined(__clang__)
+#define POBJ_CPP_DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#define POBJ_CPP_DEPRECATED __declspec(deprecated)
+#else
+#define POBJ_CPP_DEPRECATED
+#endif
+
 namespace pmem
 {
 

--- a/include/libpmemobj++/make_persistent_array_atomic.hpp
+++ b/include/libpmemobj++/make_persistent_array_atomic.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -75,8 +75,8 @@ make_persistent_atomic(pool_base &pool,
 {
 	typedef typename detail::pp_array_type<T>::type I;
 
-	auto ret = pmemobj_alloc(pool.get_handle(), ptr.raw_ptr(),
-				 sizeof(I) * N, detail::type_num<I>(),
+	auto ret = pmemobj_alloc(pool.handle(), ptr.raw_ptr(), sizeof(I) * N,
+				 detail::type_num<I>(),
 				 &detail::array_constructor<I>,
 				 static_cast<void *>(&N));
 
@@ -105,8 +105,8 @@ make_persistent_atomic(pool_base &pool,
 	typedef typename detail::pp_array_type<T>::type I;
 	std::size_t N = detail::pp_array_elems<T>::elems;
 
-	auto ret = pmemobj_alloc(pool.get_handle(), ptr.raw_ptr(),
-				 sizeof(I) * N, detail::type_num<I>(),
+	auto ret = pmemobj_alloc(pool.handle(), ptr.raw_ptr(), sizeof(I) * N,
+				 detail::type_num<I>(),
 				 &detail::array_constructor<I>,
 				 static_cast<void *>(&N));
 

--- a/include/libpmemobj++/make_persistent_atomic.hpp
+++ b/include/libpmemobj++/make_persistent_atomic.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,7 +77,7 @@ make_persistent_atomic(pool_base &pool,
 		       Args &&... args)
 {
 	std::tuple<Args &...> arg_pack{args...};
-	auto ret = pmemobj_alloc(pool.get_handle(), ptr.raw_ptr(), sizeof(T),
+	auto ret = pmemobj_alloc(pool.handle(), ptr.raw_ptr(), sizeof(T),
 				 detail::type_num<T>(),
 				 &detail::obj_constructor<T, Args...>,
 				 static_cast<void *>(&arg_pack));

--- a/include/libpmemobj++/pool.hpp
+++ b/include/libpmemobj++/pool.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,6 +42,7 @@
 #include <string>
 #include <sys/stat.h>
 
+#include "libpmemobj++/detail/common.hpp"
 #include "libpmemobj++/detail/pexceptions.hpp"
 #include "libpmemobj++/p.hpp"
 #include "libpmemobj/pool_base.h"
@@ -393,9 +394,15 @@ public:
 	 * @return pool opaque handle.
 	 */
 	PMEMobjpool *
-	get_handle() noexcept
+	handle() noexcept
 	{
 		return this->pop;
+	}
+
+	POBJ_CPP_DEPRECATED PMEMobjpool *
+	get_handle() noexcept
+	{
+		return pool_base::handle();
 	}
 
 protected:
@@ -472,13 +479,19 @@ public:
 	 * @return persistent pointer to the root object.
 	 */
 	persistent_ptr<T>
-	get_root()
+	root()
 	{
 		if (pop == nullptr)
 			throw pool_error("Invalid pool handle");
 
 		persistent_ptr<T> root = pmemobj_root(this->pop, sizeof(T));
 		return root;
+	}
+
+	POBJ_CPP_DEPRECATED persistent_ptr<T>
+	get_root()
+	{
+		return pool::root();
 	}
 
 	/**

--- a/tests/aggregate_initialization/aggregate_initialization.cpp
+++ b/tests/aggregate_initialization/aggregate_initialization.cpp
@@ -56,7 +56,7 @@ struct root {
 void
 test_aggregate(nvobj::pool<root> &pop)
 {
-	nvobj::persistent_ptr<root> r = pop.get_root();
+	nvobj::persistent_ptr<root> r = pop.root();
 
 #if !__cpp_lib_is_aggregate
 	/* make sure aggregate initialization is available */
@@ -64,7 +64,7 @@ test_aggregate(nvobj::pool<root> &pop)
 #endif
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			r->pfoo = nvobj::make_persistent<foo>(2, 3);
 
 			UT_ASSERTeq(r->pfoo->a, 2);

--- a/tests/allocator/allocator.cpp
+++ b/tests/allocator/allocator.cpp
@@ -92,7 +92,7 @@ test_alloc_valid(nvobj::pool_base &pop)
 	nvobj::allocator<foo> al;
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			auto fooptr = al.allocate(1);
 			UT_ASSERT(pmemobj_alloc_usable_size(fooptr.raw()) >=
 				  sizeof(foo));

--- a/tests/array_algorithms/array_algorithms.cpp
+++ b/tests/array_algorithms/array_algorithms.cpp
@@ -80,10 +80,10 @@ struct root {
 void
 test_sort_single_element(pmem::obj::pool<struct root> &pop)
 {
-	auto r = pop.get_root();
+	auto r = pop.root();
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->test_sort = pmem::obj::make_persistent<TestSort>();
 		});
 	} catch (...) {
@@ -91,7 +91,7 @@ test_sort_single_element(pmem::obj::pool<struct root> &pop)
 	}
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->test_sort->sort_single_element_snapshot();
 
 			pmem::obj::transaction::abort(0);
@@ -106,7 +106,7 @@ test_sort_single_element(pmem::obj::pool<struct root> &pop)
 	}
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			pmem::obj::delete_persistent<TestSort>(r->test_sort);
 		});
 	} catch (...) {
@@ -117,10 +117,10 @@ test_sort_single_element(pmem::obj::pool<struct root> &pop)
 void
 test_sort_range(pmem::obj::pool<struct root> &pop)
 {
-	auto r = pop.get_root();
+	auto r = pop.root();
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->test_sort = pmem::obj::make_persistent<TestSort>();
 		});
 	} catch (...) {
@@ -128,7 +128,7 @@ test_sort_range(pmem::obj::pool<struct root> &pop)
 	}
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->test_sort->sort_range_snapshot();
 
 			pmem::obj::transaction::abort(0);
@@ -143,7 +143,7 @@ test_sort_range(pmem::obj::pool<struct root> &pop)
 	}
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			pmem::obj::delete_persistent<TestSort>(r->test_sort);
 		});
 	} catch (...) {

--- a/tests/array_iterator/array_iterator.cpp
+++ b/tests/array_iterator/array_iterator.cpp
@@ -155,10 +155,10 @@ struct root {
 void
 run_test1(pmem::obj::pool<struct root> &pop)
 {
-	auto r = pop.get_root();
+	auto r = pop.root();
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->test1 = pmem::obj::make_persistent<Test1>();
 		});
 	} catch (...) {
@@ -166,7 +166,7 @@ run_test1(pmem::obj::pool<struct root> &pop)
 	}
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->test1->iterator_pass();
 			r->test1->check_pass();
 		});
@@ -175,7 +175,7 @@ run_test1(pmem::obj::pool<struct root> &pop)
 	}
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->test1->iterator_access();
 
 			pmem::obj::delete_persistent<Test1>(r->test1);
@@ -188,10 +188,10 @@ run_test1(pmem::obj::pool<struct root> &pop)
 void
 run_test2(pmem::obj::pool<struct root> &pop)
 {
-	auto r = pop.get_root();
+	auto r = pop.root();
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->test2 = pmem::obj::make_persistent<Test2>();
 		});
 	} catch (...) {
@@ -199,7 +199,7 @@ run_test2(pmem::obj::pool<struct root> &pop)
 	}
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->test2->reverse_iterator_pass();
 			r->test2->check_pass();
 
@@ -213,10 +213,10 @@ run_test2(pmem::obj::pool<struct root> &pop)
 void
 run_test3(pmem::obj::pool<struct root> &pop)
 {
-	auto r = pop.get_root();
+	auto r = pop.root();
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->test3 = pmem::obj::make_persistent<Test3>();
 		});
 	} catch (...) {
@@ -224,7 +224,7 @@ run_test3(pmem::obj::pool<struct root> &pop)
 	}
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->test3->iterator_operators();
 
 			pmem::obj::delete_persistent<Test3>(r->test3);

--- a/tests/array_slice/array_slice.cpp
+++ b/tests/array_slice/array_slice.cpp
@@ -253,10 +253,10 @@ struct root {
 void
 run_test_success(pmem::obj::pool<struct root> &pop)
 {
-	auto r = pop.get_root();
+	auto r = pop.root();
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->ptr_s = pmem::obj::make_persistent<TestSuccess>();
 		});
 	} catch (...) {
@@ -264,7 +264,7 @@ run_test_success(pmem::obj::pool<struct root> &pop)
 	}
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->ptr_s->run();
 			r->ptr_s->run_reverse();
 
@@ -278,10 +278,10 @@ run_test_success(pmem::obj::pool<struct root> &pop)
 void
 run_test_abort(pmem::obj::pool<struct root> &pop)
 {
-	auto r = pop.get_root();
+	auto r = pop.root();
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->ptr_a = pmem::obj::make_persistent<TestAbort>();
 		});
 	} catch (...) {
@@ -290,7 +290,7 @@ run_test_abort(pmem::obj::pool<struct root> &pop)
 
 	/* Run TestAbort expecting success */
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->ptr_a->run();
 
 			pmem::obj::delete_persistent<TestAbort>(r->ptr_a);
@@ -303,10 +303,10 @@ run_test_abort(pmem::obj::pool<struct root> &pop)
 void
 run_test_abort_with_revert(pmem::obj::pool<struct root> &pop)
 {
-	auto r = pop.get_root();
+	auto r = pop.root();
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->ptr_a = pmem::obj::make_persistent<TestAbort>();
 		});
 	} catch (...) {
@@ -315,7 +315,7 @@ run_test_abort_with_revert(pmem::obj::pool<struct root> &pop)
 
 	/* Run TestAbort expecting transaction abort */
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->ptr_a->run();
 
 			pmem::obj::transaction::abort(0);
@@ -338,7 +338,7 @@ run_test_abort_with_revert(pmem::obj::pool<struct root> &pop)
 	}
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			pmem::obj::delete_persistent<TestAbort>(r->ptr_a);
 		});
 	} catch (...) {
@@ -349,10 +349,10 @@ run_test_abort_with_revert(pmem::obj::pool<struct root> &pop)
 void
 run_test_ranges(pmem::obj::pool<struct root> &pop)
 {
-	auto r = pop.get_root();
+	auto r = pop.root();
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->ptr_r = pmem::obj::make_persistent<TestRanges>();
 		});
 	} catch (...) {
@@ -360,7 +360,7 @@ run_test_ranges(pmem::obj::pool<struct root> &pop)
 	}
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->ptr_r->run();
 
 			pmem::obj::delete_persistent<TestRanges>(r->ptr_r);
@@ -373,10 +373,10 @@ run_test_ranges(pmem::obj::pool<struct root> &pop)
 void
 run_test_at(pmem::obj::pool<struct root> &pop)
 {
-	auto r = pop.get_root();
+	auto r = pop.root();
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->ptr_at = pmem::obj::make_persistent<TestAt>();
 		});
 	} catch (...) {
@@ -384,7 +384,7 @@ run_test_at(pmem::obj::pool<struct root> &pop)
 	}
 
 	try {
-		pmem::obj::transaction::exec_tx(pop, [&] {
+		pmem::obj::transaction::run(pop, [&] {
 			r->ptr_at->run();
 
 			pmem::obj::delete_persistent<TestAt>(r->ptr_at);

--- a/tests/common/cont_test_common.hpp
+++ b/tests/common/cont_test_common.hpp
@@ -122,7 +122,7 @@ loop_insert(pool &pop, T &cont, const Y &val, int count)
 {
 	for (int i = 0; i < count; ++i) {
 		try {
-			nvobj::transaction::exec_tx(pop, [&] {
+			nvobj::transaction::run(pop, [&] {
 				cont.insert(cont.cbegin(), Y(val));
 			});
 		} catch (...) {

--- a/tests/cond_var/cond_var.cpp
+++ b/tests/cond_var/cond_var.cpp
@@ -364,7 +364,7 @@ cond_zero_test(nvobj::pool<struct root> &pop)
 {
 	PMEMoid raw_cnd;
 
-	pmemobj_alloc(pop.get_handle(), &raw_cnd, sizeof(PMEMcond), 1,
+	pmemobj_alloc(pop.handle(), &raw_cnd, sizeof(PMEMcond), 1,
 		      [](PMEMobjpool *pop, void *ptr, void *) -> int {
 			      PMEMcond *mtx = static_cast<PMEMcond *>(ptr);
 			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
@@ -374,7 +374,7 @@ cond_zero_test(nvobj::pool<struct root> &pop)
 
 	nvobj::condition_variable *placed_mtx =
 		new (pmemobj_direct(raw_cnd)) nvobj::condition_variable;
-	std::unique_lock<nvobj::mutex> lock(pop.get_root()->pmutex);
+	std::unique_lock<nvobj::mutex> lock(pop.root()->pmutex);
 	placed_mtx->wait_for(lock, wait_time, []() { return false; });
 }
 
@@ -389,7 +389,7 @@ mutex_test(nvobj::pool<struct root> &pop, bool notify, bool notify_all,
 	const auto total_threads = num_threads * 2u;
 	std::thread threads[total_threads];
 
-	nvobj::persistent_ptr<struct root> proot = pop.get_root();
+	nvobj::persistent_ptr<struct root> proot = pop.root();
 
 	for (unsigned i = 0; i < total_threads; i += 2) {
 		threads[i] = std::thread(reader, proot);
@@ -432,10 +432,10 @@ main(int argc, char *argv[])
 		unsigned reset_value = 42;
 
 		mutex_test(pop, true, false, write_notify, func);
-		pop.get_root()->counter = reset_value;
+		pop.root()->counter = reset_value;
 
 		mutex_test(pop, true, true, write_notify, func);
-		pop.get_root()->counter = reset_value;
+		pop.root()->counter = reset_value;
 	}
 
 	std::vector<reader_type> not_notify_functions(
@@ -447,15 +447,15 @@ main(int argc, char *argv[])
 		unsigned reset_value = 42;
 
 		mutex_test(pop, false, false, write_notify, func);
-		pop.get_root()->counter = reset_value;
+		pop.root()->counter = reset_value;
 
 		mutex_test(pop, false, true, write_notify, func);
-		pop.get_root()->counter = reset_value;
+		pop.root()->counter = reset_value;
 	}
 
 	/* pmemcheck related persist */
-	pmemobj_persist(pop.get_handle(), &(pop.get_root()->counter),
-			sizeof(pop.get_root()->counter));
+	pmemobj_persist(pop.handle(), &(pop.root()->counter),
+			sizeof(pop.root()->counter));
 
 	pop.close();
 }

--- a/tests/make_persistent/make_persistent.cpp
+++ b/tests/make_persistent/make_persistent.cpp
@@ -112,10 +112,10 @@ struct root {
 void
 test_make_no_args(nvobj::pool<struct root> &pop)
 {
-	nvobj::persistent_ptr<root> r = pop.get_root();
+	nvobj::persistent_ptr<root> r = pop.root();
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->pfoo == nullptr);
 
 			r->pfoo = nvobj::make_persistent<foo>();
@@ -137,10 +137,10 @@ test_make_no_args(nvobj::pool<struct root> &pop)
 void
 test_make_args(nvobj::pool<struct root> &pop)
 {
-	nvobj::persistent_ptr<root> r = pop.get_root();
+	nvobj::persistent_ptr<root> r = pop.root();
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->pfoo == nullptr);
 
 			r->pfoo = nvobj::make_persistent<foo>(2);
@@ -167,10 +167,10 @@ test_make_args(nvobj::pool<struct root> &pop)
 void
 test_additional_delete(nvobj::pool<struct root> &pop)
 {
-	nvobj::persistent_ptr<root> r = pop.get_root();
+	nvobj::persistent_ptr<root> r = pop.root();
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->pfoo == nullptr);
 
 			r->pfoo = nvobj::make_persistent<foo>();
@@ -182,7 +182,7 @@ test_additional_delete(nvobj::pool<struct root> &pop)
 
 	bool exception_thrown = false;
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->pfoo != nullptr);
 			nvobj::delete_persistent<foo>(r->pfoo);
 			r->pfoo = nullptr;
@@ -201,7 +201,7 @@ test_additional_delete(nvobj::pool<struct root> &pop)
 	r->pfoo->check_foo(1, 1);
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->pfoo != nullptr);
 			nvobj::delete_persistent<foo>(r->pfoo);
 			r->pfoo = nullptr;
@@ -220,7 +220,7 @@ test_additional_delete(nvobj::pool<struct root> &pop)
 void
 test_exceptions_handling(nvobj::pool<struct root> &pop)
 {
-	nvobj::persistent_ptr<root> r = pop.get_root();
+	nvobj::persistent_ptr<root> r = pop.root();
 
 	bool scope_error_thrown = false;
 	try {
@@ -234,7 +234,7 @@ test_exceptions_handling(nvobj::pool<struct root> &pop)
 
 	bool alloc_error_thrown = false;
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->bstruct == nullptr);
 
 			r->bstruct = nvobj::make_persistent<big_struct>();
@@ -247,7 +247,7 @@ test_exceptions_handling(nvobj::pool<struct root> &pop)
 
 	bool scope_error_delete_thrown = false;
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->pfoo == nullptr);
 
 			r->pfoo = nvobj::make_persistent<foo>();
@@ -265,7 +265,7 @@ test_exceptions_handling(nvobj::pool<struct root> &pop)
 	UT_ASSERT(scope_error_delete_thrown);
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->throwing == nullptr);
 
 			r->throwing = nvobj::make_persistent<struct_throwing>();

--- a/tests/make_persistent_array/make_persistent_array.cpp
+++ b/tests/make_persistent_array/make_persistent_array.cpp
@@ -113,7 +113,7 @@ void
 test_make_one_d(nvobj::pool_base &pop)
 {
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			auto pfoo = nvobj::make_persistent<foo[]>(5);
 			for (int i = 0; i < 5; ++i)
 				pfoo[i].check_foo();
@@ -144,7 +144,7 @@ void
 test_make_N_d(nvobj::pool_base &pop)
 {
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			auto pfoo = nvobj::make_persistent<foo[][2]>(5);
 			for (int i = 0; i < 5; ++i)
 				for (int j = 0; j < 2; j++)
@@ -195,10 +195,10 @@ test_abort_revert(nvobj::pool_base &pop)
 {
 	nvobj::pool<struct root> &root_pop =
 		dynamic_cast<nvobj::pool<struct root> &>(pop);
-	nvobj::persistent_ptr<root> r = root_pop.get_root();
+	nvobj::persistent_ptr<root> r = root_pop.root();
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			r->pfoo = nvobj::make_persistent<foo[]>(5);
 			for (int i = 0; i < 5; ++i)
 				r->pfoo[i].check_foo();
@@ -209,7 +209,7 @@ test_abort_revert(nvobj::pool_base &pop)
 
 	bool exception_thrown = false;
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->pfoo != nullptr);
 			nvobj::delete_persistent<foo[]>(r->pfoo, 5);
 			r->pfoo = nullptr;
@@ -228,7 +228,7 @@ test_abort_revert(nvobj::pool_base &pop)
 		r->pfoo[i].check_foo();
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			nvobj::delete_persistent<foo[]>(r->pfoo, 5);
 			r->pfoo = nullptr;
 		});
@@ -246,7 +246,7 @@ test_abort_revert(nvobj::pool_base &pop)
 void
 test_exceptions_handling(nvobj::pool<struct root> &pop)
 {
-	nvobj::persistent_ptr<root> r = pop.get_root();
+	nvobj::persistent_ptr<root> r = pop.root();
 
 	bool scope_error_thrown = false;
 	try {
@@ -260,7 +260,7 @@ test_exceptions_handling(nvobj::pool<struct root> &pop)
 
 	bool alloc_error_thrown = false;
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->pfoo == nullptr);
 
 			r->pfoo =
@@ -274,7 +274,7 @@ test_exceptions_handling(nvobj::pool<struct root> &pop)
 
 	bool scope_error_delete_thrown = false;
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->pfoo == nullptr);
 
 			r->pfoo = nvobj::make_persistent<foo[]>(5);
@@ -294,7 +294,7 @@ test_exceptions_handling(nvobj::pool<struct root> &pop)
 	ctor_number = 0;
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->throwing == nullptr);
 
 			r->throwing =
@@ -313,7 +313,7 @@ test_exceptions_handling(nvobj::pool<struct root> &pop)
 void
 test_exceptions_handling_sized(nvobj::pool<struct root> &pop)
 {
-	nvobj::persistent_ptr<root> r = pop.get_root();
+	nvobj::persistent_ptr<root> r = pop.root();
 
 	bool scope_error_thrown = false;
 	try {
@@ -327,7 +327,7 @@ test_exceptions_handling_sized(nvobj::pool<struct root> &pop)
 
 	bool alloc_error_thrown = false;
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->pfoo_sized == nullptr);
 
 			r->pfoo_sized_big =
@@ -341,7 +341,7 @@ test_exceptions_handling_sized(nvobj::pool<struct root> &pop)
 
 	bool scope_error_delete_thrown = false;
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->pfoo_sized == nullptr);
 
 			r->pfoo_sized = nvobj::make_persistent<foo[10]>();
@@ -361,7 +361,7 @@ test_exceptions_handling_sized(nvobj::pool<struct root> &pop)
 	ctor_number = 0;
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->throwing_sized == nullptr);
 
 			r->throwing_sized =

--- a/tests/make_persistent_atomic/make_persistent_atomic.cpp
+++ b/tests/make_persistent_atomic/make_persistent_atomic.cpp
@@ -96,7 +96,7 @@ struct root {
 void
 test_make_no_args(nvobj::pool<struct root> &pop)
 {
-	nvobj::persistent_ptr<root> r = pop.get_root();
+	nvobj::persistent_ptr<root> r = pop.root();
 
 	UT_ASSERT(r->pfoo == nullptr);
 
@@ -112,7 +112,7 @@ test_make_no_args(nvobj::pool<struct root> &pop)
 void
 test_make_args(nvobj::pool<struct root> &pop)
 {
-	nvobj::persistent_ptr<root> r = pop.get_root();
+	nvobj::persistent_ptr<root> r = pop.root();
 	UT_ASSERT(r->pfoo == nullptr);
 
 	nvobj::make_persistent_atomic<foo>(pop, r->pfoo, 2);

--- a/tests/mutex/mutex.cpp
+++ b/tests/mutex/mutex.cpp
@@ -110,7 +110,7 @@ mutex_zero_test(nvobj::pool<struct root> &pop)
 {
 	PMEMoid raw_mutex;
 
-	pmemobj_alloc(pop.get_handle(), &raw_mutex, sizeof(PMEMmutex), 1,
+	pmemobj_alloc(pop.handle(), &raw_mutex, sizeof(PMEMmutex), 1,
 		      [](PMEMobjpool *pop, void *ptr, void *) -> int {
 			      PMEMmutex *mtx = static_cast<PMEMmutex *>(ptr);
 			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
@@ -131,7 +131,7 @@ mutex_test(nvobj::pool<struct root> &pop, const Worker &function)
 {
 	std::thread threads[num_threads];
 
-	nvobj::persistent_ptr<struct root> proot = pop.get_root();
+	nvobj::persistent_ptr<struct root> proot = pop.root();
 
 	for (unsigned i = 0; i < num_threads; ++i)
 		threads[i] = std::thread(function, proot);
@@ -163,17 +163,17 @@ main(int argc, char *argv[])
 	mutex_zero_test(pop);
 
 	mutex_test(pop, increment_pint);
-	UT_ASSERTeq(pop.get_root()->counter, num_threads * num_ops);
+	UT_ASSERTeq(pop.root()->counter, num_threads * num_ops);
 
 	mutex_test(pop, decrement_pint);
-	UT_ASSERTeq(pop.get_root()->counter, 0);
+	UT_ASSERTeq(pop.root()->counter, 0);
 
 	mutex_test(pop, trylock_test);
-	UT_ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.root()->counter, num_threads);
 
 	/* pmemcheck related persist */
-	pmemobj_persist(pop.get_handle(), &(pop.get_root()->counter),
-			sizeof(pop.get_root()->counter));
+	pmemobj_persist(pop.handle(), &(pop.root()->counter),
+			sizeof(pop.root()->counter));
 
 	pop.close();
 }

--- a/tests/mutex_posix/mutex_posix.cpp
+++ b/tests/mutex_posix/mutex_posix.cpp
@@ -121,7 +121,7 @@ mutex_zero_test(nvobj::pool<struct root> &pop)
 {
 	PMEMoid raw_mutex;
 
-	pmemobj_alloc(pop.get_handle(), &raw_mutex, sizeof(PMEMmutex), 1,
+	pmemobj_alloc(pop.handle(), &raw_mutex, sizeof(PMEMmutex), 1,
 		      [](PMEMobjpool *pop, void *ptr, void *arg) -> int {
 			      PMEMmutex *mtx = static_cast<PMEMmutex *>(ptr);
 			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
@@ -142,7 +142,7 @@ mutex_test(nvobj::pool<struct root> &pop, Worker function)
 {
 	pthread_t threads[num_threads];
 
-	nvobj::persistent_ptr<struct root> proot = pop.get_root();
+	nvobj::persistent_ptr<struct root> proot = pop.root();
 
 	for (unsigned i = 0; i < num_threads; ++i)
 		ut_pthread_create(&threads[i], nullptr, function, &proot);
@@ -174,17 +174,17 @@ main(int argc, char *argv[])
 	mutex_zero_test(pop);
 
 	mutex_test(pop, increment_pint);
-	UT_ASSERTeq(pop.get_root()->counter, num_threads * num_ops);
+	UT_ASSERTeq(pop.root()->counter, num_threads * num_ops);
 
 	mutex_test(pop, decrement_pint);
-	UT_ASSERTeq(pop.get_root()->counter, 0);
+	UT_ASSERTeq(pop.root()->counter, 0);
 
 	mutex_test(pop, trylock_test);
-	UT_ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.root()->counter, num_threads);
 
 	/* pmemcheck related persist */
-	pmemobj_persist(pop.get_handle(), &(pop.get_root()->counter),
-			sizeof(pop.get_root()->counter));
+	pmemobj_persist(pop.handle(), &(pop.root()->counter),
+			sizeof(pop.root()->counter));
 
 	pop.close();
 }

--- a/tests/p_ext/p_ext.cpp
+++ b/tests/p_ext/p_ext.cpp
@@ -77,10 +77,10 @@ init_foobar(nvobj::pool_base &pop)
 {
 	nvobj::pool<struct root> &root_pop =
 		dynamic_cast<nvobj::pool<struct root> &>(pop);
-	nvobj::persistent_ptr<root> r = root_pop.get_root();
+	nvobj::persistent_ptr<root> r = root_pop.root();
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->bar_ptr == nullptr);
 			UT_ASSERT(r->foo_ptr == nullptr);
 
@@ -109,10 +109,10 @@ cleanup_foobar(nvobj::pool_base &pop)
 {
 	nvobj::pool<struct root> &root_pop =
 		dynamic_cast<nvobj::pool<struct root> &>(pop);
-	nvobj::persistent_ptr<root> r = root_pop.get_root();
+	nvobj::persistent_ptr<root> r = root_pop.root();
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			UT_ASSERT(r->bar_ptr != nullptr);
 			UT_ASSERT(r->foo_ptr != nullptr);
 
@@ -139,7 +139,7 @@ arithmetic_test(nvobj::pool_base &pop)
 
 	/* operations test */
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			/* addition */
 			r->foo_ptr->puchar += r->foo_ptr->puchar;
 			r->foo_ptr->puchar +=
@@ -232,7 +232,7 @@ bitwise_test(nvobj::pool_base &pop)
 	nvobj::persistent_ptr<root> r = init_foobar(pop);
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			/* OR */
 			r->foo_ptr->puchar |= r->foo_ptr->pllong;
 			r->foo_ptr->puchar |= r->foo_ptr->pint;
@@ -311,7 +311,7 @@ stream_test(nvobj::pool_base &pop)
 	nvobj::persistent_ptr<root> r = init_foobar(pop);
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			std::stringstream stream("12.4");
 			stream >> r->bar_ptr->pdouble;
 			/*
@@ -345,12 +345,12 @@ swap_test(nvobj::pool_base &pop)
 	nvobj::persistent_ptr<_bar> swap_one;
 	nvobj::persistent_ptr<_bar> swap_two;
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			swap_one = pmemobj_tx_zalloc(sizeof(_bar), 0);
 			swap_two = pmemobj_tx_zalloc(sizeof(_bar), 0);
 		});
 
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			swap_one->value = 1;
 			swap_two->value = 2;
 

--- a/tests/pool/pool.cpp
+++ b/tests/pool/pool.cpp
@@ -62,7 +62,7 @@ pool_create(const char *path, const char *layout, size_t poolsize,
 	nvobj::pool<root> pop;
 	try {
 		pop = nvobj::pool<root>::create(path, layout, poolsize, mode);
-		nvobj::persistent_ptr<root> root = pop.get_root();
+		nvobj::persistent_ptr<root> root = pop.root();
 		UT_ASSERT(root != nullptr);
 	} catch (pmem::pool_error &) {
 		UT_OUT("!%s: pool::create", path);
@@ -147,7 +147,7 @@ get_root_closed()
 	nvobj::pool<root> pop;
 
 	try {
-		pop.get_root();
+		pop.root();
 	} catch (pmem::pool_error &pe) {
 		UT_OUT("pool.get_root: %s", pe.what());
 	}

--- a/tests/pool_primitives/pool_primitives.cpp
+++ b/tests/pool_primitives/pool_primitives.cpp
@@ -64,7 +64,7 @@ struct root {
 void
 pool_test_memset(nvobj::pool<root> &pop)
 {
-	nvobj::persistent_ptr<root> root = pop.get_root();
+	nvobj::persistent_ptr<root> root = pop.root();
 	UT_ASSERT(root != nullptr);
 
 	void *ret = pop.memset_persist(&root->val, TEST_VAL, sizeof(root->val));
@@ -81,7 +81,7 @@ pool_test_memset(nvobj::pool<root> &pop)
 void
 pool_test_memcpy(nvobj::pool<root> &pop)
 {
-	nvobj::persistent_ptr<root> root = pop.get_root();
+	nvobj::persistent_ptr<root> root = pop.root();
 	UT_ASSERT(root != nullptr);
 
 	int v = TEST_VAL;
@@ -105,7 +105,7 @@ pool_test_drain(nvobj::pool<root> &pop)
 void
 pool_test_flush(nvobj::pool<root> &pop)
 {
-	nvobj::persistent_ptr<root> root = pop.get_root();
+	nvobj::persistent_ptr<root> root = pop.root();
 	UT_ASSERT(root != nullptr);
 
 	root->val = TEST_VAL;
@@ -119,7 +119,7 @@ pool_test_flush(nvobj::pool<root> &pop)
 void
 pool_test_flush_p(nvobj::pool<root> &pop)
 {
-	nvobj::persistent_ptr<root> root = pop.get_root();
+	nvobj::persistent_ptr<root> root = pop.root();
 	UT_ASSERT(root != nullptr);
 
 	root->val = TEST_VAL;
@@ -133,7 +133,7 @@ pool_test_flush_p(nvobj::pool<root> &pop)
 void
 pool_test_flush_ptr(nvobj::pool<root> &pop)
 {
-	nvobj::persistent_ptr<root> root = pop.get_root();
+	nvobj::persistent_ptr<root> root = pop.root();
 	UT_ASSERT(root != nullptr);
 
 	root->me = root;
@@ -148,7 +148,7 @@ pool_test_flush_ptr(nvobj::pool<root> &pop)
 void
 pool_test_flush_ptr_obj(nvobj::pool<root> &pop)
 {
-	nvobj::persistent_ptr<root> root = pop.get_root();
+	nvobj::persistent_ptr<root> root = pop.root();
 	UT_ASSERT(root != nullptr);
 
 	root->me = root;
@@ -164,7 +164,7 @@ pool_test_flush_ptr_obj(nvobj::pool<root> &pop)
 void
 pool_test_flush_ptr_obj_no_pop(nvobj::pool<root> &pop)
 {
-	nvobj::persistent_ptr<root> root = pop.get_root();
+	nvobj::persistent_ptr<root> root = pop.root();
 	UT_ASSERT(root != nullptr);
 
 	root->me = root;
@@ -179,7 +179,7 @@ pool_test_flush_ptr_obj_no_pop(nvobj::pool<root> &pop)
 void
 pool_test_persist(nvobj::pool<root> &pop)
 {
-	nvobj::persistent_ptr<root> root = pop.get_root();
+	nvobj::persistent_ptr<root> root = pop.root();
 	UT_ASSERT(root != nullptr);
 
 	root->val = TEST_VAL;
@@ -193,7 +193,7 @@ pool_test_persist(nvobj::pool<root> &pop)
 void
 pool_test_persist_p(nvobj::pool<root> &pop)
 {
-	nvobj::persistent_ptr<root> root = pop.get_root();
+	nvobj::persistent_ptr<root> root = pop.root();
 	UT_ASSERT(root != nullptr);
 
 	root->val = TEST_VAL;
@@ -207,7 +207,7 @@ pool_test_persist_p(nvobj::pool<root> &pop)
 void
 pool_test_persist_ptr(nvobj::pool<root> &pop)
 {
-	nvobj::persistent_ptr<root> root = pop.get_root();
+	nvobj::persistent_ptr<root> root = pop.root();
 	UT_ASSERT(root != nullptr);
 
 	root->me = root;
@@ -222,7 +222,7 @@ pool_test_persist_ptr(nvobj::pool<root> &pop)
 void
 pool_test_persist_ptr_obj(nvobj::pool<root> &pop)
 {
-	nvobj::persistent_ptr<root> root = pop.get_root();
+	nvobj::persistent_ptr<root> root = pop.root();
 	UT_ASSERT(root != nullptr);
 
 	root->me = root;
@@ -238,7 +238,7 @@ pool_test_persist_ptr_obj(nvobj::pool<root> &pop)
 void
 pool_test_persist_ptr_obj_no_pop(nvobj::pool<root> &pop)
 {
-	nvobj::persistent_ptr<root> root = pop.get_root();
+	nvobj::persistent_ptr<root> root = pop.root();
 	UT_ASSERT(root != nullptr);
 
 	root->me = root;
@@ -256,7 +256,7 @@ pool_create(const char *path, const char *layout, size_t poolsize,
 {
 	nvobj::pool<root> pop =
 		nvobj::pool<root>::create(path, layout, poolsize, mode);
-	nvobj::persistent_ptr<root> root = pop.get_root();
+	nvobj::persistent_ptr<root> root = pop.root();
 	UT_ASSERT(root != nullptr);
 
 	return pop;

--- a/tests/pool_win/pool_win.cpp
+++ b/tests/pool_win/pool_win.cpp
@@ -64,7 +64,7 @@ pool_create(const wchar_t *path, const wchar_t *layout, size_t poolsize,
 
 	try {
 		pop = nvobj::pool<root>::create(path, layout, poolsize, mode);
-		nvobj::persistent_ptr<root> root = pop.get_root();
+		nvobj::persistent_ptr<root> root = pop.root();
 		UT_ASSERT(root != nullptr);
 	} catch (pmem::pool_error &) {
 		UT_OUT("!%s: pool::create", _path.get());
@@ -153,7 +153,7 @@ get_root_closed()
 	nvobj::pool<root> pop;
 
 	try {
-		pop.get_root();
+		pop.root();
 	} catch (pmem::pool_error &pe) {
 		UT_OUT("pool.get_root: %s", pe.what());
 	}

--- a/tests/ptr_arith/ptr_arith.cpp
+++ b/tests/ptr_arith/ptr_arith.cpp
@@ -63,7 +63,7 @@ prepare_array(nvobj::pool_base &pop)
 	int ret;
 
 	nvobj::persistent_ptr<T> parr_vsize;
-	ret = pmemobj_zalloc(pop.get_handle(), parr_vsize.raw_ptr(),
+	ret = pmemobj_zalloc(pop.handle(), parr_vsize.raw_ptr(),
 			     sizeof(T) * TEST_ARR_SIZE, 0);
 
 	UT_ASSERTeq(ret, 0);
@@ -71,7 +71,7 @@ prepare_array(nvobj::pool_base &pop)
 	T *parray = parr_vsize.get();
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&] {
+		nvobj::transaction::run(pop, [&] {
 			for (int i = 0; i < TEST_ARR_SIZE; ++i) {
 				parray[i] = i;
 			}

--- a/tests/shared_mutex/shared_mutex.cpp
+++ b/tests/shared_mutex/shared_mutex.cpp
@@ -127,7 +127,7 @@ mutex_zero_test(nvobj::pool<struct root> &pop)
 {
 	PMEMoid raw_mutex;
 
-	pmemobj_alloc(pop.get_handle(), &raw_mutex, sizeof(PMEMrwlock), 1,
+	pmemobj_alloc(pop.handle(), &raw_mutex, sizeof(PMEMrwlock), 1,
 		      [](PMEMobjpool *pop, void *ptr, void *arg) -> int {
 			      PMEMrwlock *mtx = static_cast<PMEMrwlock *>(ptr);
 			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
@@ -150,7 +150,7 @@ mutex_test(nvobj::pool<root> &pop, const Worker &writer, const Worker &reader)
 	const auto total_threads = num_threads * 2u;
 	std::thread threads[total_threads];
 
-	nvobj::persistent_ptr<root> proot = pop.get_root();
+	nvobj::persistent_ptr<root> proot = pop.root();
 
 	for (unsigned i = 0; i < total_threads; i += 2) {
 		threads[i] = std::thread(writer, proot);
@@ -185,16 +185,16 @@ main(int argc, char *argv[])
 
 	auto expected = num_threads * num_ops * 2;
 	mutex_test(pop, writer, reader);
-	UT_ASSERTeq(pop.get_root()->counter, expected);
+	UT_ASSERTeq(pop.root()->counter, expected);
 
 	/* trylocks are not tested as exhaustively */
 	expected -= num_threads * 2;
 	mutex_test(pop, writer_trylock, reader_trylock);
-	UT_ASSERTeq(pop.get_root()->counter, expected);
+	UT_ASSERTeq(pop.root()->counter, expected);
 
 	/* pmemcheck related persist */
-	pmemobj_persist(pop.get_handle(), &(pop.get_root()->counter),
-			sizeof(pop.get_root()->counter));
+	pmemobj_persist(pop.handle(), &(pop.root()->counter),
+			sizeof(pop.root()->counter));
 
 	pop.close();
 }

--- a/tests/shared_mutex_posix/shared_mutex_posix.cpp
+++ b/tests/shared_mutex_posix/shared_mutex_posix.cpp
@@ -137,7 +137,7 @@ mutex_zero_test(nvobj::pool<struct root> &pop)
 {
 	PMEMoid raw_mutex;
 
-	pmemobj_alloc(pop.get_handle(), &raw_mutex, sizeof(PMEMrwlock), 1,
+	pmemobj_alloc(pop.handle(), &raw_mutex, sizeof(PMEMrwlock), 1,
 		      [](PMEMobjpool *pop, void *ptr, void *arg) -> int {
 			      PMEMrwlock *mtx = static_cast<PMEMrwlock *>(ptr);
 			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
@@ -160,7 +160,7 @@ mutex_test(nvobj::pool<root> &pop, Worker writer, Worker reader)
 	const auto total_threads = num_threads * 2u;
 	pthread_t threads[total_threads];
 
-	auto proot = pop.get_root();
+	auto proot = pop.root();
 
 	for (unsigned i = 0; i < total_threads; i += 2) {
 		ut_pthread_create(&threads[i], nullptr, writer, &proot);
@@ -195,16 +195,16 @@ main(int argc, char *argv[])
 
 	auto expected = num_threads * num_ops * 2;
 	mutex_test(pop, writer, reader);
-	UT_ASSERTeq(pop.get_root()->counter, expected);
+	UT_ASSERTeq(pop.root()->counter, expected);
 
 	/* trylocks are not tested as exhaustively */
 	expected -= num_threads * 2;
 	mutex_test(pop, writer_trylock, reader_trylock);
-	UT_ASSERTeq(pop.get_root()->counter, expected);
+	UT_ASSERTeq(pop.root()->counter, expected);
 
 	/* pmemcheck related persist */
-	pmemobj_persist(pop.get_handle(), &(pop.get_root()->counter),
-			sizeof(pop.get_root()->counter));
+	pmemobj_persist(pop.handle(), &(pop.root()->counter),
+			sizeof(pop.root()->counter));
 
 	pop.close();
 }

--- a/tests/timed_mtx/timed_mtx.cpp
+++ b/tests/timed_mtx/timed_mtx.cpp
@@ -172,7 +172,7 @@ mutex_zero_test(nvobj::pool<struct root> &pop)
 {
 	PMEMoid raw_mutex;
 
-	pmemobj_alloc(pop.get_handle(), &raw_mutex, sizeof(PMEMmutex), 1,
+	pmemobj_alloc(pop.handle(), &raw_mutex, sizeof(PMEMmutex), 1,
 		      [](PMEMobjpool *pop, void *ptr, void *) -> int {
 			      PMEMmutex *mtx = static_cast<PMEMmutex *>(ptr);
 			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
@@ -194,7 +194,7 @@ timed_mtx_test(nvobj::pool<root> &pop, const Worker &function)
 {
 	std::thread threads[num_threads];
 
-	auto proot = pop.get_root();
+	auto proot = pop.root();
 
 	for (unsigned i = 0; i < num_threads; ++i)
 		threads[i] = std::thread(function, proot);
@@ -226,38 +226,38 @@ main(int argc, char *argv[])
 	mutex_zero_test(pop);
 
 	timed_mtx_test(pop, increment_pint);
-	UT_ASSERTeq(pop.get_root()->counter, num_threads * num_ops);
+	UT_ASSERTeq(pop.root()->counter, num_threads * num_ops);
 
 	timed_mtx_test(pop, decrement_pint);
-	UT_ASSERTeq(pop.get_root()->counter, 0);
+	UT_ASSERTeq(pop.root()->counter, 0);
 
 	timed_mtx_test(pop, trylock_test);
-	UT_ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.root()->counter, num_threads);
 
 	/* loop the next two tests */
 	loop = true;
 
 	timed_mtx_test(pop, trylock_until_test);
-	UT_ASSERTeq(pop.get_root()->counter, 0);
+	UT_ASSERTeq(pop.root()->counter, 0);
 
 	timed_mtx_test(pop, trylock_for_test);
-	UT_ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.root()->counter, num_threads);
 
 	loop = false;
 
-	pop.get_root()->pmutex.lock();
+	pop.root()->pmutex.lock();
 
 	timed_mtx_test(pop, trylock_until_test);
-	UT_ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.root()->counter, num_threads);
 
 	timed_mtx_test(pop, trylock_for_test);
-	UT_ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.root()->counter, num_threads);
 
-	pop.get_root()->pmutex.unlock();
+	pop.root()->pmutex.unlock();
 
 	/* pmemcheck related persist */
-	pmemobj_persist(pop.get_handle(), &(pop.get_root()->counter),
-			sizeof(pop.get_root()->counter));
+	pmemobj_persist(pop.handle(), &(pop.root()->counter),
+			sizeof(pop.root()->counter));
 
 	pop.close();
 }

--- a/tests/timed_mtx_posix/timed_mtx_posix.cpp
+++ b/tests/timed_mtx_posix/timed_mtx_posix.cpp
@@ -174,7 +174,7 @@ mutex_zero_test(nvobj::pool<struct root> &pop)
 {
 	PMEMoid raw_mutex;
 
-	pmemobj_alloc(pop.get_handle(), &raw_mutex, sizeof(PMEMmutex), 1,
+	pmemobj_alloc(pop.handle(), &raw_mutex, sizeof(PMEMmutex), 1,
 		      [](PMEMobjpool *pop, void *ptr, void *arg) -> int {
 			      PMEMmutex *mtx = static_cast<PMEMmutex *>(ptr);
 			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
@@ -196,7 +196,7 @@ timed_mtx_test(nvobj::pool<struct root> &pop, Worker function)
 {
 	pthread_t threads[num_threads];
 
-	auto proot = pop.get_root();
+	auto proot = pop.root();
 
 	for (unsigned i = 0; i < num_threads; ++i)
 		ut_pthread_create(&threads[i], nullptr, function, &proot);
@@ -228,38 +228,38 @@ main(int argc, char *argv[])
 	mutex_zero_test(pop);
 
 	timed_mtx_test(pop, increment_pint);
-	UT_ASSERTeq(pop.get_root()->counter, num_threads * num_ops);
+	UT_ASSERTeq(pop.root()->counter, num_threads * num_ops);
 
 	timed_mtx_test(pop, decrement_pint);
-	UT_ASSERTeq(pop.get_root()->counter, 0);
+	UT_ASSERTeq(pop.root()->counter, 0);
 
 	timed_mtx_test(pop, trylock_test);
-	UT_ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.root()->counter, num_threads);
 
 	/* loop the next two tests */
 	loop = true;
 
 	timed_mtx_test(pop, trylock_until_test);
-	UT_ASSERTeq(pop.get_root()->counter, 0);
+	UT_ASSERTeq(pop.root()->counter, 0);
 
 	timed_mtx_test(pop, trylock_for_test);
-	UT_ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.root()->counter, num_threads);
 
 	loop = false;
 
-	pop.get_root()->pmutex.lock();
+	pop.root()->pmutex.lock();
 
 	timed_mtx_test(pop, trylock_until_test);
-	UT_ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.root()->counter, num_threads);
 
 	timed_mtx_test(pop, trylock_for_test);
-	UT_ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.root()->counter, num_threads);
 
-	pop.get_root()->pmutex.unlock();
+	pop.root()->pmutex.unlock();
 
 	/* pmemcheck related persist */
-	pmemobj_persist(pop.get_handle(), &(pop.get_root()->counter),
-			sizeof(pop.get_root()->counter));
+	pmemobj_persist(pop.handle(), &(pop.root()->counter),
+			sizeof(pop.root()->counter));
 
 	pop.close();
 }

--- a/tests/transaction/transaction.cpp
+++ b/tests/transaction/transaction.cpp
@@ -117,7 +117,7 @@ public:
 	void
 	operator()()
 	{
-		auto rootp = this->pop.get_root();
+		auto rootp = this->pop.root();
 
 		if (rootp->pfoo == nullptr)
 			rootp->pfoo = nvobj::make_persistent<foo>();
@@ -135,7 +135,7 @@ private:
 void
 do_transaction(nvobj::pool<root> &pop)
 {
-	auto rootp = pop.get_root();
+	auto rootp = pop.root();
 
 	rootp->parr = nvobj::make_persistent<nvobj::p<int>>();
 
@@ -152,13 +152,13 @@ do_transaction(nvobj::pool<root> &pop)
 void
 test_tx_no_throw_no_abort(nvobj::pool<root> &pop)
 {
-	auto rootp = pop.get_root();
+	auto rootp = pop.root();
 
 	UT_ASSERT(rootp->pfoo == nullptr);
 	UT_ASSERT(rootp->parr == nullptr);
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&]() {
+		nvobj::transaction::run(pop, [&]() {
 			rootp->pfoo = nvobj::make_persistent<foo>();
 		});
 	} catch (...) {
@@ -169,7 +169,7 @@ test_tx_no_throw_no_abort(nvobj::pool<root> &pop)
 	UT_ASSERT(rootp->parr == nullptr);
 
 	try {
-		nvobj::transaction::exec_tx(
+		nvobj::transaction::run(
 			pop, std::bind(do_transaction, std::ref(pop)),
 			rootp->mtx);
 	} catch (...) {
@@ -181,8 +181,8 @@ test_tx_no_throw_no_abort(nvobj::pool<root> &pop)
 	UT_ASSERTeq(*rootp->parr.get(), 5);
 
 	try {
-		nvobj::transaction::exec_tx(pop, transaction_test(pop),
-					    rootp->mtx, rootp->pfoo->smtx);
+		nvobj::transaction::run(pop, transaction_test(pop), rootp->mtx,
+					rootp->pfoo->smtx);
 	} catch (...) {
 		UT_ASSERT(0);
 	}
@@ -193,7 +193,7 @@ test_tx_no_throw_no_abort(nvobj::pool<root> &pop)
 	UT_ASSERTeq(rootp->pfoo->bar, 42);
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&]() {
+		nvobj::transaction::run(pop, [&]() {
 			nvobj::delete_persistent<foo>(rootp->pfoo);
 			nvobj::delete_persistent<nvobj::p<int>>(rootp->parr);
 			rootp->pfoo = nullptr;
@@ -213,14 +213,14 @@ test_tx_no_throw_no_abort(nvobj::pool<root> &pop)
 void
 test_tx_throw_no_abort(nvobj::pool<root> &pop)
 {
-	auto rootp = pop.get_root();
+	auto rootp = pop.root();
 
 	UT_ASSERT(rootp->pfoo == nullptr);
 	UT_ASSERT(rootp->parr == nullptr);
 
 	bool exception_thrown = false;
 	try {
-		nvobj::transaction::exec_tx(pop, [&]() {
+		nvobj::transaction::run(pop, [&]() {
 			rootp->pfoo = nvobj::make_persistent<foo>();
 			throw std::runtime_error("error");
 		});
@@ -236,9 +236,9 @@ test_tx_throw_no_abort(nvobj::pool<root> &pop)
 	UT_ASSERT(rootp->parr == nullptr);
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&]() {
+		nvobj::transaction::run(pop, [&]() {
 			rootp->pfoo = nvobj::make_persistent<foo>();
-			nvobj::transaction::exec_tx(pop, [&]() {
+			nvobj::transaction::run(pop, [&]() {
 				throw std::runtime_error("error");
 			});
 		});
@@ -254,10 +254,10 @@ test_tx_throw_no_abort(nvobj::pool<root> &pop)
 	UT_ASSERT(rootp->parr == nullptr);
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&]() {
+		nvobj::transaction::run(pop, [&]() {
 			rootp->pfoo = nvobj::make_persistent<foo>();
 			try {
-				nvobj::transaction::exec_tx(pop, [&]() {
+				nvobj::transaction::run(pop, [&]() {
 					throw std::runtime_error("error");
 				});
 			} catch (std::runtime_error &) {
@@ -285,14 +285,14 @@ test_tx_throw_no_abort(nvobj::pool<root> &pop)
 void
 test_tx_no_throw_abort(nvobj::pool<root> &pop)
 {
-	auto rootp = pop.get_root();
+	auto rootp = pop.root();
 
 	UT_ASSERT(rootp->pfoo == nullptr);
 	UT_ASSERT(rootp->parr == nullptr);
 
 	bool exception_thrown = false;
 	try {
-		nvobj::transaction::exec_tx(pop, [&]() {
+		nvobj::transaction::run(pop, [&]() {
 			rootp->pfoo = nvobj::make_persistent<foo>();
 			nvobj::transaction::abort(-1);
 		});
@@ -308,9 +308,9 @@ test_tx_no_throw_abort(nvobj::pool<root> &pop)
 	UT_ASSERT(rootp->parr == nullptr);
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&]() {
+		nvobj::transaction::run(pop, [&]() {
 			rootp->pfoo = nvobj::make_persistent<foo>();
-			nvobj::transaction::exec_tx(
+			nvobj::transaction::run(
 				pop, [&]() { nvobj::transaction::abort(-1); });
 		});
 	} catch (pmem::manual_tx_abort &) {
@@ -325,10 +325,10 @@ test_tx_no_throw_abort(nvobj::pool<root> &pop)
 	UT_ASSERT(rootp->parr == nullptr);
 
 	try {
-		nvobj::transaction::exec_tx(pop, [&]() {
+		nvobj::transaction::run(pop, [&]() {
 			rootp->pfoo = nvobj::make_persistent<foo>();
 			try {
-				nvobj::transaction::exec_tx(pop, [&]() {
+				nvobj::transaction::run(pop, [&]() {
 					nvobj::transaction::abort(-1);
 				});
 			} catch (pmem::manual_tx_abort &) {
@@ -361,7 +361,7 @@ void
 test_tx_no_throw_no_abort_scope(nvobj::pool<root> &pop,
 				std::function<void()> commit)
 {
-	auto rootp = pop.get_root();
+	auto rootp = pop.root();
 
 	UT_ASSERT(rootp->pfoo == nullptr);
 	UT_ASSERT(rootp->parr == nullptr);
@@ -374,7 +374,7 @@ test_tx_no_throw_no_abort_scope(nvobj::pool<root> &pop,
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTeq(nvobj::transaction::get_last_tx_error(), 0);
+	UT_ASSERTeq(nvobj::transaction::error(), 0);
 	UT_ASSERT(rootp->pfoo != nullptr);
 	UT_ASSERT(rootp->parr == nullptr);
 
@@ -386,7 +386,7 @@ test_tx_no_throw_no_abort_scope(nvobj::pool<root> &pop,
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTeq(nvobj::transaction::get_last_tx_error(), 0);
+	UT_ASSERTeq(nvobj::transaction::error(), 0);
 	UT_ASSERT(rootp->pfoo != nullptr);
 	UT_ASSERT(rootp->parr != nullptr);
 	UT_ASSERTeq(*rootp->parr.get(), 5);
@@ -400,7 +400,7 @@ test_tx_no_throw_no_abort_scope(nvobj::pool<root> &pop,
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTeq(nvobj::transaction::get_last_tx_error(), 0);
+	UT_ASSERTeq(nvobj::transaction::error(), 0);
 	UT_ASSERT(rootp->pfoo != nullptr);
 	UT_ASSERT(rootp->parr != nullptr);
 	UT_ASSERTeq(*rootp->parr.get(), 5);
@@ -417,7 +417,7 @@ test_tx_no_throw_no_abort_scope(nvobj::pool<root> &pop,
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTeq(nvobj::transaction::get_last_tx_error(), 0);
+	UT_ASSERTeq(nvobj::transaction::error(), 0);
 	UT_ASSERT(rootp->pfoo == nullptr);
 	UT_ASSERT(rootp->parr == nullptr);
 }
@@ -430,7 +430,7 @@ template <typename T>
 void
 test_tx_throw_no_abort_scope(nvobj::pool<root> &pop)
 {
-	auto rootp = pop.get_root();
+	auto rootp = pop.root();
 
 	UT_ASSERT(rootp->pfoo == nullptr);
 	UT_ASSERT(rootp->parr == nullptr);
@@ -448,7 +448,7 @@ test_tx_throw_no_abort_scope(nvobj::pool<root> &pop)
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTeq(nvobj::transaction::get_last_tx_error(), ECANCELED);
+	UT_ASSERTeq(nvobj::transaction::error(), ECANCELED);
 	UT_ASSERT(exception_thrown);
 	exception_thrown = false;
 	UT_ASSERT(rootp->pfoo == nullptr);
@@ -469,7 +469,7 @@ test_tx_throw_no_abort_scope(nvobj::pool<root> &pop)
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTeq(nvobj::transaction::get_last_tx_error(), ECANCELED);
+	UT_ASSERTeq(nvobj::transaction::error(), ECANCELED);
 	UT_ASSERT(exception_thrown);
 	exception_thrown = false;
 	UT_ASSERT(rootp->pfoo == nullptr);
@@ -498,7 +498,7 @@ test_tx_throw_no_abort_scope(nvobj::pool<root> &pop)
 	}
 
 	/* the transaction will be aborted silently */
-	UT_ASSERTeq(nvobj::transaction::get_last_tx_error(), ECANCELED);
+	UT_ASSERTeq(nvobj::transaction::error(), ECANCELED);
 	if (std::is_same<T, nvobj::transaction::automatic>::value)
 		UT_ASSERT(exception_thrown);
 	else
@@ -515,7 +515,7 @@ template <typename T>
 void
 test_tx_no_throw_abort_scope(nvobj::pool<root> &pop)
 {
-	auto rootp = pop.get_root();
+	auto rootp = pop.root();
 
 	UT_ASSERT(rootp->pfoo == nullptr);
 	UT_ASSERT(rootp->parr == nullptr);
@@ -533,7 +533,7 @@ test_tx_no_throw_abort_scope(nvobj::pool<root> &pop)
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTeq(nvobj::transaction::get_last_tx_error(), ECANCELED);
+	UT_ASSERTeq(nvobj::transaction::error(), ECANCELED);
 	UT_ASSERT(exception_thrown);
 	exception_thrown = false;
 	UT_ASSERT(rootp->pfoo == nullptr);
@@ -554,7 +554,7 @@ test_tx_no_throw_abort_scope(nvobj::pool<root> &pop)
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTeq(nvobj::transaction::get_last_tx_error(), EINVAL);
+	UT_ASSERTeq(nvobj::transaction::error(), EINVAL);
 	UT_ASSERT(exception_thrown);
 	exception_thrown = false;
 	UT_ASSERT(rootp->pfoo == nullptr);
@@ -579,7 +579,7 @@ test_tx_no_throw_abort_scope(nvobj::pool<root> &pop)
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTeq(nvobj::transaction::get_last_tx_error(), -1);
+	UT_ASSERTeq(nvobj::transaction::error(), -1);
 	UT_ASSERT(exception_thrown);
 	UT_ASSERT(rootp->pfoo == nullptr);
 	UT_ASSERT(rootp->parr == nullptr);
@@ -592,7 +592,7 @@ test_tx_no_throw_abort_scope(nvobj::pool<root> &pop)
 void
 test_tx_automatic_destructor_throw(nvobj::pool<root> &pop)
 {
-	auto rootp = pop.get_root();
+	auto rootp = pop.root();
 
 	UT_ASSERT(rootp->pfoo == nullptr);
 	UT_ASSERT(rootp->parr == nullptr);
@@ -608,7 +608,7 @@ test_tx_automatic_destructor_throw(nvobj::pool<root> &pop)
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTeq(nvobj::transaction::get_last_tx_error(), ECANCELED);
+	UT_ASSERTeq(nvobj::transaction::error(), ECANCELED);
 	UT_ASSERT(exception_thrown);
 	exception_thrown = false;
 	UT_ASSERT(rootp->pfoo == nullptr);
@@ -626,7 +626,7 @@ test_tx_automatic_destructor_throw(nvobj::pool<root> &pop)
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTeq(nvobj::transaction::get_last_tx_error(), ECANCELED);
+	UT_ASSERTeq(nvobj::transaction::error(), ECANCELED);
 	UT_ASSERT(exception_thrown);
 	exception_thrown = false;
 	UT_ASSERT(rootp->pfoo == nullptr);
@@ -643,7 +643,7 @@ test_tx_automatic_destructor_throw(nvobj::pool<root> &pop)
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTeq(nvobj::transaction::get_last_tx_error(), 0);
+	UT_ASSERTeq(nvobj::transaction::error(), 0);
 	UT_ASSERT(!exception_thrown);
 
 	counter = 0;
@@ -666,7 +666,7 @@ test_tx_automatic_destructor_throw(nvobj::pool<root> &pop)
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTeq(nvobj::transaction::get_last_tx_error(), -1);
+	UT_ASSERTeq(nvobj::transaction::error(), -1);
 	UT_ASSERT(exception_thrown);
 	UT_ASSERT(rootp->pfoo == nullptr);
 	UT_ASSERT(rootp->parr == nullptr);
@@ -688,7 +688,7 @@ test_tx_automatic_destructor_throw(nvobj::pool<root> &pop)
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTeq(nvobj::transaction::get_last_tx_error(), -1);
+	UT_ASSERTeq(nvobj::transaction::error(), -1);
 	UT_ASSERT(exception_thrown);
 	UT_ASSERT(rootp->pfoo == nullptr);
 	UT_ASSERT(rootp->parr == nullptr);
@@ -716,7 +716,7 @@ test_tx_automatic_destructor_throw(nvobj::pool<root> &pop)
 	}
 
 	/* the transaction will be aborted silently */
-	UT_ASSERTeq(nvobj::transaction::get_last_tx_error(), ECANCELED);
+	UT_ASSERTeq(nvobj::transaction::error(), ECANCELED);
 	UT_ASSERT(exception_thrown);
 	UT_ASSERT(rootp->pfoo == nullptr);
 	UT_ASSERT(rootp->parr == nullptr);

--- a/tests/v/v.cpp
+++ b/tests/v/v.cpp
@@ -77,8 +77,8 @@ struct root {
 void
 test_init(nvobj::pool<root> &pop)
 {
-	UT_ASSERTeq(pop.get_root()->f.get().counter, TEST_VALUE);
-	UT_ASSERTeq(pop.get_root()->bar_ptr->vfoo.get().counter, TEST_VALUE);
+	UT_ASSERTeq(pop.root()->f.get().counter, TEST_VALUE);
+	UT_ASSERTeq(pop.root()->bar_ptr->vfoo.get().counter, TEST_VALUE);
 }
 }
 
@@ -101,12 +101,12 @@ main(int argc, char *argv[])
 		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
 
-	nvobj::make_persistent_atomic<bar>(pop, pop.get_root()->bar_ptr);
+	nvobj::make_persistent_atomic<bar>(pop, pop.root()->bar_ptr);
 
 	test_init(pop);
 
-	pop.get_root()->f.get().counter = 20;
-	UT_ASSERTeq(pop.get_root()->f.get().counter, 20);
+	pop.root()->f.get().counter = 20;
+	UT_ASSERTeq(pop.root()->f.get().counter, 20);
 
 	pop.close();
 


### PR DESCRIPTION
This just a small cleanup of function names that in retrospect
were badly choosen ;)
'pool::get_root' -> 'pool::root'
'pool::get_handle' -> 'pool::handle'
'transaction::get_last_tx_error' -> 'transaction::error'
'transaction::exec_tx' -> 'transaction::run'

Because the old names are present, but deprecated by compiler function attributes, this might break dependent builds that use `-Werror`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/75)
<!-- Reviewable:end -->
