### PR TITLE
Modify pmem::obj::array and iterators to unconditionally snapshot data.

### DIFF
--- a/include/libpmemobj++/detail/common.hpp
+++ b/include/libpmemobj++/detail/common.hpp
@@ -91,6 +91,30 @@ conditional_add_to_tx(const T *that, std::size_t count = 1)
 			"Could not add object(s) to the transaction.");
 }
 
+/**
+ * Takes snapshot of `count` objects.
+ *
+ * Snapshots count objects starting from `that` to the transaction.
+ * `that` must point to pmem and there must be an active transaction.
+ *
+ * @param[in] that pointer to the first object being snapshotted.
+ * @param[in] count number of elements to be snapshotted.
+ */
+template <typename T>
+static void
+snapshot(const T *that, std::size_t count = 1)
+{
+	if (pmemobj_pool_by_ptr(that) == nullptr)
+		throw pool_error("Object is not on pmem");
+
+	if (pmemobj_tx_stage() != TX_STAGE_WORK)
+		throw transaction_error("Transaction is not active");
+
+	if (pmemobj_tx_add_range_direct(that, sizeof(*that) * count))
+		throw transaction_error(
+			"Could not add object(s) to the transaction.");
+}
+
 /*
  * Return type number for given type.
  */

--- a/include/libpmemobj++/experimental/array.hpp
+++ b/include/libpmemobj++/experimental/array.hpp
@@ -40,6 +40,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <initializer_list>
 
 #include <libpmemobj++/detail/common.hpp>
 #include <libpmemobj++/experimental/contiguous_iterator.hpp>
@@ -148,6 +149,54 @@ struct array {
 		detail::conditional_add_to_tx(this);
 
 		std::copy(other.cbegin(), other.cend(), _get_data());
+		return *this;
+	}
+
+	/**
+	 * Copy assignment operator which takes std::array - adds 'this'
+	 * to a transaction.
+	 *
+	 * @throw transaction_error when adding the object to the
+	 *		transaction failed.
+	 */
+	array &
+	operator=(const std::array<T, N> &other)
+	{
+		detail::conditional_add_to_tx(this);
+
+		std::copy(other.cbegin(), other.cend(), _get_data());
+		return *this;
+	}
+
+	/**
+	 * Move assignment operator which takes std::array - adds 'this'
+	 * to a transaction.
+	 *
+	 * @throw transaction_error when adding the object to the
+	 *		transaction failed.
+	 */
+	array &
+	operator=(std::array<T, N> &&other)
+	{
+		detail::conditional_add_to_tx(this);
+
+		std::copy(other.cbegin(), other.cend(), _get_data());
+		return *this;
+	}
+
+	/**
+	 * Move assignment operator which takes std::initializer_list - adds
+	 * 'this' to a transaction.
+	 *
+	 * @throw transaction_error when adding the object to the
+	 *		transaction failed.
+	 */
+	array &
+	operator=(std::initializer_list<T> other)
+	{
+		detail::conditional_add_to_tx(this);
+
+		std::copy(other.begin(), other.end(), _get_data());
 		return *this;
 	}
 
@@ -639,6 +688,128 @@ operator>=(const array<T, N> &lhs, const array<T, N> &rhs)
 template <typename T, std::size_t N>
 inline bool
 operator<=(const array<T, N> &lhs, const array<T, N> &rhs)
