### PR TITLE
Vector skeleton

### DIFF
--- a/include/libpmemobj++/experimental/vector.hpp
+++ b/include/libpmemobj++/experimental/vector.hpp
@@ -1,0 +1,420 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * Vector container with std::vector compatible interface.
+ */
+
+#ifndef LIBPMEMOBJ_CPP_VECTOR_HPP
+#define LIBPMEMOBJ_CPP_VECTOR_HPP
+
+#include <libpmemobj++/detail/common.hpp>
+#include <libpmemobj++/detail/iterator_traits.hpp>
+#include <libpmemobj++/detail/life.hpp>
+#include <libpmemobj++/experimental/contiguous_iterator.hpp>
+#include <libpmemobj++/experimental/slice.hpp>
+#include <libpmemobj++/make_persistent_array.hpp>
+#include <libpmemobj++/persistent_ptr.hpp>
+#include <libpmemobj++/pext.hpp>
+#include <libpmemobj++/transaction.hpp>
+#include <libpmemobj.h>
+
+#include <cassert>
+#include <utility>
+
+namespace pmem
+{
+
+namespace obj
+{
+
+namespace experimental
+{
+
+/**
+ * pmem::obj::experimental::vector - EXPERIMENTAL persistent container
+ * with std::vector compatible interface.
+ */
+template <typename T>
+class vector {
+public:
+	/* Member types */
+	using value_type = T;
+	using size_type = std::size_t;
+	using difference_type = std::ptrdiff_t;
+	using reference = value_type &;
+	using const_reference = const value_type &;
+	using pointer = value_type *;
+	using const_pointer = const value_type *;
+	using iterator = basic_contiguous_iterator<T>;
+	using const_iterator = const_contiguous_iterator<T>;
+	using reverse_iterator = std::reverse_iterator<iterator>;
+	using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+	/* Constructors */
+	vector();
+	// vector(size_type count, const value_type &value = T());
+	// template <typename InputIt>
+	// vector(InputIt first, typename
+	// std::enable_if<detail::is_input_iterator<InputIt>::value &&
+	// std::is_constructible<value_type, typename
+	// std::iterator_traits<InputIt>::reference>::value, InputIt>::type
+	// last); vector(const vector &other); vector(vector &&other);
+	// vector(std::initializer_list<T> init);
+
+	/* Assign operators */
+	// vector &operator=(const vector &other);
+	// vector &operator=(vector &&other);
+	// vector &operator=(std::initializer_list<T> ilist);
+
+	/* Assign methods */
+	// void assign(size_type count, const T &value);
+	// template <typename InputIt>
+	// void assign(InputIt first, typename
+	// std::enable_if<detail::is_input_iterator<InputIt>::value &&
+	// std::is_constructible<value_type, typename
+	// std::iterator_traits<InputIt>::reference>::value, InputIt>::type
+	// last); void assign(std::initializer_list<T> ilist);
+
+	/* Destructor */
+	// ~vector();
+
+	/* Element access */
+	// reference at(size_type n);
+	// const_reference at(size_type n) const;
+	// reference operator[](size_type n);
+	// const_reference operator[](size_type n) const;
+	// reference front();
+	// const_reference front() const;
+	// reference back();
+	// const_reference back() const;
+	// pointer data();
+	// const_pointer data() const noexcept;
+
+	/* Iterators */
+	// iterator begin();
+	// const_iterator begin() const noexcept;
+	// const_iterator cbegin() const noexcept;
+	// iterator end();
+	// const_iterator end() const noexcept;
+	// const_iterator cend() const noexcept;
+	// reverse_iterator rbegin();
+	// const_reverse_iterator rbegin() const noexcept;
+	// const_reverse_iterator crbegin() const noexcept;
+	// reverse_iterator rend();
+	// const_reverse_iterator rend() const noexcept;
+	// const_reverse_iterator crend() const noexcept;
+
+	/* Capacity */
+	constexpr bool empty() const noexcept;
+	// size_type size() const noexcept;
+	constexpr size_type max_size() const noexcept;
+	// void reserve(size_type capacity_new);
+	// size_type capacity() const noexcept;
+	// void shrink_to_fit();
+
+	/* Modifiers */
+	// void clear() noexcept;
+	// void free_data();
+	// iterator insert(const_iterator pos, const T &value);
+	// iterator insert(const_iterator pos, T &&value);
+	// iterator insert(const_iterator pos, size_type count, const T &value);
+	// template <typename InputIt>
+	// iterator insert(const_iterator pos, InputIt first, typename
+	// std::enable_if<detail::is_input_iterator<InputIt>::value,
+	// InputIt>::type last); iterator insert(const_iterator pos,
+	// std::initializer_list<T> ilist); template <class... Args> iterator
+	// emplace(const_iterator pos, Args&&... args); template< class... Args
+	// > void emplace_back(Args&&... args); iterator erase(iterator pos);
+	// iterator erase(const_iterator pos);
+	// iterator erase(iterator first, iterator last);
+	// iterator erase(const_iterator first, const_iterator last);
+	// void push_back(const T& value);
+	// void push_back(T&& value);
+	// void pop_back();
+	// void resize(size_type count, T value = T());
+	// void resize(size_type count);
+	// void resize(size_type count, const value_type& value);
+	// void swap(vector &other);
+
+private:
+	/* helper functions */
+	void _alloc(size_type size);
+	void _dealloc();
+	void _grow(size_type count, const_reference value);
+	template <typename InputIt,
+		  typename std::enable_if<
+			  detail::is_input_iterator<InputIt>::value &&
+				  std::is_constructible<
+					  value_type,
+					  typename std::iterator_traits<
+						  InputIt>::reference>::value,
+			  InputIt>::type * = nullptr>
+	void _grow(InputIt first, InputIt last);
+	void _shrink(size_type size_new) noexcept;
+
+	/* Underlying array */
+	persistent_ptr<T[]> _data;
+
+	p<size_type> _size;
+	p<size_type> _capacity;
+};
+
+/**
+ * Default constructor. Constructs an empty container.
+ *
+ * @pre pmemobj_tx_stage() == TX_STAGE_WORK
+ *
+ * @throw pmem::pool_error if an object is not in persistent memory.
+ * @throw pmem::transaction_error if function wasn't called in transaction.
+ */
+template <typename T>
+vector<T>::vector()
+{
+	auto pop = pmemobj_pool_by_ptr(this);
+	if (pop == nullptr)
+		throw pool_error("Invalid pool handle.");
+
+	if (pmemobj_tx_stage() != TX_STAGE_WORK)
+		throw transaction_error(
+			"Default constructor called out of transaction scope.");
+
+	_data = nullptr;
+	_size = 0;
+	_capacity = 0;
+}
+
+/**
+ * Checks whether the container is empty.
+ *
+ * @return true if container is empty, 0 otherwise.
+ */
+template <typename T>
+constexpr bool
+vector<T>::empty() const noexcept
+{
+	return _size == 0;
+}
+
+/**
+ * @return maximum number of elements the container is able to hold due to PMDK
+ * limitations.
+ */
+template <typename T>
+constexpr typename vector<T>::size_type
+vector<T>::max_size() const noexcept
+{
+	return PMEMOBJ_MAX_ALLOC_SIZE / sizeof(value_type);
+}
+
+/**
+ * Private helper function. Must be called during transaction. Allocates memory
+ * for given number of elements.
+ *
+ * @param[in] capacity_new capacity of new underlying array
+ *
+ * @throw std::length_error if new size exceeds biggest possible pmem
+ * allocation.
+ * @throw pmem::transaction_alloc_error when allocating memory for underlying
+ * array in transaction failed.
+ *
+ * @pre pmemobj_tx_stage() == TX_STAGE_WORK
+ * @pre _data == nullptr;
+ * @pre _size == 0
+ *
+ * @post _capacity = capacity_new
+ */
+template <typename T>
+void
+vector<T>::_alloc(size_type capacity_new)
+{
+	assert(pmemobj_tx_stage() == TX_STAGE_WORK);
+	assert(_data == nullptr);
+	assert(_size == 0);
+
+	if (capacity_new > max_size())
+		throw std::length_error("New capacity exceeds max size.");
+
+	_capacity = capacity_new;
+
+	if (capacity_new == 0)
+		return;
+
+	_data = pmemobj_tx_alloc(sizeof(value_type) * capacity_new,
+				 detail::type_num<value_type>());
+
+	if (_data == nullptr)
+		throw transaction_alloc_error(
+			"Failed to allocate persistent memory object");
+}
+
+/**
+ * Private helper function. Must be called during transaction. Deallocates
+ * underlying array.
+ *
+ * @throw pmem::transaction_free_error when freeing old underlying array
+ * failed.
+ *
+ * @pre pmemobj_tx_stage() == TX_STAGE_WORK
+ *
+ * @post _size = _capacity = 0
+ * @post _data = nullptr
+ */
+template <typename T>
+void
+vector<T>::_dealloc()
+{
+	assert(pmemobj_tx_stage() == TX_STAGE_WORK);
+
+	if (_data != nullptr) {
+		_shrink(0);
+		if (pmemobj_tx_free(*_data.raw_ptr()) != 0)
+			throw transaction_free_error(
+				"failed to delete persistent memory object");
+		_data = nullptr;
+		_capacity = 0;
+	}
+}
+
+/**
+ * Private helper function. Must be called during transaction. Assumes that
+ * there is enough space for additional elements. Copy constructs elements at
+ * the end of underlying array based on given parameters.
+ *
+ * @param[in] count number of elements to construct.
+ * @param[in] value value of all constructed elements.
+ *
+ * @throw rethrows constructor exception.
+ *
+ * @pre pmemobj_tx_stage() == TX_STAGE_WORK
+ * @pre if initialized, range [end(), end() + count) must be snapshotted in
+ * current transaction
+ * @pre _capacity >= count + _size
+ * @pre value is valid argument for value_type copy constructor
+ *
+ * @post _size = _size + count
+ */
+template <typename T>
+void
+vector<T>::_grow(size_type count, const_reference value)
+{
+	assert(pmemobj_tx_stage() == TX_STAGE_WORK);
+	assert(_capacity >= count + _size);
+
+	pointer dest = _data.get() + static_cast<size_type>(_size);
+	const_pointer end = dest + count;
+	for (; dest != end; ++dest)
+		detail::create<value_type, const_reference>(dest, value);
+	_size += count;
+}
+
+/**
+ * Private helper function. Must be called during transaction. Assumes that
+ * there is enough space for additional elements and input arguments satisfy
+ * InputIterator requirements. Constructs elements in underlying array with the
+ * contents of the range [first, last). The first and last arguments must
+ * satisfy InputIterator requirements. This overload participates in overload
+ * resolution only if InputIt satisfies InputIterator.
+ *
+ * @param[in] first first iterator.
+ * @param[in] last last iterator.
+ *
+ * @throw rethrows constructor exception.
+ *
+ * @pre pmemobj_tx_stage() == TX_STAGE_WORK
+ * @pre if initialized, range [end(), end() + std::distance(first, last)) must
+ * be snapshotted in current transaction
+ * @pre _capacity >= std::distance(first, last) + _size
+ * @pre InputIt is InputIterator
+ * @pre InputIt::reference is valid argument for value_type copy constructor
+ *
+ * @post _size = _size + std::distance(first, last)
+ */
+template <typename T>
+template <typename InputIt,
+	  typename std::enable_if<
+		  detail::is_input_iterator<InputIt>::value &&
+			  std::is_constructible<
+				  T,
+				  typename std::iterator_traits<
+					  InputIt>::reference>::value,
+		  InputIt>::type *>
+void
+vector<T>::_grow(InputIt first, InputIt last)
+{
+	assert(pmemobj_tx_stage() == TX_STAGE_WORK);
+	difference_type diff = std::distance(first, last);
+	assert(diff >= 0);
+	assert(_capacity >= static_cast<size_type>(diff) + _size);
+
+	pointer dest = _data.get() + static_cast<size_type>(_size);
+	_size += static_cast<size_type>(diff);
+	while (first != last)
+		detail::create<value_type>(dest++, *first++);
+}
+
+/**
+ * Private helper function. Must be called during transaction. Destroys
+ * elements in underlying array beginning from position size_new.
+ *
+ * @param[in] size_new new size
+ *
+ * @pre pmemobj_tx_stage() == TX_STAGE_WORK
+ * @pre if initialized, range [begin(), end()) must be snapshotted in current
+ * transaction
+ * @pre size_new <= _size
+ *
+ * @post _size = size_new
+ */
+template <typename T>
+void
+vector<T>::_shrink(size_type size_new) noexcept
+{
+	assert(pmemobj_tx_stage() == TX_STAGE_WORK);
+	assert(size_new <= _size);
+
+	for (size_type i = size_new; i < _size; ++i)
+		// XXX: to remove static_cast when sign-detection in
+		// persistent_ptr will be available
+		detail::destroy<value_type>(
+			_data[static_cast<difference_type>(i)]);
+	_size = size_new;
+}
+
+} /* namespace experimental */
+
+} /* namespace obj */
+
+} /* namespace pmem */
+
+#endif /* LIBPMEMOBJ_CPP_VECTOR_HPP */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -254,4 +254,18 @@ else()
 	message(WARNING "Skipping pmreorder tests because of no pmreorder support")
 endif()
 
