### PR TITLE
Always initialize pmem::obj::array using double braces.

### DIFF
--- a/tests/external/libcxx/array/array.cons/initializer_list.pass.cpp
+++ b/tests/external/libcxx/array/array.cons/initializer_list.pass.cpp
@@ -25,7 +25,7 @@ namespace pmem_exp = pmem::obj::experimental;
 struct Testcase1 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	C c = {1, 2, 3.5};
+	C c = {{1, 2, 3.5}};
 
 	void
 	run()
@@ -40,7 +40,7 @@ struct Testcase1 {
 struct Testcase2 {
 	typedef double T;
 	typedef pmem_exp::array<T, 0> C;
-	C c = {};
+	C c = {{}};
 
 	void
 	run()
@@ -52,7 +52,7 @@ struct Testcase2 {
 struct Testcase3 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	C c = {1};
+	C c = {{1}};
 
 	void
 	run()
@@ -65,7 +65,7 @@ struct Testcase3 {
 struct Testcase4 {
 	typedef int T;
 	typedef pmem_exp::array<T, 1> C;
-	C c = {};
+	C c = {{}};
 
 	void
 	run()

--- a/tests/external/libcxx/array/array.data/data.pass.cpp
+++ b/tests/external/libcxx/array/array.data/data.pass.cpp
@@ -26,7 +26,7 @@ namespace pmem_exp = pmem::obj::experimental;
 struct Testcase1 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	C c = {1, 2, 3.5};
+	C c = {{1, 2, 3.5}};
 
 	void
 	run()
@@ -55,7 +55,7 @@ struct Testcase2 {
 struct Testcase3 {
 	typedef std::max_align_t T;
 	typedef pmem_exp::array<T, 0> C;
-	const C c = {};
+	const C c = {{}};
 
 	void
 	run()

--- a/tests/external/libcxx/array/array.data/data_const.pass.cpp
+++ b/tests/external/libcxx/array/array.data/data_const.pass.cpp
@@ -26,7 +26,7 @@ namespace pmem_exp = pmem::obj::experimental;
 struct Testcase1 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	const C c = {1, 2, 3.5};
+	const C c = {{1, 2, 3.5}};
 
 	void
 	run()
@@ -41,7 +41,7 @@ struct Testcase1 {
 struct Testcase2 {
 	typedef std::max_align_t T;
 	typedef pmem_exp::array<T, 0> C;
-	const C c = {};
+	const C c = {{}};
 
 	void
 	run()

--- a/tests/external/libcxx/array/array.fill/fill.fail.cpp
+++ b/tests/external/libcxx/array/array.fill/fill.fail.cpp
@@ -26,7 +26,7 @@ main()
 
 		typedef double T;
 		typedef pmem_exp::array<const T, 0> C;
-		C c = {};
+		C c = {{}};
 		// expected-error-re@array:* {{static_assert failed
 		// {{.*}}"cannot fill zero-sized array of type 'const T'"}}
 		c.fill(5.5); // expected-note {{requested here}}

--- a/tests/external/libcxx/array/array.fill/fill.pass.cpp
+++ b/tests/external/libcxx/array/array.fill/fill.pass.cpp
@@ -25,7 +25,7 @@ namespace pmem_exp = pmem::obj::experimental;
 struct Testcase1 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	C c = {1, 2, 3.5};
+	C c = {{1, 2, 3.5}};
 
 	void
 	run()
@@ -41,7 +41,7 @@ struct Testcase1 {
 struct Testcase2 {
 	typedef double T;
 	typedef pmem_exp::array<T, 0> C;
-	C c = {};
+	C c = {{}};
 
 	void
 	run()

--- a/tests/external/libcxx/array/array.size/size.pass.cpp
+++ b/tests/external/libcxx/array/array.size/size.pass.cpp
@@ -25,7 +25,7 @@ namespace pmem_exp = pmem::obj::experimental;
 struct Testcase1 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	C c = {1, 2, 3.5};
+	C c = {{1, 2, 3.5}};
 
 	void
 	run()
@@ -39,7 +39,7 @@ struct Testcase1 {
 struct Testcase2 {
 	typedef double T;
 	typedef pmem_exp::array<T, 0> C;
-	C c = {};
+	C c = {{}};
 
 	void
 	run()

--- a/tests/external/libcxx/array/array.special/swap.pass.cpp
+++ b/tests/external/libcxx/array/array.special/swap.pass.cpp
@@ -47,8 +47,8 @@ struct can_swap : std::is_same<decltype(can_swap_imp<Tp>(0)), void> {
 struct Testcase1 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	C c1 = {1, 2, 3.5};
-	C c2 = {4, 5, 6.5};
+	C c1 = {{1, 2, 3.5}};
+	C c2 = {{4, 5, 6.5}};
 
 	void
 	run()
@@ -68,8 +68,8 @@ struct Testcase1 {
 struct Testcase2 {
 	typedef double T;
 	typedef pmem_exp::array<T, 0> C;
-	C c1 = {};
-	C c2 = {};
+	C c1 = {{}};
+	C c2 = {{}};
 
 	void
 	run()
@@ -84,8 +84,8 @@ struct Testcase3 {
 	typedef NonSwappable T;
 	typedef pmem_exp::array<T, 0> C0;
 	static_assert(can_swap<C0 &>::value, "");
-	C0 l = {};
-	C0 r = {};
+	C0 l = {{}};
+	C0 r = {{}};
 
 	void
 	run()

--- a/tests/external/libcxx/array/array.swap/swap.fail.cpp
+++ b/tests/external/libcxx/array/array.swap/swap.fail.cpp
@@ -29,8 +29,8 @@ main()
 
 		typedef double T;
 		typedef pmem_exp::array<const T, 0> C;
-		C c = {};
-		C c2 = {};
+		C c = {{}};
+		C c2 = {{}};
 		// expected-error-re@array:* {{static_assert failed
 		// {{.*}}"cannot swap zero-sized array of type 'const T'"}}
 		c.swap(c2); // expected-note {{requested here}}

--- a/tests/external/libcxx/array/array.tuple/get.fail.cpp
+++ b/tests/external/libcxx/array/array.tuple/get.fail.cpp
@@ -28,7 +28,7 @@ main()
 	{
 		typedef double T;
 		typedef pmem_exp::array<T, 3> C;
-		C c = {1, 2, 3.5};
+		C c = {{1, 2, 3.5}};
 		get<3>(c) = 5.5; // expected-note {{requested here}}
 		// expected-error@array:* {{static_assert failed "Index out of
 		// bounds in std::get<> (std::array)"}}

--- a/tests/external/libcxx/array/array.tuple/get.pass.cpp
+++ b/tests/external/libcxx/array/array.tuple/get.pass.cpp
@@ -27,7 +27,7 @@ using pmem_exp::get;
 struct Testcase1 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	C c = {1, 2, 3.5};
+	C c = {{1, 2, 3.5}};
 
 	void
 	run()

--- a/tests/external/libcxx/array/array.tuple/get_const.pass.cpp
+++ b/tests/external/libcxx/array/array.tuple/get_const.pass.cpp
@@ -27,7 +27,7 @@ using pmem_exp::get;
 struct Testcase1 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	const C c = {1, 2, 3.5};
+	const C c = {{1, 2, 3.5}};
 
 	void
 	run()

--- a/tests/external/libcxx/array/array.tuple/get_const_rv.pass.cpp
+++ b/tests/external/libcxx/array/array.tuple/get_const_rv.pass.cpp
@@ -27,7 +27,7 @@ using pmem_exp::get;
 struct Testcase1 {
 	typedef std::unique_ptr<double> T;
 	typedef pmem_exp::array<T, 1> C;
-	const C c = {std::unique_ptr<double>(new double(3.5))};
+	const C c = {{std::unique_ptr<double>(new double(3.5))}};
 
 	void
 	run()

--- a/tests/external/libcxx/array/array.tuple/get_rv.pass.cpp
+++ b/tests/external/libcxx/array/array.tuple/get_rv.pass.cpp
@@ -27,7 +27,7 @@ using pmem_exp::get;
 struct Testcase1 {
 	typedef std::unique_ptr<double> T;
 	typedef pmem_exp::array<T, 1> C;
-	C c = {std::unique_ptr<double>(new double(3.5))};
+	C c = {{std::unique_ptr<double>(new double(3.5))}};
 
 	void
 	run()

--- a/tests/external/libcxx/array/at.pass.cpp
+++ b/tests/external/libcxx/array/at.pass.cpp
@@ -25,7 +25,7 @@ namespace pmem_exp = pmem::obj::experimental;
 struct Testcase1 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	C c = {1, 2, 3.5};
+	C c = {{1, 2, 3.5}};
 
 	void
 	run()
@@ -51,7 +51,7 @@ struct Testcase1 {
 struct Testcase2 {
 	typedef double T;
 	typedef pmem_exp::array<T, 0> C;
-	C c = {};
+	C c = {{}};
 
 	void
 	run()
@@ -73,7 +73,7 @@ struct Testcase2 {
 struct Testcase3 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	const C c = {1, 2, 3.5};
+	const C c = {{1, 2, 3.5}};
 
 	void
 	run()

--- a/tests/external/libcxx/array/begin.pass.cpp
+++ b/tests/external/libcxx/array/begin.pass.cpp
@@ -25,7 +25,7 @@ namespace pmem_exp = pmem::obj::experimental;
 struct Testcase1 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	C c = {1, 2, 3.5};
+	C c = {{1, 2, 3.5}};
 
 	void
 	run()
@@ -47,7 +47,7 @@ struct Testcase2 {
 	};
 	typedef NoDefault T;
 	typedef pmem_exp::array<T, 0> C;
-	C c = {};
+	C c = {{}};
 
 	void
 	run()

--- a/tests/external/libcxx/array/compare.pass.cpp
+++ b/tests/external/libcxx/array/compare.pass.cpp
@@ -42,10 +42,10 @@ test_compare(const Array &LHS, const Array &RHS)
 struct Testcase1 {
 	typedef int T;
 	typedef pmem_exp::array<T, 3> C;
-	C c1 = {1, 2, 3};
-	C c2 = {1, 2, 3};
-	C c3 = {3, 2, 1};
-	C c4 = {1, 2, 1};
+	C c1 = {{1, 2, 3}};
+	C c2 = {{1, 2, 3}};
+	C c3 = {{3, 2, 1}};
+	C c4 = {{1, 2, 1}};
 
 	void
 	run()
@@ -59,8 +59,8 @@ struct Testcase1 {
 struct Testcase2 {
 	typedef int T;
 	typedef pmem_exp::array<T, 0> C;
-	C c1 = {};
-	C c2 = {};
+	C c1 = {{}};
+	C c2 = {{}};
 
 	void
 	run()

--- a/tests/external/libcxx/array/front_back.pass.cpp
+++ b/tests/external/libcxx/array/front_back.pass.cpp
@@ -25,7 +25,7 @@ namespace pmem_exp = pmem::obj::experimental;
 struct Testcase1 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	C c = {1, 2, 3.5};
+	C c = {{1, 2, 3.5}};
 
 	void
 	run()
@@ -45,7 +45,7 @@ struct Testcase1 {
 struct Testcase2 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	const C c = {1, 2, 3.5};
+	const C c = {{1, 2, 3.5}};
 
 	void
 	run()
@@ -61,7 +61,7 @@ struct Testcase2 {
 struct Testcase3 {
 	typedef double T;
 	typedef pmem_exp::array<T, 0> C;
-	C c = {};
+	C c = {{}};
 
 	void
 	run()

--- a/tests/external/libcxx/array/indexing.pass.cpp
+++ b/tests/external/libcxx/array/indexing.pass.cpp
@@ -25,7 +25,7 @@ namespace pmem_exp = pmem::obj::experimental;
 struct Testcase1 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	C c = {1, 2, 3.5};
+	C c = {{1, 2, 3.5}};
 
 	void
 	run()
@@ -45,7 +45,7 @@ struct Testcase1 {
 struct Testcase2 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	const C c = {1, 2, 3.5};
+	const C c = {{1, 2, 3.5}};
 
 	void
 	run()
@@ -60,7 +60,7 @@ struct Testcase2 {
 struct Testcase3 {
 	typedef double T;
 	typedef pmem_exp::array<T, 0> C;
-	C c = {};
+	C c = {{}};
 
 	void
 	run()


### PR DESCRIPTION
Using single braces initialization is allowed by the standard (C++11 §8.5.1/11),
however older versions of gcc (up-to 5.5.0) do not properly elide braces and
emit error in this case.

This causes build failures on quickbuild.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/150)
<!-- Reviewable:end -->