+{
+	return !(lhs > rhs);
+}
+
+/**
+ * Non-member equal operator.
+ */
+template <typename T, std::size_t N>
+inline bool
+operator==(const array<T, N> &lhs, const std::array<T, N> &rhs)
+{
+	return std::equal(lhs.cbegin(), lhs.cend(), rhs.cbegin());
+}
+
+/**
+ * Non-member not-equal operator.
+ */
+template <typename T, std::size_t N>
+inline bool
+operator!=(const array<T, N> &lhs, const std::array<T, N> &rhs)
+{
+	return !(lhs == rhs);
+}
+
+/**
+ * Non-member less than operator.
+ */
+template <typename T, std::size_t N>
+inline bool
+operator<(const array<T, N> &lhs, const std::array<T, N> &rhs)
+{
+	return std::lexicographical_compare(lhs.cbegin(), lhs.cend(),
+					    rhs.cbegin(), rhs.cend());
+}
+
+/**
+ * Non-member greater than operator.
+ */
+template <typename T, std::size_t N>
+inline bool
+operator>(const array<T, N> &lhs, const std::array<T, N> &rhs)
+{
+	return rhs < lhs;
+}
+
+/**
+ * Non-member greater or equal operator.
+ */
+template <typename T, std::size_t N>
+inline bool
+operator>=(const array<T, N> &lhs, const std::array<T, N> &rhs)
+{
+	return !(lhs < rhs);
+}
+
+/**
+ * Non-member less or equal operator.
+ */
+template <typename T, std::size_t N>
+inline bool
+operator<=(const array<T, N> &lhs, const std::array<T, N> &rhs)
+{
+	return !(lhs > rhs);
+}
+
+/**
+ * Non-member equal operator.
+ */
+template <typename T, std::size_t N>
+inline bool
+operator==(const std::array<T, N> &lhs, const array<T, N> &rhs)
+{
+	return std::equal(lhs.cbegin(), lhs.cend(), rhs.cbegin());
+}
+
+/**
+ * Non-member not-equal operator.
+ */
+template <typename T, std::size_t N>
+inline bool
+operator!=(const std::array<T, N> &lhs, const array<T, N> &rhs)
+{
+	return !(lhs == rhs);
+}
+
+/**
+ * Non-member less than operator.
+ */
+template <typename T, std::size_t N>
+inline bool
+operator<(const std::array<T, N> &lhs, const array<T, N> &rhs)
+{
+	return std::lexicographical_compare(lhs.cbegin(), lhs.cend(),
+					    rhs.cbegin(), rhs.cend());
+}
+
+/**
+ * Non-member greater than operator.
+ */
+template <typename T, std::size_t N>
+inline bool
+operator>(const std::array<T, N> &lhs, const array<T, N> &rhs)
+{
+	return rhs < lhs;
+}
+
+/**
+ * Non-member greater or equal operator.
+ */
+template <typename T, std::size_t N>
+inline bool
+operator>=(const std::array<T, N> &lhs, const array<T, N> &rhs)
+{
+	return !(lhs < rhs);
+}
+
+/**
+ * Non-member less or equal operator.
+ */
+template <typename T, std::size_t N>
+inline bool
+operator<=(const std::array<T, N> &lhs, const array<T, N> &rhs)
 {
 	return !(lhs > rhs);
 }

--- a/include/libpmemobj++/experimental/contiguous_iterator.hpp
+++ b/include/libpmemobj++/experimental/contiguous_iterator.hpp
@@ -43,6 +43,7 @@
 #include <functional>
 
 #include <libpmemobj++/detail/common.hpp>