+build_test(vector_private vector_private/vector_private.cpp)
+add_test_generic(vector_private none)
+add_test_generic(vector_private memcheck)
+add_test_generic(vector_private pmemcheck)
+
+build_test(vector_ctor_default_nopmem vector_ctor_default_nopmem/vector_ctor_default_nopmem.cpp)
+add_test_generic(vector_ctor_default_nopmem none)
+add_test_generic(vector_ctor_default_nopmem memcheck)
+add_test_generic(vector_ctor_default_nopmem pmemcheck)
+
+build_test(vector_ctor_default_notx vector_ctor_default_notx/vector_ctor_default_notx.cpp)
+add_test_generic(vector_ctor_default_notx none)
+add_test_generic(vector_ctor_default_notx memcheck)
+
 add_subdirectory(external)

--- a/tests/external/CMakeLists.txt
+++ b/tests/external/CMakeLists.txt
@@ -142,3 +142,8 @@ build_test(array_get libcxx/array/array.tuple/get.pass.cpp)
 add_test_default(array_get none)
 
 add_test_expect_failure(array_get libcxx/array/array.tuple/get.fail.cpp)
+
+build_test(vector_libcxx_ctor_default libcxx/vector/vector.cons/construct_default.pass.cpp)
+add_test_default(vector_libcxx_ctor_default none)
+add_test_default(vector_libcxx_ctor_default pmemcheck)
+add_test_default(vector_libcxx_ctor_default memcheck)

