### PR TITLE
cmake: replace unsupported boolean comparison

### DIFF
--- a/tests/ctest_helpers.cmake
+++ b/tests/ctest_helpers.cmake
@@ -185,7 +185,7 @@ function(find_packages)
 			include_directories(${VALGRIND_INCLUDE_DIRS})
 			find_pmemcheck()
 
-			if (PMEMCHECK_VERSION GREATER_EQUAL 1.0 AND PMEMCHECK_VERSION LESS 2.0)
+			if ((NOT(PMEMCHECK_VERSION LESS 1.0)) AND PMEMCHECK_VERSION LESS 2.0)
 				find_program(PMREORDER names pmreorder HINTS ${LIBPMEMOBJ_PREFIX}/bin)
 				check_pmemobj_cow_support("cow.pool")
 


### PR DESCRIPTION
GREATER_EQUAL operator is supported from CMake 3.7, but we require at least CMake 3.3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/149)
<!-- Reviewable:end -->
