### PR TITLE
vector: fix _alloc() error handling

### DIFF
--- a/tests/vector_private/vector_private.cpp
+++ b/tests/vector_private/vector_private.cpp
@@ -109,6 +109,7 @@ test_vector_private_alloc(nvobj::pool<struct root> &pop)
 				nvobj::make_persistent<pmem_exp::vector<int>>();
 			r->v_pptr->_alloc(r->v_pptr->max_size() + 1);
 		});
+		UT_ASSERT(0);
 	} catch (std::length_error &) {
 		exception_thrown = true;
 	} catch (...) {


### PR DESCRIPTION
We need to cache pmemobj_tx_alloc return value and only after that assign it to _data, because when pmemobj_tx_alloc fails, it aborts transaction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/144)
<!-- Reviewable:end -->
