### PR TITLE
check for brace initialization in new expression for specific classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,10 +263,30 @@ if(NOT MSVC_VERSION)
 			return 0;
 		}"
 		NO_GCC_AGGREGATE_INITIALIZATION_BUG)
+
+	# Check for issues related to agregate initialization in new expression.
+	# Following code will fail for LLVM compiler https://bugs.llvm.org/show_bug.cgi?id=39988
+	set(CMAKE_REQUIRED_FLAGS "--std=c++11 -Wno-error")
+	CHECK_CXX_SOURCE_COMPILES(
+		"template<typename T>
+		struct A {
+			 A() {};
+			~A() {};
+		};
+		struct B {
+			A<int> a;
+			A<int> b;
+		};
+		int main() {
+			new B{};
+			return 0;
+		}"
+		NO_CLANG_BRACE_INITIALIZATION_NEWEXPR_BUG)
 	set(CMAKE_REQUIRED_FLAGS ${SAVED_CMAKE_REQUIRED_FLAGS})
 else()
 	set(NO_GCC_VARIADIC_TEMPLATE_BUG TRUE)
 	set(NO_GCC_AGGREGATE_INITIALIZATION_BUG TRUE)
+	set(NO_CLANG_BRACE_INITIALIZATION_NEWEXPR_BUG TRUE)
 endif()
 
 include_directories(include)

--- a/tests/external/libcxx/vector/vector.cons/construct_default.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/construct_default.pass.cpp
@@ -29,7 +29,9 @@ using vector_type = pmem_exp::vector<int>;
 
 struct foo {
 	vector_type v_1;
+#ifdef NO_CLANG_BRACE_INITIALIZATION_NEWEXPR_BUG
 	vector_type v_2 = {};
+#endif
 };
 
 struct root {
@@ -54,7 +56,9 @@ test_default_ctor(nvobj::pool<struct root> &pop)
 		});
 		UT_ASSERT(r->v_pptr->empty() == 1);
 		UT_ASSERT(r->foo_pptr->v_1.empty() == 1);
+#ifdef NO_CLANG_BRACE_INITIALIZATION_NEWEXPR_BUG
 		UT_ASSERT(r->foo_pptr->v_2.empty() == 1);
+#endif
 	} catch (std::exception &e) {
 		std::cerr << e.what() << std::endl
 			  << std::strerror(nvobj::transaction::error())


### PR DESCRIPTION
Brace initialization in new expression for specific classes fails to compile with clang++ =<7.0.0
One of vector tests will start failing soon after adding destructor to vector class.