+#include <libpmemobj++/transaction.hpp>
 
 namespace pmem
 {
@@ -183,6 +184,9 @@ struct contiguous_iterator {
 		return ptr[n];
 	}
 
+	/**
+	 * Returns underlying pointer.
+	 */
 	Pointer
 	get_ptr() const
 	{
@@ -289,6 +293,9 @@ struct operator_base {
  * If iterator is moved from 1 to 3, that means it is now in another
  * range, and that range must be added to a transaction
  * (elements 2 and 3).
+ *
+ * This iterator can be used only inside a transaction (both moving and
+ * dereferencing this iterator requires a transaction).
  */
 template <typename T>
 struct range_snapshotting_iterator
@@ -324,10 +331,16 @@ struct range_snapshotting_iterator
 	 * Element access operator.
 	 *
 	 * Adds element to a transaction.
+	 *
+	 * @pre must be called in transaction scope.
+	 *
+	 * @throw transaction_error when adding the object to the
+	 *		transaction failed.
+	 * @throw pool_error when object is not on pmem
 	 */
 	reference operator[](std::size_t n)
 	{
-		detail::conditional_add_to_tx(&this->ptr[n]);
+		detail::snapshot(&this->ptr[n]);
 		return base_type::operator[](n);
 	}
 
@@ -391,7 +404,7 @@ private:
 		verify_range(range_begin, range_size);
 #endif
 
-		detail::conditional_add_to_tx(range_begin, range_size);
+		detail::snapshot(range_begin, range_size);
 	}
 
 #ifndef NDEBUG
@@ -439,20 +452,32 @@ struct basic_contiguous_iterator
 	/**
 	 * Dereference operator which adds dereferenced element to
 	 * a transaction.
+	 *
+	 * @pre must be called in transaction scope.
+	 *
+	 * @throw transaction_error when adding the object to the
+	 *		transaction failed.
+	 * @throw pool_error when object is not on pmem
 	 */
 	reference operator*() const
 	{
-		detail::conditional_add_to_tx(this->ptr);
+		detail::snapshot(this->ptr);
 		return base_type::operator*();
 	}
 
 	/**
 	 * Arrow operator which adds underlying element to
 	 * a transactions.
+	 *
+	 * @pre must be called in transaction scope.
+	 *
+	 * @throw transaction_error when adding the object to the
+	 *		transaction failed.
+	 * @throw pool_error when object is not on pmem
 	 */
 	pointer operator->() const
 	{
-		detail::conditional_add_to_tx(this->ptr);
+		detail::snapshot(this->ptr);
 		return base_type::operator->();
 	}
 
@@ -460,10 +485,27 @@ struct basic_contiguous_iterator
 	 * Element access operator.
 	 *
 	 * Adds range containing specified element to a transaction.
+	 *
+	 * @pre must be called in transaction scope.
+	 *
+	 * @throw transaction_error when adding the object to the
+	 *		transaction failed.
+	 * @throw pool_error when object is not on pmem
 	 */
 	reference operator[](std::size_t n)
 	{
-		detail::conditional_add_to_tx(&this->ptr[n]);
+		detail::snapshot(&this->ptr[n]);
+		return base_type::operator[](n);
+	}
+
+	/**
+	 * Element access operator, which does NOT snapshot data.
+	 *
+	 * It can be used to access data outside of a transaction.
+	 */
+	reference
+	unsafe_at(std::size_t n = 0)
+	{
 		return base_type::operator[](n);
 	}
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -235,6 +235,13 @@ build_test(array_iterator array_iterator/array_iterator.cpp)
 add_test_generic(array_iterator none)
 add_test_generic(array_iterator pmemcheck)
 
+build_test(array_transactions array_transactions/array_transactions.cpp)
+add_test_generic(array_transactions none)
+add_test_generic(array_transactions pmemcheck)
+
+build_test(array_comparison array_comparison/array_comparison.cpp)
+add_test_generic(array_comparison none)
+
 build_test(iterator_traits iterator_traits/iterator_traits.cpp)
 add_test_generic(iterator_traits none)
 

--- a/tests/array_comparison/array_comparison.cpp
+++ b/tests/array_comparison/array_comparison.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "unittest.hpp"
+
+#include <algorithm>
+#include <array>
+#include <iterator>
+
+#include <libpmemobj++/experimental/array.hpp>
+#include <libpmemobj++/make_persistent.hpp>
+#include <libpmemobj++/pool.hpp>
+#include <libpmemobj++/transaction.hpp>
+
+namespace pmemobj_exp = pmem::obj::experimental;
+
+struct TestArray;
+
+struct root {
+	pmem::obj::persistent_ptr<TestArray> test;
+};
+
+struct TestArray {
+
+	/* Test array modifiers outside of a transaction */
+	void
+	test_comparison_with_std()
+	{
+		std::array<int, 5> std_array;
+
+		array.fill(1);
+		std_array.fill(2);
+
+		UT_ASSERT(array < std_array);
+		UT_ASSERT(array <= std_array);
+		UT_ASSERT(array != std_array);
+		UT_ASSERT(!(array == std_array));
+		UT_ASSERT(!(array > std_array));
+		UT_ASSERT(!(array >= std_array));
+
+		UT_ASSERT(std_array > array);
+		UT_ASSERT(std_array >= array);
+		UT_ASSERT(std_array != array);
+		UT_ASSERT(!(std_array == array));
+		UT_ASSERT(!(std_array < array));
+		UT_ASSERT(!(std_array <= array));
+	}
+
+	pmemobj_exp::array<int, 5> array;
+};
+
+void
+test_comparison(pmem::obj::pool<struct root> &pop)
+{
+	auto r = pop.root();
+
+	try {
+		pmem::obj::transaction::run(pop, [&] {
+			r->test = pmem::obj::make_persistent<TestArray>();
+		});
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+
+	try {
+		r->test->test_comparison_with_std();
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+}
+
+int
+main(int argc, char *argv[])
+{
+	START();
+
+	if (argc < 2) {
+		std::cerr << "usage: " << argv[0] << " file-name" << std::endl;
+		return 1;
+	}
+
+	auto path = argv[1];
+
+	auto pop = pmem::obj::pool<root>::create(
+		path, "ArrayTest", PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR);
+
+	test_comparison(pop);
+
+	pop.close();
+
+	return 0;
+}

--- a/tests/array_comparison/array_comparison_0.cmake
+++ b/tests/array_comparison/array_comparison_0.cmake
@@ -1,0 +1,38 @@
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+include(${SRC_DIR}/../helpers.cmake)
+
+setup()
+
+execute(${TEST_EXECUTABLE} ${DIR}/testfile)
+
+finish()

--- a/tests/array_transactions/array_transactions.cpp
+++ b/tests/array_transactions/array_transactions.cpp
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "unittest.hpp"
+
+#include <algorithm>
+#include <array>
+#include <iterator>
+
+#include <libpmemobj++/experimental/array.hpp>
+#include <libpmemobj++/make_persistent.hpp>
+#include <libpmemobj++/pool.hpp>
+#include <libpmemobj++/transaction.hpp>
+
+namespace pmemobj_exp = pmem::obj::experimental;
+
+struct TestArray;
+
+using array_type = pmemobj_exp::array<int, 5>;
+
+struct root {
+	pmem::obj::persistent_ptr<TestArray> test;
+	pmem::obj::persistent_ptr<array_type> arr;
+};
+
+void
+assert_array_equal(const array_type &lhs, const std::array<int, 5> &rhs)
+{
+	UT_ASSERT(lhs == rhs);
+}
+
+void
+assert_no_tx()
+{
+	UT_ASSERT(pmemobj_tx_stage() != TX_STAGE_WORK);
+}
+
+void
+assert_tx()
+{
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_WORK);
+}
+
+template <typename T>
+void
+assert_pmem(const T &ptr)
+{
+	UT_ASSERT(pmemobj_pool_by_ptr(&ptr) != nullptr);
+}
+
+template <typename T>
+void
+assert_no_pmem(const T &ptr)
+{
+	UT_ASSERT(pmemobj_pool_by_ptr(&ptr) == nullptr);
+}
+
+/*
+ * this function verifies that f() succeeds only inside a transaction and when
+ * obj is on pmem.
+ */
+template <typename T>
+void
+pmem_tx_only(const T &obj, std::function<void(void)> f)
+{
+	try {
+		f();
+
+		assert_tx();
+		assert_pmem(obj);
+	} catch (pmem::transaction_error &) {
+		assert_no_tx();
+	} catch (pmem::pool_error &) {
+		assert_no_pmem(obj);
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+}
+
+/*
+ * this function verifies that f() succeeds only when obj is on pmem.
+ */
+template <typename T>
+void
+pmem_only(const T &obj, std::function<void(void)> f)
+{
+	try {
+		f();
+
+		assert_pmem(obj);
+	} catch (pmem::pool_error &) {
+		assert_no_pmem(obj);
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+}
+
+struct TestArray {
+	array_type array;
+};
+
+void
+test_modifiers(pmem::obj::pool<struct root> &pop, array_type &array)
+{
+	auto r = pop.root();
+
+	try {
+		pmem::obj::transaction::run(pop, [&] {
+			r->arr = pmem::obj::make_persistent<array_type>();
+			r->arr->fill(1);
+		});
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+
+	std::array<int, 5> std_array = {{2, 2, 2, 2, 2}};
+
+	pmem_only(array, [&] {
+		array.fill(10);
+		assert_array_equal(array, {{10, 10, 10, 10, 10}});
+	});
+
+	pmem_only(array, [&] {
+		array.swap(*r->arr);
+		assert_array_equal(array, {{1, 1, 1, 1, 1}});
+		assert_array_equal(*r->arr, {{10, 10, 10, 10, 10}});
+	});
+
+	pmem_only(array, [&] {
+		array = *(r->arr);
+		assert_array_equal(array, {{10, 10, 10, 10, 10}});
+	});
+
+	pmem_only(array, [&] {
+		array = std_array;
+		assert_array_equal(array, {{2, 2, 2, 2, 2}});
+	});
+
+	pmem_only(array, [&] {
+		array = {1, 2, 3, 4, 5};
+		assert_array_equal(array, {{1, 2, 3, 4, 5}});
+	});
+
+	pmem_only(array, [&] {
+		array = std::move(*(r->arr));
+		assert_array_equal(array, {{10, 10, 10, 10, 10}});
+	});
+
+	pmem_only(array, [&] {
+		array = std::move(std_array);
+		assert_array_equal(array, {{2, 2, 2, 2, 2}});
+	});
+}
+
+/*
+ * Test if access operators of array and iterators behave correctly
+ * if run outside/inside tx and on/off pmem.
+ */
+void
+test_access_operators(pmem::obj::pool<struct root> &pop, array_type &array)
+{
+	pmem_tx_only(array, [&] { array[2] = 2; });
+
+	pmem_tx_only(array, [&] { array.at(2) = 2; });
+
+	pmem_tx_only(array, [&] { array.data()[2] = 2; });
+
+	pmem_tx_only(array, [&] { array.front() = 2; });
+
+	pmem_tx_only(array, [&] { array.back() = 2; });
+
+	pmem_tx_only(array, [&] {
+		auto slice = array.range(0, array.size());
+		(void)slice;
+	});
+
+	pmem_tx_only(array, [&] {
+		auto it = array.begin();
+		*it = 2;
+	});
+
+	pmem_tx_only(array, [&] {
+		auto it = array.end();
+		*it = 2;
+	});
+
+	pmem_tx_only(array, [&] {
+		auto it = array.rbegin();
+		*it = 2;
+	});
+
+	pmem_tx_only(array, [&] {
+		auto it = array.rend();
+		*it = 2;
+	});
+
+	try {
+		auto it = array.end();
+		auto it2 = array.begin();
+
+		it--;
+		it--;
+		it += 2;
+
+		it2++;
+		it2--;
+		it2 += 2;
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+}
+
+/* all of functions called here should not throw exception
+ * outside tx */
+void
+test_notx(array_type &array)
+{
+	auto const &const_array = array;
+
+	try {
+		(void)array.size();
+		(void)array.max_size();
+		(void)array.empty();
+		(void)array.cbegin();
+		(void)array.cend();
+		(void)array.crbegin();
+		(void)array.crend();
+		(void)array.unsafe_at(2);
+		(void)array.begin().unsafe_at(2);
+		(void)array.const_at(2);
+		(void)const_array[2];
+		(void)const_array.at(2);
+		(void)const_array.data();
+		(void)const_array.begin();
+		(void)const_array.range(0, const_array.size());
+		(void)const_array.end();
+		(void)const_array.front();
+		(void)const_array.back();
+		(void)const_array.rbegin();
+		(void)const_array.rend();
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+}
+
+void
+run_tests(pmem::obj::pool<struct root> &pop)
+{
+	auto r = pop.root();
+
+	try {
+		pmem::obj::transaction::run(pop, [&] {
+			r->test = pmem::obj::make_persistent<TestArray>();
+		});
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+
+	try {
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+
+	/* on pmem, in transaction */
+	pmem::obj::transaction::run(pop, [&] {
+		test_access_operators(pop, r->test->array);
+		test_modifiers(pop, r->test->array);
+		test_notx(r->test->array);
+	});
+
+	/* on pmem, outside transaction */
+	test_access_operators(pop, r->test->array);
+	test_modifiers(pop, r->test->array);
+	test_notx(r->test->array);
+
+	array_type stack_array;
+
+	/* on stack, in transaction */
+	pmem::obj::transaction::run(pop, [&] {
+		test_access_operators(pop, stack_array);
+		test_modifiers(pop, stack_array);
+		test_notx(stack_array);
+	});
+
+	/* on stack, outside transaction */
+	test_access_operators(pop, stack_array);
+	test_modifiers(pop, stack_array);
+	test_notx(stack_array);
+}
+
+int
+main(int argc, char *argv[])
+{
+	START();
+
+	if (argc < 2) {
+		std::cerr << "usage: " << argv[0] << " file-name" << std::endl;
+		return 1;
+	}
+
+	auto path = argv[1];
+
+	auto pop = pmem::obj::pool<root>::create(
+		path, "ArrayTest", PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR);
+
+	run_tests(pop);
+
+	pop.close();
+
+	return 0;
+}

--- a/tests/array_transactions/array_transactions_0.cmake
+++ b/tests/array_transactions/array_transactions_0.cmake
@@ -1,0 +1,38 @@
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+include(${SRC_DIR}/../helpers.cmake)
+
+setup()
+
+execute(${TEST_EXECUTABLE} ${DIR}/testfile)
+
+finish()


### PR DESCRIPTION
This patch modifies behaviour of array and iterator methods.
Methods which modify the container itself now start a transaction, element access methods require an active transaction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/146)
<!-- Reviewable:end -->
