### PR TITLE
Fix typo in pmem::obj::array method description

### DIFF
--- a/include/libpmemobj++/experimental/array.hpp
+++ b/include/libpmemobj++/experimental/array.hpp
@@ -488,7 +488,7 @@ struct array {
 	}
 
 	/**
-	 * Checks wheter array is empty.
+	 * Checks whether array is empty.
 	 */
 	constexpr bool
 	empty() const noexcept


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/114)
<!-- Reviewable:end -->
