### PR TITLE
Fix clang format detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,9 +164,16 @@ add_custom_target(tests)
 
 if(DEVELOPER_MODE)
 	add_flag(-Werror) # XXX: WX for windows
-	find_program(CLANG_FORMAT NAMES clang-format-6.0)
-	if (NOT CLANG_FORMAT)
-		message(WARNING "clang-format not found - C++ sources will not be checked (needed version: 6.0)")
+	find_program(CLANG_FORMAT NAMES clang-format clang-format-6.0)
+	set(CLANG_FORMAT_REQUIRED "6.0")
+	if(CLANG_FORMAT)
+		get_program_version(${CLANG_FORMAT} CLANG_FORMAT_VERSION)
+		if(NOT (CLANG_FORMAT_VERSION VERSION_EQUAL CLANG_FORMAT_REQUIRED))
+			message(WARNING "required clang-format version is ${CLANG_FORMAT_REQUIRED}")
+			unset(CLANG_FORMAT)
+		endif()
+	else()
+		message(WARNING "clang-format not found - C++ sources will not be checked (needed version: ${CLANG_FORMAT_REQUIRED})")
 	endif()
 
 	execute_process(COMMAND ${PERL_EXECUTABLE} -MText::Diff -e ""

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -143,3 +143,12 @@ function(add_check_whitespace name)
 
 	add_dependencies(check-whitespace check-whitespace-${name})
 endfunction()
+
+# Sets ${ret} to version of program specified by ${name} in major.minor.patch format
+function(get_program_version name ret)
+	execute_process(COMMAND ${name} --version
+		OUTPUT_VARIABLE cmd_ret
+		ERROR_QUIET)
+	STRING(REGEX MATCH "([0-9]+.)([0-9]+.)([0-9]+)" VERSION ${cmd_ret})
+	SET(${ret} ${VERSION} PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
Current solution checks availability of clang-format-X.Y program which is valid on Ubuntu, whilst on Fedora clang format is installed as clang-format binary

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/105)
<!-- Reviewable:end -->
