### PR TITLE
tests: change initialization of slice

### DIFF
--- a/tests/array_slice/array_slice.cpp
+++ b/tests/array_slice/array_slice.cpp
@@ -112,7 +112,7 @@ struct TestSuccess {
 		}
 
 		try {
-			pmemobj_exp::slice<char *> bad_slice(data, data - 1);
+			pmemobj_exp::slice<char *> bad_slice(data + 1, data);
 			UT_ASSERT(0);
 		} catch (...) {
 		}


### PR DESCRIPTION
some compilers give array-subscript error when pointer to array is
decremented by 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/139)
<!-- Reviewable:end -->