--- a/tests/external/libcxx/vector/vector.cons/construct_default.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/construct_default.pass.cpp
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+ // <vector>
+ // vector();
+// vector(const Alloc&);
+ #include <vector>
+#include <cassert>
+ #include "test_macros.h"
+#include "test_allocator.h"
+#include "../../../NotConstructible.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+ template <class C>
+void
+test0()
+{
+#if TEST_STD_VER > 14
+    static_assert((noexcept(C{})), "" );
+#elif TEST_STD_VER >= 11
+    static_assert((noexcept(C()) == noexcept(typename C::allocator_type())), "" );
+#endif
+    C c;
+    LIBCPP_ASSERT(c.__invariants());
+    assert(c.empty());
+    assert(c.get_allocator() == typename C::allocator_type());
+    LIBCPP_ASSERT(is_contiguous_container_asan_correct(c));
+#if TEST_STD_VER >= 11
+    C c1 = {};
+    LIBCPP_ASSERT(c1.__invariants());
+    assert(c1.empty());
+    assert(c1.get_allocator() == typename C::allocator_type());
+    LIBCPP_ASSERT(is_contiguous_container_asan_correct(c1));
+#endif
+}
+ template <class C>
+void
+test1(const typename C::allocator_type& a)
+{
+#if TEST_STD_VER > 14
+    static_assert((noexcept(C{typename C::allocator_type{}})), "" );
+#elif TEST_STD_VER >= 11
+    static_assert((noexcept(C(typename C::allocator_type())) == std::is_nothrow_copy_constructible<typename C::allocator_type>::value), "" );
+#endif
+    C c(a);
+    LIBCPP_ASSERT(c.__invariants());
+    assert(c.empty());
+    assert(c.get_allocator() == a);
+    LIBCPP_ASSERT(is_contiguous_container_asan_correct(c));
+}
+ int main()
+{
+    {
+    test0<std::vector<int> >();
+    test0<std::vector<NotConstructible> >();
+    test1<std::vector<int, test_allocator<int> > >(test_allocator<int>(3));
+    test1<std::vector<NotConstructible, test_allocator<NotConstructible> > >
+        (test_allocator<NotConstructible>(5));
+    }
+    {
+        std::vector<int, limited_allocator<int, 10> > v;
+        assert(v.empty());
+    }
+#if TEST_STD_VER >= 11
+    {
+    test0<std::vector<int, min_allocator<int>> >();
+    test0<std::vector<NotConstructible, min_allocator<NotConstructible>> >();
+    test1<std::vector<int, min_allocator<int> > >(min_allocator<int>{});
+    test1<std::vector<NotConstructible, min_allocator<NotConstructible> > >
+        (min_allocator<NotConstructible>{});
+    }
+    {
+        std::vector<int, min_allocator<int> > v;
+        assert(v.empty());
+    }
+     {
+    test0<std::vector<int, explicit_allocator<int>> >();
+    test0<std::vector<NotConstructible, explicit_allocator<NotConstructible>> >();
+    test1<std::vector<int, explicit_allocator<int> > >(explicit_allocator<int>{});
+    test1<std::vector<NotConstructible, explicit_allocator<NotConstructible> > >
+        (explicit_allocator<NotConstructible>{});
+    }
+    {
+        std::vector<int, explicit_allocator<int> > v;
+        assert(v.empty());
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.cons/construct_default.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/construct_default.pass.cpp
@@ -6,89 +6,78 @@
 // Source Licenses. See LICENSE.TXT for details.
 //
 //===----------------------------------------------------------------------===//
- // <vector>
- // vector();
-// vector(const Alloc&);
- #include <vector>
-#include <cassert>
- #include "test_macros.h"
-#include "test_allocator.h"
-#include "../../../NotConstructible.h"
-#include "test_allocator.h"
-#include "min_allocator.h"
-#include "asan_testing.h"
- template <class C>
+//
+// Copyright 2018, Intel Corporation
+//
+// Modified to test pmem::obj containers
+//
+
+#include "unittest.hpp"
+
+#include <libpmemobj++/detail/common.hpp>
+#include <libpmemobj++/detail/life.hpp>
+#include <libpmemobj++/experimental/vector.hpp>
+#include <libpmemobj++/make_persistent.hpp>
+#include <libpmemobj++/pool.hpp>
+#include <libpmemobj++/transaction.hpp>
+
+#include <cstring>
+
+namespace nvobj = pmem::obj;
+namespace pmem_exp = nvobj::experimental;
+using vector_type = pmem_exp::vector<int>;
+
+struct foo {
+	vector_type v_1;
+	vector_type v_2 = {};
+};
+
+struct root {
+	nvobj::persistent_ptr<vector_type> v_pptr;
+	nvobj::persistent_ptr<foo> foo_pptr;
+};
+
+/**
+ * Test pmem::obj::experimental::vector default constructor.
+ *
+ * First case: call default constructor in three different ways and check if
+ * new container is empty. Expect no exception is thrown.
+ */
 void
-test0()
+test_default_ctor(nvobj::pool<struct root> &pop)
 {
-#if TEST_STD_VER > 14
-    static_assert((noexcept(C{})), "" );
-#elif TEST_STD_VER >= 11
-    static_assert((noexcept(C()) == noexcept(typename C::allocator_type())), "" );
-#endif
-    C c;
-    LIBCPP_ASSERT(c.__invariants());
-    assert(c.empty());
-    assert(c.get_allocator() == typename C::allocator_type());
-    LIBCPP_ASSERT(is_contiguous_container_asan_correct(c));
-#if TEST_STD_VER >= 11
-    C c1 = {};
-    LIBCPP_ASSERT(c1.__invariants());
-    assert(c1.empty());
-    assert(c1.get_allocator() == typename C::allocator_type());
-    LIBCPP_ASSERT(is_contiguous_container_asan_correct(c1));
-#endif
+	auto r = pop.root();
+	try {
+		nvobj::transaction::run(pop, [&] {
+			r->v_pptr = nvobj::make_persistent<vector_type>();
+			r->foo_pptr = nvobj::make_persistent<foo>();
+		});
+		UT_ASSERT(r->v_pptr->empty() == 1);
+		UT_ASSERT(r->foo_pptr->v_1.empty() == 1);
+		UT_ASSERT(r->foo_pptr->v_2.empty() == 1);
+	} catch (std::exception &e) {
+		std::cerr << e.what() << std::endl
+			  << std::strerror(nvobj::transaction::error())
+			  << std::endl;
+		UT_ASSERT(0);
+	}
 }
- template <class C>
-void
-test1(const typename C::allocator_type& a)
+
+int
+main(int argc, char *argv[])
 {
-#if TEST_STD_VER > 14
-    static_assert((noexcept(C{typename C::allocator_type{}})), "" );
-#elif TEST_STD_VER >= 11
-    static_assert((noexcept(C(typename C::allocator_type())) == std::is_nothrow_copy_constructible<typename C::allocator_type>::value), "" );
-#endif
-    C c(a);
-    LIBCPP_ASSERT(c.__invariants());
-    assert(c.empty());
-    assert(c.get_allocator() == a);
-    LIBCPP_ASSERT(is_contiguous_container_asan_correct(c));
-}
- int main()
-{
-    {
-    test0<std::vector<int> >();
-    test0<std::vector<NotConstructible> >();
-    test1<std::vector<int, test_allocator<int> > >(test_allocator<int>(3));
-    test1<std::vector<NotConstructible, test_allocator<NotConstructible> > >
-        (test_allocator<NotConstructible>(5));
-    }
-    {
-        std::vector<int, limited_allocator<int, 10> > v;
-        assert(v.empty());
-    }
-#if TEST_STD_VER >= 11
-    {
-    test0<std::vector<int, min_allocator<int>> >();
-    test0<std::vector<NotConstructible, min_allocator<NotConstructible>> >();
-    test1<std::vector<int, min_allocator<int> > >(min_allocator<int>{});
-    test1<std::vector<NotConstructible, min_allocator<NotConstructible> > >
-        (min_allocator<NotConstructible>{});
-    }
-    {
-        std::vector<int, min_allocator<int> > v;
-        assert(v.empty());
-    }
-     {
-    test0<std::vector<int, explicit_allocator<int>> >();
-    test0<std::vector<NotConstructible, explicit_allocator<NotConstructible>> >();
-    test1<std::vector<int, explicit_allocator<int> > >(explicit_allocator<int>{});
-    test1<std::vector<NotConstructible, explicit_allocator<NotConstructible> > >
-        (explicit_allocator<NotConstructible>{});
-    }
-    {
-        std::vector<int, explicit_allocator<int> > v;
-        assert(v.empty());
-    }
-#endif
+	START();
+	if (argc < 2) {
+		std::cerr << "usage: " << argv[0] << " file-name" << std::endl;
+		return 1;
+	}
+	auto path = argv[1];
+	auto pop = nvobj::pool<root>::create(
+		path, "VectorTest: construct_default.pass", PMEMOBJ_MIN_POOL,
+		S_IWUSR | S_IRUSR);
+	test_default_ctor(pop);
+
+	pop.close();
+
+	return 0;
 }

--- a/tests/vector_ctor_default_nopmem/vector_ctor_default_nopmem.cpp
+++ b/tests/vector_ctor_default_nopmem/vector_ctor_default_nopmem.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "unittest.hpp"
+
+#include <libpmemobj++/experimental/vector.hpp>
+#include <libpmemobj++/pool.hpp>
+
+#include <cstring>
+
+namespace nvobj = pmem::obj;
+namespace pmem_exp = nvobj::experimental;
+using vector_type = pmem_exp::vector<int>;
+
+/**
+ * Test pmem::obj::experimental::vector default constructor.
+ *
+ * Call default constructor for volatile instance of
+ * pmem::obj::experimental::vector. Expect pmem::pool_error exception is thrown.
+ */
+void
+test_default_ctor()
+{
+	bool exception_thrown = false;
+	try {
+		vector_type v_3 = {};
+		(void)v_3;
+	} catch (pmem::pool_error &) {
+		exception_thrown = true;
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+	UT_ASSERT(exception_thrown);
+}
+
+int
+main(int argc, char *argv[])
+{
+	START();
+	if (argc < 2) {
+		std::cerr << "usage: " << argv[0] << " file-name" << std::endl;
+		return 1;
+	}
+
+	test_default_ctor();
+
+	return 0;
+}

--- a/tests/vector_ctor_default_nopmem/vector_ctor_default_nopmem_0.cmake
+++ b/tests/vector_ctor_default_nopmem/vector_ctor_default_nopmem_0.cmake
@@ -1,0 +1,38 @@
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+include(${SRC_DIR}/../helpers.cmake)
+
+setup()
+
+execute(${TEST_EXECUTABLE} ${DIR}/testfile)
+
+finish()

--- a/tests/vector_ctor_default_notx/vector_ctor_default_notx.cpp
+++ b/tests/vector_ctor_default_notx/vector_ctor_default_notx.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "unittest.hpp"
+
+#include <libpmemobj++/detail/common.hpp>
+#include <libpmemobj++/detail/life.hpp>
+#include <libpmemobj++/experimental/vector.hpp>
+#include <libpmemobj++/make_persistent.hpp>
+#include <libpmemobj++/pool.hpp>
+#include <libpmemobj++/transaction.hpp>
+
+#include <cstring>
+
+namespace nvobj = pmem::obj;
+namespace pmem_exp = nvobj::experimental;
+using vector_type = pmem_exp::vector<int>;
+
+/**
+ * Test pmem::obj::experimental::vector default constructor.
+ *
+ * Call default constructor out of transaction scope. Expect
+ * pmem:transaction_error exception is thrown.
+ */
+void
+test_default_ctor(nvobj::pool<struct root> &pop)
+{
+	bool exception_thrown = false;
+	try {
+		nvobj::persistent_ptr<vector_type> pptr_v = nullptr;
+		nvobj::transaction::run(pop, [&] {
+			pptr_v = pmemobj_tx_alloc(
+				sizeof(vector_type),
+				pmem::detail::type_num<vector_type>());
+			if (pptr_v == nullptr)
+				UT_ASSERT(0);
+		});
+		pmem::detail::create<vector_type>(&*pptr_v);
+	} catch (pmem::transaction_error &) {
+		exception_thrown = true;
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+	UT_ASSERT(exception_thrown);
+}
+
+int
+main(int argc, char *argv[])
+{
+	START();
+	if (argc < 2) {
+		std::cerr << "usage: " << argv[0] << " file-name" << std::endl;
+		return 1;
+	}
+	auto path = argv[1];
+	auto pop = nvobj::pool<root>::create(
+		path, "VectorTest: vector_ctor_default", PMEMOBJ_MIN_POOL,
+		S_IWUSR | S_IRUSR);
+
+	test_default_ctor(pop);
+
+	pop.close();
+
+	return 0;
+}

--- a/tests/vector_ctor_default_notx/vector_ctor_default_notx_0.cmake
+++ b/tests/vector_ctor_default_notx/vector_ctor_default_notx_0.cmake
@@ -1,0 +1,38 @@
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+include(${SRC_DIR}/../helpers.cmake)
+
+setup()
+
+execute(${TEST_EXECUTABLE} ${DIR}/testfile)
+
+finish()

--- a/tests/vector_private/vector_private.cpp
+++ b/tests/vector_private/vector_private.cpp
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "unittest.hpp"
+
+#include <libpmemobj++/detail/common.hpp>
+#include <libpmemobj++/make_persistent.hpp>
+#include <libpmemobj++/make_persistent_atomic.hpp>
+#include <libpmemobj++/pool.hpp>
+#include <libpmemobj++/transaction.hpp>
+
+#include <cstring>
+#include <vector>
+
+/**
+ * We are testing private methods, with precondition of snapshotted initialized
+ * memory area. For unitialized memory area, we have to use Valgrind annotations
+ * and let pmemcheck know that this area is added to transaction and is flushed.
+ */
+#ifdef LIBPMEMOBJ_CPP_PMEMCHECK_INSTRUMENTATION
+#include <pmemcheck.h>
+#endif
+
+/**
+ * Ugly way to test private methods, but safe since vector is header-only
+ * container
+ */
+#define private public
+#include <libpmemobj++/experimental/vector.hpp>
+
+namespace nvobj = pmem::obj;
+namespace pmem_exp = pmem::obj::experimental;
+namespace test = test_support;
+
+#define TEST_CAPACITY 666
+#define TEST_SIZE_1 66
+#define TEST_VAL_1 6
+#define TEST_SIZE_2 33
+#define TEST_VAL_2 3
+
+struct root {
+	nvobj::persistent_ptr<pmem_exp::vector<int>> v_pptr;
+};
+
+/**
+ * Test _alloc pmem::obj::experimental::vector private function.
+ *
+ * First case: allocate memory for TEST_CAPACITY elements of given type (int),
+ * check if _capacity had changed. Expect no exception is thrown.
+ *
+ * Second case: allocate memory for more than max_size() elements of given type
+ * (int), expect std::length_error exception is thrown.
+ */
+void
+test_vector_private_alloc(nvobj::pool<struct root> &pop)
+{
+	auto r = pop.root();
+	/* first case */
+	try {
+		nvobj::transaction::run(pop, [&] {
+			r->v_pptr =
+				nvobj::make_persistent<pmem_exp::vector<int>>();
+			r->v_pptr->_alloc(TEST_CAPACITY);
+		});
+		UT_ASSERT(r->v_pptr->_capacity == TEST_CAPACITY);
+		nvobj::delete_persistent_atomic<pmem_exp::vector<int>>(
+			r->v_pptr);
+	} catch (std::exception &e) {
+		std::cerr << e.what() << std::endl
+			  << std::strerror(nvobj::transaction::error())
+			  << std::endl;
+		UT_ASSERT(0);
+	}
+
+	/* second case */
+	bool exception_thrown = false;
+	try {
+		nvobj::transaction::run(pop, [&] {
+			r->v_pptr =
+				nvobj::make_persistent<pmem_exp::vector<int>>();
+			r->v_pptr->_alloc(r->v_pptr->max_size() + 1);
+		});
+	} catch (std::length_error &) {
+		exception_thrown = true;
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+	UT_ASSERT(exception_thrown);
+}
+
+/**
+ * Test _dealloc pmem::obj::experimental::vector private function.
+ *
+ * Allocate memory for TEST_CAPACITY elements of given type (int)
+ * and call _dealloc. Expect _capacity changed to 0 and no exception is thrown.
+ */
+void
+test_vector_private_dealloc(nvobj::pool<struct root> &pop) try {
+	auto r = pop.root();
+	nvobj::transaction::run(pop, [&] {
+		r->v_pptr = nvobj::make_persistent<pmem_exp::vector<int>>();
+		r->v_pptr->_alloc(TEST_CAPACITY);
+		UT_ASSERT(r->v_pptr->_data != nullptr);
+		r->v_pptr->_dealloc();
+	});
+	UT_ASSERT(r->v_pptr->_capacity == 0);
+	nvobj::delete_persistent_atomic<pmem_exp::vector<int>>(r->v_pptr);
+} catch (std::exception &e) {
+	std::cerr << e.what() << std::endl
+		  << std::strerror(nvobj::transaction::error()) << std::endl;
+	UT_ASSERT(0);
+}
+
+/**
+ * Test _grow pmem::obj::experimental::vector private function.
+ *
+ * First case: allocate memory for TEST_CAPACITY elements of given type (int)
+ * and call _grow overload for count-value arguments. Check if first
+ * TEST_SIZE_1 elements in underlying array was constructed with TEST_VAL_1
+ * value.
+ *
+ * Second case: using allocated memory in previous test case, construct
+ * additional TEST_SIZE_2 at the end of underlying array. Note that _grow
+ * function requires that memory for elements to be created must be snapshotted.
+ * Since this memory area is uninitialized yet, we must use Valgrind annotations
+ * and mark this area as added to transactions and flushed. Compare values in
+ * underlying array with expected values.
+ *
+ * Third case: using allocated memory in previous test case call _grow overload
+ * for InputIterator-InputIterator arguments. Check if first TEST_SIZE_1
+ * elements in underlying array was constructed with values pointed by
+ * argument's iterators.
+ *
+ * Fourth case: using allocated memory in previous test case, construct
+ * additional TEST_SIZE_2 at the end of underlying array by calling _grow
+ * overload for InputIterator-InputIterator arguments. Note that _grow function
+ * requires that memory for elements to be created must be snapshotted. Since
+ * this memory area is uninitialized yet, we must use Valgrind annotations and
+ * mark this area as added to transaction and flushed. Compare values in
+ * underlying array with expected values.
+ */
+void
+test_vector_grow(nvobj::pool<struct root> &pop) try {
+	auto r = pop.root();
+	/* first case */
+	nvobj::transaction::run(pop, [&] {
+		r->v_pptr = nvobj::make_persistent<pmem_exp::vector<int>>();
+		r->v_pptr->_alloc(TEST_CAPACITY);
+		UT_ASSERT(r->v_pptr->_data != nullptr);
+		UT_ASSERT(r->v_pptr->_capacity == TEST_CAPACITY);
+		r->v_pptr->_grow(TEST_SIZE_1, TEST_VAL_1);
+	});
+	UT_ASSERT(r->v_pptr->_size == TEST_SIZE_1);
+	auto ptr = r->v_pptr->_data.get();
+	for (unsigned i = 0; i < TEST_SIZE_1; ++i)
+		UT_ASSERT(*ptr++ == TEST_VAL_1);
+
+	/* second case */
+	nvobj::transaction::run(pop, [&] {
+		UT_ASSERT(r->v_pptr->_capacity >=
+			  r->v_pptr->_size + TEST_SIZE_2);
+#ifdef LIBPMEMOBJ_CPP_PMEMCHECK_INSTRUMENTATION
+		auto *addr = r->v_pptr->_data.get() +
+			static_cast<std::size_t>(r->v_pptr->_size);
+		auto sz = sizeof(*addr) * TEST_SIZE_2;
+		VALGRIND_PMC_ADD_TO_TX(addr, sz);
+#endif
+		r->v_pptr->_grow(TEST_SIZE_2, TEST_VAL_2);
+#ifdef LIBPMEMOBJ_CPP_PMEMCHECK_INSTRUMENTATION
+		VALGRIND_PMC_SET_CLEAN(addr, sz);
+		VALGRIND_PMC_REMOVE_FROM_TX(addr, sz);
+#endif
+	});
+	UT_ASSERT(r->v_pptr->_size == TEST_SIZE_1 + TEST_SIZE_2);
+
+	ptr = r->v_pptr->_data.get();
+	unsigned j = 0;
+	for (; j < TEST_SIZE_1; ++j)
+		UT_ASSERT(*ptr++ == TEST_VAL_1);
+	for (; j < TEST_SIZE_2; ++j)
+		UT_ASSERT(*ptr++ == TEST_VAL_2);
+
+	nvobj::transaction::run(pop, [&] {
+		r->v_pptr->_dealloc();
+		nvobj::delete_persistent<pmem_exp::vector<int>>(r->v_pptr);
+	});
+
+	/* third case */
+	std::vector<int> v(TEST_SIZE_1, TEST_VAL_1);
+	v.insert(v.end(), TEST_SIZE_2, TEST_VAL_2);
+	auto first = test::input_it<int>(v.data());
+	auto middle = test::input_it<int>(v.data() + TEST_SIZE_1);
+	auto last = test::input_it<int>(v.data() + v.size());
+	nvobj::transaction::run(pop, [&] {
+		r->v_pptr = nvobj::make_persistent<pmem_exp::vector<int>>();
+		r->v_pptr->_alloc(TEST_CAPACITY);
+		UT_ASSERT(r->v_pptr->_data != nullptr);
+		UT_ASSERT(r->v_pptr->_capacity == TEST_CAPACITY);
+		r->v_pptr->_grow(first, middle);
+	});
+	UT_ASSERT(r->v_pptr->_size == TEST_SIZE_1);
+	ptr = r->v_pptr->_data.get();
+	for (unsigned i = 0; i < TEST_SIZE_1; ++i)
+		UT_ASSERT(*ptr++ == v[i]);
+
+	/* fourth case */
+	nvobj::transaction::run(pop, [&] {
+		UT_ASSERT(r->v_pptr->_capacity >=
+			  r->v_pptr->_size + TEST_SIZE_2);
+#ifdef LIBPMEMOBJ_CPP_PMEMCHECK_INSTRUMENTATION
+		auto *addr = r->v_pptr->_data.get() +
+			static_cast<std::size_t>(r->v_pptr->_size);
+		auto sz = sizeof(*addr) * TEST_SIZE_2;
+		VALGRIND_PMC_ADD_TO_TX(addr, sz);
+#endif
+		r->v_pptr->_grow(middle, last);
+#ifdef LIBPMEMOBJ_CPP_PMEMCHECK_INSTRUMENTATION
+		VALGRIND_PMC_SET_CLEAN(addr, sz);
+		VALGRIND_PMC_REMOVE_FROM_TX(addr, sz);
+#endif
+	});
+	UT_ASSERT(r->v_pptr->_size == TEST_SIZE_1 + TEST_SIZE_2);
+
+	ptr = r->v_pptr->_data.get();
+	j = 0;
+	for (; j < TEST_SIZE_1; ++j)
+		UT_ASSERT(*ptr++ == v[j]);
+	for (; j < TEST_SIZE_2; ++j)
+		UT_ASSERT(*ptr++ == v[j]);
+
+	nvobj::transaction::run(pop, [&] {
+		r->v_pptr->_dealloc();
+		nvobj::delete_persistent<pmem_exp::vector<int>>(r->v_pptr);
+	});
+
+} catch (std::exception &e) {
+	std::cerr << e.what() << std::endl
+		  << std::strerror(nvobj::transaction::error()) << std::endl;
+	UT_ASSERT(0);
+}
+
+/**
+ * Test _shrink pmem::obj::experimental::vector private function.
+ *
+ * Allocate memory for TEST_CAPACITY elements of given type (int)
+ * and fill it with TEST_VAL_1 value. Call _shrink with TEST_SIZE_1
+ * argument and compare values in underlying array with expected results.
+ */
+void
+test_vector_shrink(nvobj::pool<struct root> &pop) try {
+	auto r = pop.root();
+	nvobj::transaction::run(pop, [&] {
+		r->v_pptr = nvobj::make_persistent<pmem_exp::vector<int>>();
+		r->v_pptr->_alloc(TEST_CAPACITY);
+		UT_ASSERT(r->v_pptr->_data != nullptr);
+		r->v_pptr->_grow(TEST_CAPACITY, TEST_VAL_1);
+		r->v_pptr->_shrink(TEST_SIZE_1);
+	});
+	UT_ASSERT(r->v_pptr->_size == TEST_SIZE_1);
+	auto ptr = r->v_pptr->_data.get();
+	unsigned j = 0;
+	for (; j < TEST_SIZE_1; ++j)
+		UT_ASSERT(*ptr++ == TEST_VAL_1);
+	for (; j < TEST_VAL_1; ++j)
+		UT_ASSERT(*ptr++ == 0);
+
+	nvobj::transaction::run(pop, [&] {
+		r->v_pptr->_dealloc();
+		nvobj::delete_persistent<pmem_exp::vector<int>>(r->v_pptr);
+	});
+
+} catch (std::exception &e) {
+	std::cerr << e.what() << std::endl
+		  << std::strerror(nvobj::transaction::error()) << std::endl;
+	UT_ASSERT(0);
+}
+
+int
+main(int argc, char *argv[])
+{
+	START();
+	if (argc < 2) {
+		std::cerr << "usage: " << argv[0] << " file-name" << std::endl;
+		return 1;
+	}
+	auto path = argv[1];
+	auto pop =
+		nvobj::pool<root>::create(path, "VectorTest: vector_private",
+					  PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR);
+
+	test_vector_private_alloc(pop);
+	test_vector_private_dealloc(pop);
+	test_vector_grow(pop);
+	test_vector_shrink(pop);
+
+	pop.close();
+
+	return 0;
+}

--- a/tests/vector_private/vector_private_0.cmake
+++ b/tests/vector_private/vector_private_0.cmake
@@ -1,0 +1,38 @@
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+include(${SRC_DIR}/../helpers.cmake)
+
+setup()
+
+execute(${TEST_EXECUTABLE} ${DIR}/testfile)
+
+finish()


### PR DESCRIPTION
- add pmem::obj::experimental::vector container skeleton with private methods, default ctor, empty() and max_size() methods
- add libcxx default ctor test
- port provided libcxx tests to pmem::obj::experimental::vector usage
- add private methods tests

this pull request requires following pull request to be merged:
https://github.com/pmem/libpmemobj-cpp/pull/104
https://github.com/pmem/libpmemobj-cpp/pull/95

edit:
we need support of Valgrind annotations before we can finish implementation of vector skeleton:
https://github.com/pmem/libpmemobj-cpp/pull/116

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/107)
<!-- Reviewable:end -->
