### PR TITLE
fix coverege travis output issue

### DIFF
--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,7 +53,8 @@ function test_command() {
 		fi
 
 		ctest --output-on-failure -E "_memcheck|_drd|_helgrind|_pmemcheck" --timeout 540
-		bash <(curl -s https://codecov.io/bash) -c -F $1 -x "$gcovexe"
+		# the output is redundant in this case, i.e. we rely on parsed report from codecov on github
+		bash <(curl -s https://codecov.io/bash) -c -F $1 -x "$gcovexe" > /dev/null
 		cleanup
 	else
 		ctest --output-on-failure --timeout 540


### PR DESCRIPTION
Travis output has 4MB limitation for an output and recently it became a limitation for libpmemobj-cpp project.
This patch removes llvm-cov output from travis log, but coverage analysis are still being performed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/152)
<!-- Reviewable:end -->
