### PR TITLE
Add iterator_traits header file with tests

### DIFF
--- a/include/libpmemobj++/detail/iterator_traits.hpp
+++ b/include/libpmemobj++/detail/iterator_traits.hpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * Common iterator traits.
+ */
+
+#ifndef LIBPMEMOBJ_CPP_ITERATOR_TRAITS_HPP
+#define LIBPMEMOBJ_CPP_ITERATOR_TRAITS_HPP
+
+#include <iterator>
+
+namespace pmem
+{
+
+namespace detail
+{
+
+template <typename T, typename U, typename C = void>
+struct has_iterator_category_convertible_to : std::false_type {
+};
+
+template <typename T, typename U>
+struct has_iterator_category_convertible_to<
+	T, U,
+	typename std::enable_if<std::is_convertible<
+		typename std::iterator_traits<T>::iterator_category,
+		U>::value>::type> : std::true_type {
+};
+
+/**
+ * Type trait to determine if a given parameter type satisfies requirements of
+ * OutputIterator.
+ */
+template <typename T>
+struct is_output_iterator
+    : public has_iterator_category_convertible_to<T, std::output_iterator_tag> {
+};
+
+/**
+ * Type trait to determine if a given parameter type satisfies requirements of
+ * InputIterator.
+ */
+template <typename T>
+struct is_input_iterator
+    : public has_iterator_category_convertible_to<T, std::input_iterator_tag> {
+};
+
+/**
+ * Type trait to determine if a given parameter type satisfies requirements of
+ * ForwardIterator.
+ */
+template <typename T>
+struct is_forward_iterator
+    : public has_iterator_category_convertible_to<T,
+						  std::forward_iterator_tag> {
+};
+
+/**
+ * Type trait to determine if a given parameter type satisfies requirements of
+ * BidirectionalIterator.
+ */
+template <typename T>
+struct is_bidirectional_iterator : public has_iterator_category_convertible_to<
+					   T, std::bidirectional_iterator_tag> {
+};
+
+/**
+ * Type trait to determine if a given parameter type satisfies requirements of
+ * RandomAccessIterator.
+ */
+template <typename T>
+struct is_random_access_iterator : public has_iterator_category_convertible_to<
+					   T, std::random_access_iterator_tag> {
+};
+
+} /* namespace detail */
+
+} /* namespace pmem */
+
+#endif /* LIBPMEMOBJ_CPP_ITERATOR_TRAITS_HPP */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -224,4 +224,7 @@ build_test(array_iterator array_iterator/array_iterator.cpp)
 add_test_generic(array_iterator none)
 add_test_generic(array_iterator pmemcheck)
 
+build_test(iterator_traits iterator_traits/iterator_traits.cpp)
+add_test_generic(iterator_traits none)
+
 add_subdirectory(external)

