### PR TITLE
Fix array::range() method description

### DIFF
--- a/include/libpmemobj++/experimental/array.hpp
+++ b/include/libpmemobj++/experimental/array.hpp
@@ -394,12 +394,12 @@ struct array {
 	}
 
 	/**
-	 * Adds requested range to a transaction and returns slice.
+	 * Returns slice.
 	 *
 	 * @param[in] start start index of requested range.
 	 * @param[in] n number of elements in range.
 	 * @param[in] snapshot_size number of elements which should be
-	 *	snapshotted in a bulk while traversing this slice
+	 *	snapshotted in a bulk while traversing this slice.
 	 *	If provided value is larger or equal to n, entire range is
 	 *	added to a transaction. If value is equal to 0 no snapshotting
 	 *	happens.


### PR DESCRIPTION
This method does not snapshot the entire range as the comment suggested.
Snaphotting is done inside range_snapshotting_iterator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/94)
<!-- Reviewable:end -->