--- a/tests/iterator_traits/iterator_traits.cpp
+++ b/tests/iterator_traits/iterator_traits.cpp
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * iterator_traits.cpp -- iterator traits tests
+ */
+
+#include "unittest.hpp"
+
+#include "libpmemobj++/detail/iterator_traits.hpp"
+#include <iterator>
+
+struct test_iterator_base {
+	using value_type = void;
+	using difference_type = void;
+	using pointer = void;
+	using reference = void;
+};
+
+struct test_output_iterator : public test_iterator_base {
+	using iterator_category = std::output_iterator_tag;
+};
+
+struct test_input_iterator : public test_iterator_base {
+	using iterator_category = std::input_iterator_tag;
+};
+
+struct test_forward_iterator : public test_iterator_base {
+	using iterator_category = std::forward_iterator_tag;
+};
+
+struct test_bidirectional_iterator : public test_iterator_base {
+	using iterator_category = std::bidirectional_iterator_tag;
+};
+
+struct test_random_access_iterator : public test_iterator_base {
+	using iterator_category = std::random_access_iterator_tag;
+};
+
+void
+test_is_type_of_iterator()
+{
+	/* test is_output_iterator */
+	UT_ASSERT(
+		true ==
+		pmem::detail::is_output_iterator<test_output_iterator>::value);
+	UT_ASSERT(false ==
+		  pmem::detail::is_output_iterator<test_input_iterator>::value);
+	UT_ASSERT(
+		false ==
+		pmem::detail::is_output_iterator<test_forward_iterator>::value);
+	UT_ASSERT(false ==
+		  pmem::detail::is_output_iterator<
+			  test_bidirectional_iterator>::value);
+	UT_ASSERT(false ==
+		  pmem::detail::is_output_iterator<
+			  test_random_access_iterator>::value);
+	UT_ASSERT(false == pmem::detail::is_output_iterator<int>::value);
+
+	/* test is_input_iterator */
+	UT_ASSERT(false ==
+		  pmem::detail::is_input_iterator<test_output_iterator>::value);
+	UT_ASSERT(true ==
+		  pmem::detail::is_input_iterator<test_input_iterator>::value);
+	UT_ASSERT(
+		true ==
+		pmem::detail::is_input_iterator<test_forward_iterator>::value);
+	UT_ASSERT(true ==
+		  pmem::detail::is_input_iterator<
+			  test_bidirectional_iterator>::value);
+	UT_ASSERT(true ==
+		  pmem::detail::is_input_iterator<
+			  test_random_access_iterator>::value);
+	UT_ASSERT(false == pmem::detail::is_input_iterator<int>::value);
+
+	/* test forward_iterator */
+	UT_ASSERT(
+		false ==
+		pmem::detail::is_forward_iterator<test_output_iterator>::value);
+	UT_ASSERT(
+		false ==
+		pmem::detail::is_forward_iterator<test_input_iterator>::value);
+	UT_ASSERT(true ==
+		  pmem::detail::is_forward_iterator<
+			  test_forward_iterator>::value);
+	UT_ASSERT(true ==
+		  pmem::detail::is_forward_iterator<
+			  test_bidirectional_iterator>::value);
+	UT_ASSERT(true ==
+		  pmem::detail::is_forward_iterator<
+			  test_random_access_iterator>::value);
+	UT_ASSERT(false == pmem::detail::is_forward_iterator<int>::value);
+
+	/* test bidirectional_iterator */
+	UT_ASSERT(false ==
+		  pmem::detail::is_bidirectional_iterator<
+			  test_output_iterator>::value);
+	UT_ASSERT(false ==
+		  pmem::detail::is_bidirectional_iterator<
+			  test_input_iterator>::value);
+	UT_ASSERT(false ==
+		  pmem::detail::is_bidirectional_iterator<
+			  test_forward_iterator>::value);
+	UT_ASSERT(true ==
+		  pmem::detail::is_bidirectional_iterator<
+			  test_bidirectional_iterator>::value);
+	UT_ASSERT(true ==
+		  pmem::detail::is_bidirectional_iterator<
+			  test_random_access_iterator>::value);
+	UT_ASSERT(false == pmem::detail::is_bidirectional_iterator<int>::value);
+
+	/* test random_access_iterator */
+	UT_ASSERT(false ==
+		  pmem::detail::is_random_access_iterator<
+			  test_output_iterator>::value);
+	UT_ASSERT(false ==
+		  pmem::detail::is_random_access_iterator<
+			  test_input_iterator>::value);
+	UT_ASSERT(false ==
+		  pmem::detail::is_random_access_iterator<
+			  test_forward_iterator>::value);
+	UT_ASSERT(false ==
+		  pmem::detail::is_random_access_iterator<
+			  test_bidirectional_iterator>::value);
+	UT_ASSERT(true ==
+		  pmem::detail::is_random_access_iterator<
+			  test_random_access_iterator>::value);
+	UT_ASSERT(false == pmem::detail::is_random_access_iterator<int>::value);
+}
+
+int
+main()
+{
+	START();
+
+	test_is_type_of_iterator();
+
+	return 0;
+}

--- a/tests/iterator_traits/iterator_traits_0.cmake
+++ b/tests/iterator_traits/iterator_traits_0.cmake
@@ -1,0 +1,38 @@
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+include(${SRC_DIR}/../helpers.cmake)
+
+setup()
+
+execute(${TEST_EXECUTABLE} ${DIR}/testfile)
+
+finish()


### PR DESCRIPTION
Standard library does not provide public type traits to determine
if given iterator satsfies requirements of specyfic iterator type.
This commit provide such a type traits with tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/97)
<!-- Reviewable:end -->
