### PR TITLE
test: copy libcxx vector tests

### DIFF
--- a/tests/external/CMakeLists.txt
+++ b/tests/external/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -168,3 +168,85 @@ add_test_default(vector_libcxx_ctor_size_value memcheck)
 
 build_test(vector_libcxx_dtor_noexcept libcxx/vector/vector.cons/dtor_noexcept.pass.cpp)
 add_test_default(vector_libcxx_dtor_noexcept none)
+
+# XXX: port libcxx test vector.capacity/capacity.pass
+
+# XXX: port libcxx test vector.capacity/empty.fail
+
+# XXX: port libcxx test vector.capacity/empty.pass
+
+# XXX: port libcxx test vector.capacity/max_size.pass
+
+# XXX: port libcxx test vector.capacity/reserve.pass
+
+# XXX: port libcxx test vector.capacity/resize_size_value.pass
+
+# XXX: port libcxx test vector.capacity/resize_size.pass
+
+# XXX: port libcxx test vector.capacity/shrink_to_fit.pass
+
+# XXX: port libcxx test vector.capacity/size.pass
+
+# XXX: port libcxx test vector.capacity/swap.pass
+
+# XXX: port libcxx test vector.cons/assign_copy.pass
+
+# XXX: port libcxx test vector.cons/assign_initializer_list.pass
+
+# XXX: port libcxx test vector.cons/assign_iter_iter.pass
+
+# XXX: port libcxx test vector.cons/assign_move.pass
+
+# XXX: port libcxx test vector.cons/assign_size_value.pass
+
+# XXX: port libcxx test vector.cons/copy.pass
+
+# XXX: port libcxx test vector.cons/deduct.pass
+
+# XXX: port libcxx test vector.cons/default_noexcept.pass
+
+# XXX: port libcxx test vector.cons/default_recursive.pass
+
+# XXX: port libcxx test vector.cons/initializer_list.pass
+
+# XXX: port libcxx test vector.cons/move_assign_noexcept.pass
+
+# XXX: port libcxx test vector.cons/move_noexcept.pass
+
+# XXX: port libcxx test vector.cons/move.pass
+
+# XXX: port libcxx test vector.cons/op_equal_initializer_list.pass
+
+# XXX: port libcxx test vector.modifiers/clear.pass
+
+# XXX: port libcxx test vector.modifiers/emplace_back.pass
+
+# XXX: port libcxx test vector.modifiers/emplace_extra.pass
+
+# XXX: port libcxx test vector.modifiers/emplace.pass
+
+# XXX: port libcxx test vector.modifiers/erase_iter_iter.pass
+
+# XXX: port libcxx test vector.modifiers/erase_iter.pass
+
+# XXX: port libcxx test vector.modifiers/insert_iter_initializer_list.pass
+
+# XXX: port libcxx test vector.modifiers/insert_iter_iter_iter.pass
+
+# XXX: port libcxx test vector.modifiers/insert_iter_rvalue.pass
+
+# XXX: port libcxx test vector.modifiers/insert_iter_size_value.pass
+
+# XXX: port libcxx test vector.modifiers/insert_iter_value.pass
+
+# XXX: port libcxx test vector.modifiers/pop_back.pass
+
+# XXX: port libcxx test vector.modifiers/push_back_exception_safety.pass
+
+# XXX: port libcxx test vector.modifiers/push_back_rvalue.pass
+
+# XXX: port libcxx test vector.modifiers/push_back.pass
+
+# XXX: port libcxx test vector.special/swap_noexcept.pass
+
+# XXX: port libcxx test vector.special/swap.pass

--- a/tests/external/libcxx/vector/vector.capacity/capacity.pass.cpp
+++ b/tests/external/libcxx/vector/vector.capacity/capacity.pass.cpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// size_type capacity() const;
+
+#include <vector>
+#include <cassert>
+
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+        std::vector<int> v;
+        assert(v.capacity() == 0);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+    {
+        std::vector<int> v(100);
+        assert(v.capacity() == 100);
+        v.push_back(0);
+        assert(v.capacity() > 101);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+#if TEST_STD_VER >= 11
+    {
+        std::vector<int, min_allocator<int>> v;
+        assert(v.capacity() == 0);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+    {
+        std::vector<int, min_allocator<int>> v(100);
+        assert(v.capacity() == 100);
+        v.push_back(0);
+        assert(v.capacity() > 101);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.capacity/empty.fail.cpp
+++ b/tests/external/libcxx/vector/vector.capacity/empty.fail.cpp
@@ -1,0 +1,28 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// class vector
+
+// bool empty() const noexcept;
+
+// UNSUPPORTED: c++98, c++03, c++11, c++14, c++17
+// UNSUPPORTED: clang-3.3, clang-3.4, clang-3.5, clang-3.6, clang-3.7, clang-3.8
+
+#include <vector>
+
+#include "test_macros.h"
+
+int main ()
+{
+    std::vector<int> c;
+    c.empty();  // expected-error {{ignoring return value of function declared with 'nodiscard' attribute}}
+}

--- a/tests/external/libcxx/vector/vector.capacity/empty.pass.cpp
+++ b/tests/external/libcxx/vector/vector.capacity/empty.pass.cpp
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// class vector
+
+// bool empty() const noexcept;
+
+#include <vector>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+
+int main()
+{
+    {
+    typedef std::vector<int> C;
+    C c;
+    ASSERT_NOEXCEPT(c.empty());
+    assert(c.empty());
+    c.push_back(C::value_type(1));
+    assert(!c.empty());
+    c.clear();
+    assert(c.empty());
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef std::vector<int, min_allocator<int>> C;
+    C c;
+    ASSERT_NOEXCEPT(c.empty());
+    assert(c.empty());
+    c.push_back(C::value_type(1));
+    assert(!c.empty());
+    c.clear();
+    assert(c.empty());
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.capacity/max_size.pass.cpp
+++ b/tests/external/libcxx/vector/vector.capacity/max_size.pass.cpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// size_type max_size() const;
+
+#include <cassert>
+#include <limits>
+#include <type_traits>
+#include <vector>
+
+#include "test_allocator.h"
+#include "test_macros.h"
+
+
+int main() {
+  {
+    typedef limited_allocator<int, 10> A;
+    typedef std::vector<int, A> C;
+    C c;
+    assert(c.max_size() <= 10);
+    LIBCPP_ASSERT(c.max_size() == 10);
+  }
+  {
+    typedef limited_allocator<int, (size_t)-1> A;
+    typedef std::vector<int, A> C;
+    const C::difference_type max_dist =
+        std::numeric_limits<C::difference_type>::max();
+    C c;
+    assert(c.max_size() <= max_dist);
+    LIBCPP_ASSERT(c.max_size() == max_dist);
+  }
+  {
+    typedef std::vector<char> C;
+    const C::difference_type max_dist =
+        std::numeric_limits<C::difference_type>::max();
+    C c;
+    assert(c.max_size() <= max_dist);
+    assert(c.max_size() <= alloc_max_size(c.get_allocator()));
+  }
+}

--- a/tests/external/libcxx/vector/vector.capacity/reserve.pass.cpp
+++ b/tests/external/libcxx/vector/vector.capacity/reserve.pass.cpp
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// void reserve(size_type n);
+
+#include <vector>
+#include <cassert>
+#include "test_allocator.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+        std::vector<int> v;
+        v.reserve(10);
+        assert(v.capacity() >= 10);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+    {
+        std::vector<int> v(100);
+        assert(v.capacity() == 100);
+        v.reserve(50);
+        assert(v.size() == 100);
+        assert(v.capacity() == 100);
+        v.reserve(150);
+        assert(v.size() == 100);
+        assert(v.capacity() == 150);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+    {
+        // Add 1 for implementations that dynamically allocate a container proxy.
+        std::vector<int, limited_allocator<int, 250 + 1> > v(100);
+        assert(v.capacity() == 100);
+        v.reserve(50);
+        assert(v.size() == 100);
+        assert(v.capacity() == 100);
+        v.reserve(150);
+        assert(v.size() == 100);
+        assert(v.capacity() == 150);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+#if TEST_STD_VER >= 11
+    {
+        std::vector<int, min_allocator<int>> v;
+        v.reserve(10);
+        assert(v.capacity() >= 10);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+    {
+        std::vector<int, min_allocator<int>> v(100);
+        assert(v.capacity() == 100);
+        v.reserve(50);
+        assert(v.size() == 100);
+        assert(v.capacity() == 100);
+        v.reserve(150);
+        assert(v.size() == 100);
+        assert(v.capacity() == 150);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.capacity/resize_size.pass.cpp
+++ b/tests/external/libcxx/vector/vector.capacity/resize_size.pass.cpp
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// void resize(size_type sz);
+
+#include <vector>
+#include <cassert>
+
+#include "test_macros.h"
+#include "test_allocator.h"
+#include "MoveOnly.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+        std::vector<int> v(100);
+        v.resize(50);
+        assert(v.size() == 50);
+        assert(v.capacity() == 100);
+        assert(is_contiguous_container_asan_correct(v));
+        v.resize(200);
+        assert(v.size() == 200);
+        assert(v.capacity() >= 200);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+    {
+        // Add 1 for implementations that dynamically allocate a container proxy.
+        std::vector<int, limited_allocator<int, 300 + 1> > v(100);
+        v.resize(50);
+        assert(v.size() == 50);
+        assert(v.capacity() == 100);
+        assert(is_contiguous_container_asan_correct(v));
+        v.resize(200);
+        assert(v.size() == 200);
+        assert(v.capacity() >= 200);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+#if TEST_STD_VER >= 11
+    {
+        std::vector<MoveOnly> v(100);
+        v.resize(50);
+        assert(v.size() == 50);
+        assert(v.capacity() == 100);
+        assert(is_contiguous_container_asan_correct(v));
+        v.resize(200);
+        assert(v.size() == 200);
+        assert(v.capacity() >= 200);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+    {
+        // Add 1 for implementations that dynamically allocate a container proxy.
+        std::vector<MoveOnly, limited_allocator<MoveOnly, 300 + 1> > v(100);
+        v.resize(50);
+        assert(v.size() == 50);
+        assert(v.capacity() == 100);
+        assert(is_contiguous_container_asan_correct(v));
+        v.resize(200);
+        assert(v.size() == 200);
+        assert(v.capacity() >= 200);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+    {
+        std::vector<MoveOnly, min_allocator<MoveOnly>> v(100);
+        v.resize(50);
+        assert(v.size() == 50);
+        assert(v.capacity() == 100);
+        assert(is_contiguous_container_asan_correct(v));
+        v.resize(200);
+        assert(v.size() == 200);
+        assert(v.capacity() >= 200);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.capacity/resize_size_value.pass.cpp
+++ b/tests/external/libcxx/vector/vector.capacity/resize_size_value.pass.cpp
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// void resize(size_type sz, const value_type& x);
+
+#include <vector>
+#include <cassert>
+#include "test_allocator.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+        std::vector<int> v(100);
+        v.resize(50, 1);
+        assert(v.size() == 50);
+        assert(v.capacity() == 100);
+        assert(v == std::vector<int>(50));
+        v.resize(200, 1);
+        assert(v.size() == 200);
+        assert(v.capacity() >= 200);
+        assert(is_contiguous_container_asan_correct(v));
+        for (unsigned i = 0; i < 50; ++i)
+            assert(v[i] == 0);
+        for (unsigned i = 50; i < 200; ++i)
+            assert(v[i] == 1);
+    }
+    {
+        // Add 1 for implementations that dynamically allocate a container proxy.
+        std::vector<int, limited_allocator<int, 300 + 1> > v(100);
+        v.resize(50, 1);
+        assert(v.size() == 50);
+        assert(v.capacity() == 100);
+        v.resize(200, 1);
+        assert(v.size() == 200);
+        assert(v.capacity() >= 200);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+#if TEST_STD_VER >= 11
+    {
+        std::vector<int, min_allocator<int>> v(100);
+        v.resize(50, 1);
+        assert(v.size() == 50);
+        assert(v.capacity() == 100);
+        assert(is_contiguous_container_asan_correct(v));
+        assert((v == std::vector<int, min_allocator<int>>(50)));
+        v.resize(200, 1);
+        assert(v.size() == 200);
+        assert(v.capacity() >= 200);
+        assert(is_contiguous_container_asan_correct(v));
+        for (unsigned i = 0; i < 50; ++i)
+            assert(v[i] == 0);
+        for (unsigned i = 50; i < 200; ++i)
+            assert(v[i] == 1);
+    }
+    {
+        std::vector<int, min_allocator<int>> v(100);
+        v.resize(50, 1);
+        assert(v.size() == 50);
+        assert(v.capacity() == 100);
+        assert(is_contiguous_container_asan_correct(v));
+        v.resize(200, 1);
+        assert(v.size() == 200);
+        assert(v.capacity() >= 200);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.capacity/shrink_to_fit.pass.cpp
+++ b/tests/external/libcxx/vector/vector.capacity/shrink_to_fit.pass.cpp
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// void shrink_to_fit();
+
+#include <vector>
+#include <cassert>
+#include "test_allocator.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+        std::vector<int> v(100);
+        v.push_back(1);
+        assert(is_contiguous_container_asan_correct(v));
+        v.shrink_to_fit();
+        assert(v.capacity() == 101);
+        assert(v.size() == 101);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+    {
+        std::vector<int, limited_allocator<int, 401> > v(100);
+        v.push_back(1);
+        assert(is_contiguous_container_asan_correct(v));
+        v.shrink_to_fit();
+        assert(v.capacity() == 101);
+        assert(v.size() == 101);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+#ifndef _LIBCPP_NO_EXCEPTIONS
+    {
+        std::vector<int, limited_allocator<int, 400> > v(100);
+        v.push_back(1);
+        assert(is_contiguous_container_asan_correct(v));
+        v.shrink_to_fit();
+        LIBCPP_ASSERT(v.capacity() == 200); // assumes libc++'s 2x growth factor
+        assert(v.size() == 101);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+#endif
+#if TEST_STD_VER >= 11
+    {
+        std::vector<int, min_allocator<int>> v(100);
+        v.push_back(1);
+        assert(is_contiguous_container_asan_correct(v));
+        v.shrink_to_fit();
+        assert(v.capacity() == 101);
+        assert(v.size() == 101);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.capacity/size.pass.cpp
+++ b/tests/external/libcxx/vector/vector.capacity/size.pass.cpp
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// class vector
+
+// size_type size() const noexcept;
+
+#include <vector>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+
+int main()
+{
+    {
+    typedef std::vector<int> C;
+    C c;
+    ASSERT_NOEXCEPT(c.size());
+    assert(c.size() == 0);
+    c.push_back(C::value_type(2));
+    assert(c.size() == 1);
+    c.push_back(C::value_type(1));
+    assert(c.size() == 2);
+    c.push_back(C::value_type(3));
+    assert(c.size() == 3);
+    c.erase(c.begin());
+    assert(c.size() == 2);
+    c.erase(c.begin());
+    assert(c.size() == 1);
+    c.erase(c.begin());
+    assert(c.size() == 0);
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef std::vector<int, min_allocator<int>> C;
+    C c;
+    ASSERT_NOEXCEPT(c.size());
+    assert(c.size() == 0);
+    c.push_back(C::value_type(2));
+    assert(c.size() == 1);
+    c.push_back(C::value_type(1));
+    assert(c.size() == 2);
+    c.push_back(C::value_type(3));
+    assert(c.size() == 3);
+    c.erase(c.begin());
+    assert(c.size() == 2);
+    c.erase(c.begin());
+    assert(c.size() == 1);
+    c.erase(c.begin());
+    assert(c.size() == 0);
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.capacity/swap.pass.cpp
+++ b/tests/external/libcxx/vector/vector.capacity/swap.pass.cpp
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// void swap(vector& x);
+
+#include <vector>
+#include <cassert>
+
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+        std::vector<int> v1(100);
+        std::vector<int> v2(200);
+        assert(is_contiguous_container_asan_correct(v1));
+        assert(is_contiguous_container_asan_correct(v2));
+        v1.swap(v2);
+        assert(v1.size() == 200);
+        assert(v1.capacity() == 200);
+        assert(is_contiguous_container_asan_correct(v1));
+        assert(v2.size() == 100);
+        assert(v2.capacity() == 100);
+        assert(is_contiguous_container_asan_correct(v2));
+    }
+#if TEST_STD_VER >= 11
+    {
+        std::vector<int, min_allocator<int>> v1(100);
+        std::vector<int, min_allocator<int>> v2(200);
+        assert(is_contiguous_container_asan_correct(v1));
+        assert(is_contiguous_container_asan_correct(v2));
+        v1.swap(v2);
+        assert(v1.size() == 200);
+        assert(v1.capacity() == 200);
+        assert(is_contiguous_container_asan_correct(v1));
+        assert(v2.size() == 100);
+        assert(v2.capacity() == 100);
+        assert(is_contiguous_container_asan_correct(v2));
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.cons/assign_copy.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/assign_copy.pass.cpp
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// vector& operator=(const vector& c);
+
+#include <vector>
+#include <cassert>
+#include "test_allocator.h"
+#include "min_allocator.h"
+
+int main()
+{
+    {
+        std::vector<int, test_allocator<int> > l(3, 2, test_allocator<int>(5));
+        std::vector<int, test_allocator<int> > l2(l, test_allocator<int>(3));
+        l2 = l;
+        assert(l2 == l);
+        assert(l2.get_allocator() == test_allocator<int>(3));
+    }
+    {
+        std::vector<int, other_allocator<int> > l(3, 2, other_allocator<int>(5));
+        std::vector<int, other_allocator<int> > l2(l, other_allocator<int>(3));
+        l2 = l;
+        assert(l2 == l);
+        assert(l2.get_allocator() == other_allocator<int>(5));
+    }
+#if TEST_STD_VER >= 11
+    {
+        std::vector<int, min_allocator<int> > l(3, 2, min_allocator<int>());
+        std::vector<int, min_allocator<int> > l2(l, min_allocator<int>());
+        l2 = l;
+        assert(l2 == l);
+        assert(l2.get_allocator() == min_allocator<int>());
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.cons/assign_initializer_list.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/assign_initializer_list.pass.cpp
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <vector>
+
+// void assign(initializer_list<value_type> il);
+
+#include <vector>
+#include <cassert>
+
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+template <typename Vec>
+void test ( Vec &v )
+{
+    v.assign({3, 4, 5, 6});
+    assert(v.size() == 4);
+    assert(is_contiguous_container_asan_correct(v));
+    assert(v[0] == 3);
+    assert(v[1] == 4);
+    assert(v[2] == 5);
+    assert(v[3] == 6);
+}
+
+int main()
+{
+    {
+    typedef std::vector<int> V;
+    V d1;
+    V d2;
+    d2.reserve(10);  // no reallocation during assign.
+    test(d1);
+    test(d2);
+    }
+    {
+    typedef std::vector<int, min_allocator<int>> V;
+    V d1;
+    V d2;
+    d2.reserve(10);  // no reallocation during assign.
+    test(d1);
+    test(d2);
+    }
+}

--- a/tests/external/libcxx/vector/vector.cons/assign_iter_iter.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/assign_iter_iter.pass.cpp
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// void assign(size_type n, const_reference v);
+
+#include <vector>
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include "test_macros.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+#include "test_iterators.h"
+#if TEST_STD_VER >= 11
+#include "emplace_constructible.h"
+#include "container_test_types.h"
+#endif
+
+
+void test_emplaceable_concept() {
+#if TEST_STD_VER >= 11
+  int arr1[] = {42};
+  int arr2[] = {1, 101, 42};
+  {
+    using T = EmplaceConstructibleMoveableAndAssignable<int>;
+    using It = forward_iterator<int*>;
+    {
+      std::vector<T> v;
+      v.assign(It(arr1), It(std::end(arr1)));
+      assert(v[0].value == 42);
+    }
+    {
+      std::vector<T> v;
+      v.assign(It(arr2), It(std::end(arr2)));
+      assert(v[0].value == 1);
+      assert(v[1].value == 101);
+      assert(v[2].value == 42);
+    }
+  }
+  {
+    using T = EmplaceConstructibleMoveableAndAssignable<int>;
+    using It = input_iterator<int*>;
+    {
+      std::vector<T> v;
+      v.assign(It(arr1), It(std::end(arr1)));
+      assert(v[0].copied == 0);
+      assert(v[0].value == 42);
+    }
+    {
+      std::vector<T> v;
+      v.assign(It(arr2), It(std::end(arr2)));
+      //assert(v[0].copied == 0);
+      assert(v[0].value == 1);
+      //assert(v[1].copied == 0);
+      assert(v[1].value == 101);
+      assert(v[2].copied == 0);
+      assert(v[2].value == 42);
+    }
+  }
+#endif
+}
+
+
+
+int main()
+{
+    test_emplaceable_concept();
+}

--- a/tests/external/libcxx/vector/vector.cons/assign_move.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/assign_move.pass.cpp
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <vector>
+
+// vector& operator=(vector&& c);
+
+#include <vector>
+#include <cassert>
+#include "MoveOnly.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+        std::vector<MoveOnly, test_allocator<MoveOnly> > l(test_allocator<MoveOnly>(5));
+        std::vector<MoveOnly, test_allocator<MoveOnly> > lo(test_allocator<MoveOnly>(5));
+        for (int i = 1; i <= 3; ++i)
+        {
+            l.push_back(i);
+            lo.push_back(i);
+        }
+        assert(is_contiguous_container_asan_correct(l));
+        assert(is_contiguous_container_asan_correct(lo));
+        std::vector<MoveOnly, test_allocator<MoveOnly> > l2(test_allocator<MoveOnly>(5));
+        l2 = std::move(l);
+        assert(l2 == lo);
+        assert(l.empty());
+        assert(l2.get_allocator() == lo.get_allocator());
+        assert(is_contiguous_container_asan_correct(l2));
+    }
+    {
+        std::vector<MoveOnly, test_allocator<MoveOnly> > l(test_allocator<MoveOnly>(5));
+        std::vector<MoveOnly, test_allocator<MoveOnly> > lo(test_allocator<MoveOnly>(5));
+        assert(is_contiguous_container_asan_correct(l));
+        assert(is_contiguous_container_asan_correct(lo));
+        for (int i = 1; i <= 3; ++i)
+        {
+            l.push_back(i);
+            lo.push_back(i);
+        }
+        assert(is_contiguous_container_asan_correct(l));
+        assert(is_contiguous_container_asan_correct(lo));
+        std::vector<MoveOnly, test_allocator<MoveOnly> > l2(test_allocator<MoveOnly>(6));
+        l2 = std::move(l);
+        assert(l2 == lo);
+        assert(!l.empty());
+        assert(l2.get_allocator() == test_allocator<MoveOnly>(6));
+        assert(is_contiguous_container_asan_correct(l2));
+    }
+    {
+        std::vector<MoveOnly, other_allocator<MoveOnly> > l(other_allocator<MoveOnly>(5));
+        std::vector<MoveOnly, other_allocator<MoveOnly> > lo(other_allocator<MoveOnly>(5));
+        assert(is_contiguous_container_asan_correct(l));
+        assert(is_contiguous_container_asan_correct(lo));
+        for (int i = 1; i <= 3; ++i)
+        {
+            l.push_back(i);
+            lo.push_back(i);
+        }
+        assert(is_contiguous_container_asan_correct(l));
+        assert(is_contiguous_container_asan_correct(lo));
+        std::vector<MoveOnly, other_allocator<MoveOnly> > l2(other_allocator<MoveOnly>(6));
+        l2 = std::move(l);
+        assert(l2 == lo);
+        assert(l.empty());
+        assert(l2.get_allocator() == lo.get_allocator());
+        assert(is_contiguous_container_asan_correct(l2));
+    }
+    {
+        std::vector<MoveOnly, min_allocator<MoveOnly> > l(min_allocator<MoveOnly>{});
+        std::vector<MoveOnly, min_allocator<MoveOnly> > lo(min_allocator<MoveOnly>{});
+        assert(is_contiguous_container_asan_correct(l));
+        assert(is_contiguous_container_asan_correct(lo));
+        for (int i = 1; i <= 3; ++i)
+        {
+            l.push_back(i);
+            lo.push_back(i);
+        }
+        assert(is_contiguous_container_asan_correct(l));
+        assert(is_contiguous_container_asan_correct(lo));
+        std::vector<MoveOnly, min_allocator<MoveOnly> > l2(min_allocator<MoveOnly>{});
+        l2 = std::move(l);
+        assert(l2 == lo);
+        assert(l.empty());
+        assert(l2.get_allocator() == lo.get_allocator());
+        assert(is_contiguous_container_asan_correct(l2));
+    }
+}

--- a/tests/external/libcxx/vector/vector.cons/assign_size_value.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/assign_size_value.pass.cpp
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// void assign(size_type n, const_reference v);
+
+#include <vector>
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+bool is6(int x) { return x == 6; }
+
+template <typename Vec>
+void test ( Vec &v )
+{
+    v.assign(5, 6);
+    assert(v.size() == 5);
+    assert(is_contiguous_container_asan_correct(v));
+    assert(std::all_of(v.begin(), v.end(), is6));
+}
+
+int main()
+{
+    {
+    typedef std::vector<int> V;
+    V d1;
+    V d2;
+    d2.reserve(10);  // no reallocation during assign.
+    test(d1);
+    test(d2);
+    }
+
+#if TEST_STD_VER >= 11
+    {
+    typedef std::vector<int, min_allocator<int>> V;
+    V d1;
+    V d2;
+    d2.reserve(10);  // no reallocation during assign.
+    test(d1);
+    test(d2);
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.cons/copy.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/copy.pass.cpp
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// vector(const vector& v);
+
+#include <vector>
+#include <cassert>
+
+#include "test_macros.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+template <class C>
+void
+test(const C& x)
+{
+    typename C::size_type s = x.size();
+    C c(x);
+    LIBCPP_ASSERT(c.__invariants());
+    assert(c.size() == s);
+    assert(c == x);
+    LIBCPP_ASSERT(is_contiguous_container_asan_correct(c));
+}
+
+int main()
+{
+    {
+        int a[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 1, 0};
+        int* an = a + sizeof(a)/sizeof(a[0]);
+        test(std::vector<int>(a, an));
+    }
+    {
+        std::vector<int, test_allocator<int> > v(3, 2, test_allocator<int>(5));
+        std::vector<int, test_allocator<int> > v2 = v;
+        assert(is_contiguous_container_asan_correct(v));
+        assert(is_contiguous_container_asan_correct(v2));
+        assert(v2 == v);
+        assert(v2.get_allocator() == v.get_allocator());
+        assert(is_contiguous_container_asan_correct(v));
+        assert(is_contiguous_container_asan_correct(v2));
+    }
+#if TEST_STD_VER >= 11
+    {
+        std::vector<int, other_allocator<int> > v(3, 2, other_allocator<int>(5));
+        std::vector<int, other_allocator<int> > v2 = v;
+        assert(is_contiguous_container_asan_correct(v));
+        assert(is_contiguous_container_asan_correct(v2));
+        assert(v2 == v);
+        assert(v2.get_allocator() == other_allocator<int>(-2));
+        assert(is_contiguous_container_asan_correct(v));
+        assert(is_contiguous_container_asan_correct(v2));
+    }
+    {
+        int a[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 1, 0};
+        int* an = a + sizeof(a)/sizeof(a[0]);
+        test(std::vector<int, min_allocator<int>>(a, an));
+    }
+    {
+        std::vector<int, min_allocator<int> > v(3, 2, min_allocator<int>());
+        std::vector<int, min_allocator<int> > v2 = v;
+        assert(is_contiguous_container_asan_correct(v));
+        assert(is_contiguous_container_asan_correct(v2));
+        assert(v2 == v);
+        assert(v2.get_allocator() == v.get_allocator());
+        assert(is_contiguous_container_asan_correct(v));
+        assert(is_contiguous_container_asan_correct(v2));
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.cons/deduct.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/deduct.pass.cpp
@@ -1,0 +1,116 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+// UNSUPPORTED: c++98, c++03, c++11, c++14
+// UNSUPPORTED: libcpp-no-deduction-guides
+
+
+// template <class InputIterator, class Allocator = allocator<typename iterator_traits<InputIterator>::value_type>>
+//    deque(InputIterator, InputIterator, Allocator = Allocator())
+//    -> deque<typename iterator_traits<InputIterator>::value_type, Allocator>;
+//
+
+
+#include <vector>
+#include <iterator>
+#include <cassert>
+#include <cstddef>
+#include <climits> // INT_MAX
+
+#include "test_macros.h"
+#include "test_iterators.h"
+#include "test_allocator.h"
+
+struct A {};
+
+int main()
+{
+
+//  Test the explicit deduction guides
+    {
+    const int arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    std::vector vec(std::begin(arr), std::end(arr));
+
+    static_assert(std::is_same_v<decltype(vec), std::vector<int>>, "");
+    assert(std::equal(vec.begin(), vec.end(), std::begin(arr), std::end(arr)));
+    }
+
+    {
+    const long arr[] = {INT_MAX, 1L, 2L, 3L };
+    std::vector vec(std::begin(arr), std::end(arr), std::allocator<long>());
+    static_assert(std::is_same_v<decltype(vec)::value_type, long>, "");
+    assert(vec.size() == 4);
+    assert(vec[0] == INT_MAX);
+    assert(vec[1] == 1L);
+    assert(vec[2] == 2L);
+    }
+
+//  Test the implicit deduction guides
+
+    {
+//  We don't expect this one to work.
+//  std::vector vec(std::allocator<int>()); // vector (allocator &)
+    }
+
+    {
+    std::vector vec(1, A{}); // vector (size_type, T)
+    static_assert(std::is_same_v<decltype(vec)::value_type, A>, "");
+    static_assert(std::is_same_v<decltype(vec)::allocator_type, std::allocator<A>>, "");
+    assert(vec.size() == 1);
+    }
+
+    {
+    std::vector vec(1, A{}, test_allocator<A>()); // vector (size_type, T, allocator)
+    static_assert(std::is_same_v<decltype(vec)::value_type, A>, "");
+    static_assert(std::is_same_v<decltype(vec)::allocator_type, test_allocator<A>>, "");
+    assert(vec.size() == 1);
+    }
+
+    {
+    std::vector vec{1U, 2U, 3U, 4U, 5U}; // vector(initializer-list)
+    static_assert(std::is_same_v<decltype(vec)::value_type, unsigned>, "");
+    assert(vec.size() == 5);
+    assert(vec[2] == 3U);
+    }
+
+    {
+    std::vector vec({1.0, 2.0, 3.0, 4.0}, test_allocator<double>()); // vector(initializer-list, allocator)
+    static_assert(std::is_same_v<decltype(vec)::value_type, double>, "");
+    static_assert(std::is_same_v<decltype(vec)::allocator_type, test_allocator<double>>, "");
+    assert(vec.size() == 4);
+    assert(vec[3] == 4.0);
+    }
+
+    {
+    std::vector<long double> source;
+    std::vector vec(source); // vector(vector &)
+    static_assert(std::is_same_v<decltype(vec)::value_type, long double>, "");
+    static_assert(std::is_same_v<decltype(vec)::allocator_type, std::allocator<long double>>, "");
+    assert(vec.size() == 0);
+    }
+
+
+//  A couple of vector<bool> tests, too!
+    {
+    std::vector vec(3, true); // vector(initializer-list)
+    static_assert(std::is_same_v<decltype(vec)::value_type, bool>, "");
+    static_assert(std::is_same_v<decltype(vec)::allocator_type, std::allocator<bool>>, "");
+    assert(vec.size() == 3);
+    assert(vec[0] && vec[1] && vec[2]);
+    }
+
+    {
+    std::vector<bool> source;
+    std::vector vec(source); // vector(vector &)
+    static_assert(std::is_same_v<decltype(vec)::value_type, bool>, "");
+    static_assert(std::is_same_v<decltype(vec)::allocator_type, std::allocator<bool>>, "");
+    assert(vec.size() == 0);
+    }
+}

--- a/tests/external/libcxx/vector/vector.cons/default.recursive.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/default.recursive.pass.cpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+// class vector
+// vector();
+
+#include <vector>
+
+struct X
+{
+    std::vector<X> q;
+};
+
+int main()
+{
+}

--- a/tests/external/libcxx/vector/vector.cons/default_noexcept.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/default_noexcept.pass.cpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// vector()
+//        noexcept(is_nothrow_default_constructible<allocator_type>::value);
+
+// This tests a conforming extension
+
+// UNSUPPORTED: c++98, c++03
+
+#include <vector>
+#include <cassert>
+
+#include "test_macros.h"
+#include "MoveOnly.h"
+#include "test_allocator.h"
+
+template <class T>
+struct some_alloc
+{
+    typedef T value_type;
+    some_alloc(const some_alloc&);
+};
+
+int main()
+{
+    {
+        typedef std::vector<MoveOnly> C;
+        static_assert(std::is_nothrow_default_constructible<C>::value, "");
+    }
+    {
+        typedef std::vector<MoveOnly, test_allocator<MoveOnly>> C;
+        static_assert(std::is_nothrow_default_constructible<C>::value, "");
+    }
+    {
+        typedef std::vector<MoveOnly, other_allocator<MoveOnly>> C;
+        static_assert(!std::is_nothrow_default_constructible<C>::value, "");
+    }
+    {
+        typedef std::vector<MoveOnly, some_alloc<MoveOnly>> C;
+        static_assert(!std::is_nothrow_default_constructible<C>::value, "");
+    }
+}

--- a/tests/external/libcxx/vector/vector.cons/initializer_list.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/initializer_list.pass.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <vector>
+
+// vector(initializer_list<value_type> il);
+
+#include <vector>
+#include <cassert>
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+    std::vector<int> d = {3, 4, 5, 6};
+    assert(d.size() == 4);
+    assert(is_contiguous_container_asan_correct(d));
+    assert(d[0] == 3);
+    assert(d[1] == 4);
+    assert(d[2] == 5);
+    assert(d[3] == 6);
+    }
+    {
+    std::vector<int, min_allocator<int>> d = {3, 4, 5, 6};
+    assert(d.size() == 4);
+    assert(is_contiguous_container_asan_correct(d));
+    assert(d[0] == 3);
+    assert(d[1] == 4);
+    assert(d[2] == 5);
+    assert(d[3] == 6);
+    }
+}

--- a/tests/external/libcxx/vector/vector.cons/move.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/move.pass.cpp
@@ -1,0 +1,134 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <vector>
+
+// vector(vector&& c);
+
+#include <vector>
+#include <cassert>
+
+#include "test_macros.h"
+#include "MoveOnly.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+#include "verbose_assert.h"
+
+int main()
+{
+    {
+        std::vector<MoveOnly, test_allocator<MoveOnly> > l(test_allocator<MoveOnly>(5));
+        std::vector<MoveOnly, test_allocator<MoveOnly> > lo(test_allocator<MoveOnly>(5));
+        assert(is_contiguous_container_asan_correct(l));
+        assert(is_contiguous_container_asan_correct(lo));
+        for (int i = 1; i <= 3; ++i)
+        {
+            l.push_back(i);
+            lo.push_back(i);
+        }
+        assert(is_contiguous_container_asan_correct(l));
+        assert(is_contiguous_container_asan_correct(lo));
+        std::vector<MoveOnly, test_allocator<MoveOnly> > l2 = std::move(l);
+        assert(l2 == lo);
+        assert(l.empty());
+        assert(l2.get_allocator() == lo.get_allocator());
+        assert(is_contiguous_container_asan_correct(l2));
+    }
+    {
+        std::vector<MoveOnly, other_allocator<MoveOnly> > l(other_allocator<MoveOnly>(5));
+        std::vector<MoveOnly, other_allocator<MoveOnly> > lo(other_allocator<MoveOnly>(5));
+        assert(is_contiguous_container_asan_correct(l));
+        assert(is_contiguous_container_asan_correct(lo));
+        for (int i = 1; i <= 3; ++i)
+        {
+            l.push_back(i);
+            lo.push_back(i);
+        }
+        assert(is_contiguous_container_asan_correct(l));
+        assert(is_contiguous_container_asan_correct(lo));
+        std::vector<MoveOnly, other_allocator<MoveOnly> > l2 = std::move(l);
+        assert(l2 == lo);
+        assert(l.empty());
+        assert(l2.get_allocator() == lo.get_allocator());
+        assert(is_contiguous_container_asan_correct(l2));
+    }
+    {
+        int a1[] = {1, 3, 7, 9, 10};
+        std::vector<int> c1(a1, a1+sizeof(a1)/sizeof(a1[0]));
+        assert(is_contiguous_container_asan_correct(c1));
+        std::vector<int>::const_iterator i = c1.begin();
+        std::vector<int> c2 = std::move(c1);
+        assert(is_contiguous_container_asan_correct(c2));
+        std::vector<int>::iterator j = c2.erase(i);
+        assert(*j == 3);
+        assert(is_contiguous_container_asan_correct(c2));
+    }
+    {
+        std::vector<MoveOnly, min_allocator<MoveOnly> > l(min_allocator<MoveOnly>{});
+        std::vector<MoveOnly, min_allocator<MoveOnly> > lo(min_allocator<MoveOnly>{});
+        assert(is_contiguous_container_asan_correct(l));
+        assert(is_contiguous_container_asan_correct(lo));
+        for (int i = 1; i <= 3; ++i)
+        {
+            l.push_back(i);
+            lo.push_back(i);
+        }
+        assert(is_contiguous_container_asan_correct(l));
+        assert(is_contiguous_container_asan_correct(lo));
+        std::vector<MoveOnly, min_allocator<MoveOnly> > l2 = std::move(l);
+        assert(l2 == lo);
+        assert(l.empty());
+        assert(l2.get_allocator() == lo.get_allocator());
+        assert(is_contiguous_container_asan_correct(l2));
+    }
+    {
+        int a1[] = {1, 3, 7, 9, 10};
+        std::vector<int, min_allocator<int>> c1(a1, a1+sizeof(a1)/sizeof(a1[0]));
+        assert(is_contiguous_container_asan_correct(c1));
+        std::vector<int, min_allocator<int>>::const_iterator i = c1.begin();
+        std::vector<int, min_allocator<int>> c2 = std::move(c1);
+        assert(is_contiguous_container_asan_correct(c2));
+        std::vector<int, min_allocator<int>>::iterator j = c2.erase(i);
+        assert(*j == 3);
+        assert(is_contiguous_container_asan_correct(c2));
+    }
+    {
+      test_alloc_base::clear();
+      using Vect = std::vector<int, test_allocator<int> >;
+      Vect v(test_allocator<int>(42, 101));
+      assert(test_alloc_base::count == 1);
+      assert(test_alloc_base::copied == 1);
+      assert(test_alloc_base::moved == 0);
+      {
+        const test_allocator<int>& a = v.get_allocator();
+        assert(a.get_data() == 42);
+        assert(a.get_id() == 101);
+      }
+      assert(test_alloc_base::count == 1);
+      test_alloc_base::clear_ctor_counters();
+
+      Vect v2 = std::move(v);
+      assert(test_alloc_base::count == 2);
+      assert(test_alloc_base::copied == 0);
+      assert(test_alloc_base::moved == 1);
+      {
+        const test_allocator<int>& a = v.get_allocator();
+        assert(a.get_id() == test_alloc_base::moved_value);
+        assert(a.get_data() == test_alloc_base::moved_value);
+      }
+      {
+        const test_allocator<int>& a = v2.get_allocator();
+        assert(a.get_id() == 101);
+        assert(a.get_data() == 42);
+      }
+    }
+}

--- a/tests/external/libcxx/vector/vector.cons/move_assign_noexcept.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/move_assign_noexcept.pass.cpp
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// vector& operator=(vector&& c)
+//     noexcept(
+//          allocator_type::propagate_on_container_move_assignment::value &&
+//          is_nothrow_move_assignable<allocator_type>::value);
+
+// This tests a conforming extension
+
+// UNSUPPORTED: c++98, c++03
+
+#include <vector>
+#include <cassert>
+
+#include "MoveOnly.h"
+#include "test_allocator.h"
+
+template <class T>
+struct some_alloc
+{
+    typedef T value_type;
+    some_alloc(const some_alloc&);
+};
+
+template <class T>
+struct some_alloc2
+{
+    typedef T value_type;
+
+    some_alloc2() {}
+    some_alloc2(const some_alloc2&);
+    void deallocate(void*, unsigned) {}
+
+    typedef std::false_type propagate_on_container_move_assignment;
+    typedef std::true_type is_always_equal;
+};
+
+template <class T>
+struct some_alloc3
+{
+    typedef T value_type;
+
+    some_alloc3() {}
+    some_alloc3(const some_alloc3&);
+    void deallocate(void*, unsigned) {}
+
+    typedef std::false_type propagate_on_container_move_assignment;
+    typedef std::false_type is_always_equal;
+};
+
+
+int main()
+{
+    {
+        typedef std::vector<MoveOnly> C;
+        static_assert(std::is_nothrow_move_assignable<C>::value, "");
+    }
+    {
+        typedef std::vector<MoveOnly, test_allocator<MoveOnly>> C;
+        static_assert(!std::is_nothrow_move_assignable<C>::value, "");
+    }
+    {
+        typedef std::vector<MoveOnly, other_allocator<MoveOnly>> C;
+        static_assert(std::is_nothrow_move_assignable<C>::value, "");
+    }
+    {
+        typedef std::vector<MoveOnly, some_alloc<MoveOnly>> C;
+    //  In C++17, move assignment for allocators are not allowed to throw
+#if TEST_STD_VER > 14
+        static_assert( std::is_nothrow_move_assignable<C>::value, "");
+#else
+        static_assert(!std::is_nothrow_move_assignable<C>::value, "");
+#endif
+    }
+
+#if TEST_STD_VER > 14
+    {  // POCMA false, is_always_equal true
+        typedef std::vector<MoveOnly, some_alloc2<MoveOnly>> C;
+        static_assert( std::is_nothrow_move_assignable<C>::value, "");
+    }
+    {  // POCMA false, is_always_equal false
+        typedef std::vector<MoveOnly, some_alloc3<MoveOnly>> C;
+        static_assert(!std::is_nothrow_move_assignable<C>::value, "");
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.cons/move_noexcept.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/move_noexcept.pass.cpp
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// vector(vector&&)
+//        noexcept(is_nothrow_move_constructible<allocator_type>::value);
+
+// This tests a conforming extension
+
+// UNSUPPORTED: c++98, c++03
+
+#include <vector>
+#include <cassert>
+
+#include "MoveOnly.h"
+#include "test_allocator.h"
+
+template <class T>
+struct some_alloc
+{
+    typedef T value_type;
+    some_alloc(const some_alloc&);
+};
+
+int main()
+{
+    {
+        typedef std::vector<MoveOnly> C;
+        static_assert(std::is_nothrow_move_constructible<C>::value, "");
+    }
+    {
+        typedef std::vector<MoveOnly, test_allocator<MoveOnly>> C;
+        static_assert(std::is_nothrow_move_constructible<C>::value, "");
+    }
+    {
+        typedef std::vector<MoveOnly, other_allocator<MoveOnly>> C;
+        static_assert(std::is_nothrow_move_constructible<C>::value, "");
+    }
+    {
+        typedef std::vector<MoveOnly, some_alloc<MoveOnly>> C;
+    //  In C++17, move constructors for allocators are not allowed to throw
+#if TEST_STD_VER > 14
+        static_assert( std::is_nothrow_move_constructible<C>::value, "");
+#else
+        static_assert(!std::is_nothrow_move_constructible<C>::value, "");
+#endif
+    }
+}

--- a/tests/external/libcxx/vector/vector.cons/op_equal_initializer_list.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/op_equal_initializer_list.pass.cpp
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <vector>
+
+// vector& operator=(initializer_list<value_type> il);
+
+#include <vector>
+#include <cassert>
+
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+    std::vector<int> d;
+    d = {3, 4, 5, 6};
+    assert(d.size() == 4);
+    assert(is_contiguous_container_asan_correct(d));
+    assert(d[0] == 3);
+    assert(d[1] == 4);
+    assert(d[2] == 5);
+    assert(d[3] == 6);
+    }
+    {
+    std::vector<int, min_allocator<int>> d;
+    d = {3, 4, 5, 6};
+    assert(d.size() == 4);
+    assert(is_contiguous_container_asan_correct(d));
+    assert(d[0] == 3);
+    assert(d[1] == 4);
+    assert(d[2] == 5);
+    assert(d[3] == 6);
+    }
+}

--- a/tests/external/libcxx/vector/vector.modifiers/clear.pass.cpp
+++ b/tests/external/libcxx/vector/vector.modifiers/clear.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// void clear() noexcept;
+
+#include <vector>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+    int a[] = {1, 2, 3};
+    std::vector<int> c(a, a+3);
+    ASSERT_NOEXCEPT(c.clear());
+    c.clear();
+    assert(c.empty());
+    LIBCPP_ASSERT(c.__invariants());
+    LIBCPP_ASSERT(is_contiguous_container_asan_correct(c));
+    }
+#if TEST_STD_VER >= 11
+    {
+    int a[] = {1, 2, 3};
+    std::vector<int, min_allocator<int>> c(a, a+3);
+    ASSERT_NOEXCEPT(c.clear());
+    c.clear();
+    assert(c.empty());
+    LIBCPP_ASSERT(c.__invariants());
+    LIBCPP_ASSERT(is_contiguous_container_asan_correct(c));
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.modifiers/emplace.pass.cpp
+++ b/tests/external/libcxx/vector/vector.modifiers/emplace.pass.cpp
@@ -1,0 +1,136 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <vector>
+
+// template <class... Args> iterator emplace(const_iterator pos, Args&&... args);
+
+#include <vector>
+#include <cassert>
+
+#include "test_macros.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+class A
+{
+    int i_;
+    double d_;
+
+    A(const A&);
+    A& operator=(const A&);
+public:
+    A(int i, double d)
+        : i_(i), d_(d) {}
+
+    A(A&& a)
+        : i_(a.i_),
+          d_(a.d_)
+    {
+        a.i_ = 0;
+        a.d_ = 0;
+    }
+
+    A& operator=(A&& a)
+    {
+        i_ = a.i_;
+        d_ = a.d_;
+        a.i_ = 0;
+        a.d_ = 0;
+        return *this;
+    }
+
+    int geti() const {return i_;}
+    double getd() const {return d_;}
+};
+
+int main()
+{
+    {
+        std::vector<A> c;
+        std::vector<A>::iterator i = c.emplace(c.cbegin(), 2, 3.5);
+        assert(i == c.begin());
+        assert(c.size() == 1);
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(is_contiguous_container_asan_correct(c));
+        i = c.emplace(c.cend(), 3, 4.5);
+        assert(i == c.end()-1);
+        assert(c.size() == 2);
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(c.back().geti() == 3);
+        assert(c.back().getd() == 4.5);
+        assert(is_contiguous_container_asan_correct(c));
+        i = c.emplace(c.cbegin()+1, 4, 6.5);
+        assert(i == c.begin()+1);
+        assert(c.size() == 3);
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(c[1].geti() == 4);
+        assert(c[1].getd() == 6.5);
+        assert(c.back().geti() == 3);
+        assert(c.back().getd() == 4.5);
+        assert(is_contiguous_container_asan_correct(c));
+    }
+    {
+        std::vector<A, limited_allocator<A, 7> > c;
+        std::vector<A, limited_allocator<A, 7> >::iterator i = c.emplace(c.cbegin(), 2, 3.5);
+        assert(i == c.begin());
+        assert(c.size() == 1);
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(is_contiguous_container_asan_correct(c));
+        i = c.emplace(c.cend(), 3, 4.5);
+        assert(i == c.end()-1);
+        assert(c.size() == 2);
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(c.back().geti() == 3);
+        assert(c.back().getd() == 4.5);
+        assert(is_contiguous_container_asan_correct(c));
+        i = c.emplace(c.cbegin()+1, 4, 6.5);
+        assert(i == c.begin()+1);
+        assert(c.size() == 3);
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(c[1].geti() == 4);
+        assert(c[1].getd() == 6.5);
+        assert(c.back().geti() == 3);
+        assert(c.back().getd() == 4.5);
+        assert(is_contiguous_container_asan_correct(c));
+    }
+    {
+        std::vector<A, min_allocator<A>> c;
+        std::vector<A, min_allocator<A>>::iterator i = c.emplace(c.cbegin(), 2, 3.5);
+        assert(i == c.begin());
+        assert(c.size() == 1);
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        i = c.emplace(c.cend(), 3, 4.5);
+        assert(i == c.end()-1);
+        assert(c.size() == 2);
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(c.back().geti() == 3);
+        assert(c.back().getd() == 4.5);
+        i = c.emplace(c.cbegin()+1, 4, 6.5);
+        assert(i == c.begin()+1);
+        assert(c.size() == 3);
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(c[1].geti() == 4);
+        assert(c[1].getd() == 6.5);
+        assert(c.back().geti() == 3);
+        assert(c.back().getd() == 4.5);
+    }
+}

--- a/tests/external/libcxx/vector/vector.modifiers/emplace_back.pass.cpp
+++ b/tests/external/libcxx/vector/vector.modifiers/emplace_back.pass.cpp
@@ -1,0 +1,148 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <vector>
+
+// template <class... Args> reference emplace_back(Args&&... args);
+// return type is 'reference' in C++17; 'void' before
+
+#include <vector>
+#include <cassert>
+#include "test_macros.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+#include "test_allocator.h"
+#include "asan_testing.h"
+
+class A
+{
+    int i_;
+    double d_;
+
+    A(const A&);
+    A& operator=(const A&);
+public:
+    A(int i, double d)
+        : i_(i), d_(d) {}
+
+    A(A&& a)
+        : i_(a.i_),
+          d_(a.d_)
+    {
+        a.i_ = 0;
+        a.d_ = 0;
+    }
+
+    A& operator=(A&& a)
+    {
+        i_ = a.i_;
+        d_ = a.d_;
+        a.i_ = 0;
+        a.d_ = 0;
+        return *this;
+    }
+
+    int geti() const {return i_;}
+    double getd() const {return d_;}
+};
+
+int main()
+{
+    {
+        std::vector<A> c;
+#if TEST_STD_VER > 14
+        A& r1 = c.emplace_back(2, 3.5);
+        assert(c.size() == 1);
+        assert(&r1 == &c.back());
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(is_contiguous_container_asan_correct(c));
+        A& r2 = c.emplace_back(3, 4.5);
+        assert(c.size() == 2);
+        assert(&r2 == &c.back());
+#else
+        c.emplace_back(2, 3.5);
+        assert(c.size() == 1);
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(is_contiguous_container_asan_correct(c));
+        c.emplace_back(3, 4.5);
+        assert(c.size() == 2);
+#endif
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(c.back().geti() == 3);
+        assert(c.back().getd() == 4.5);
+        assert(is_contiguous_container_asan_correct(c));
+    }
+    {
+        std::vector<A, limited_allocator<A, 4> > c;
+#if TEST_STD_VER > 14
+        A& r1 = c.emplace_back(2, 3.5);
+        assert(c.size() == 1);
+        assert(&r1 == &c.back());
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(is_contiguous_container_asan_correct(c));
+        A& r2 = c.emplace_back(3, 4.5);
+        assert(c.size() == 2);
+        assert(&r2 == &c.back());
+#else
+        c.emplace_back(2, 3.5);
+        assert(c.size() == 1);
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(is_contiguous_container_asan_correct(c));
+        c.emplace_back(3, 4.5);
+        assert(c.size() == 2);
+#endif
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(c.back().geti() == 3);
+        assert(c.back().getd() == 4.5);
+        assert(is_contiguous_container_asan_correct(c));
+    }
+    {
+        std::vector<A, min_allocator<A>> c;
+#if TEST_STD_VER > 14
+        A& r1 = c.emplace_back(2, 3.5);
+        assert(c.size() == 1);
+        assert(&r1 == &c.back());
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(is_contiguous_container_asan_correct(c));
+        A& r2 = c.emplace_back(3, 4.5);
+        assert(c.size() == 2);
+        assert(&r2 == &c.back());
+#else
+        c.emplace_back(2, 3.5);
+        assert(c.size() == 1);
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(is_contiguous_container_asan_correct(c));
+        c.emplace_back(3, 4.5);
+        assert(c.size() == 2);
+#endif
+        assert(c.front().geti() == 2);
+        assert(c.front().getd() == 3.5);
+        assert(c.back().geti() == 3);
+        assert(c.back().getd() == 4.5);
+        assert(is_contiguous_container_asan_correct(c));
+    }
+    {
+        std::vector<Tag_X, TaggingAllocator<Tag_X>> c;
+        c.emplace_back();
+        assert(c.size() == 1);
+        c.emplace_back(1, 2, 3);
+        assert(c.size() == 2);
+        assert(is_contiguous_container_asan_correct(c));
+    }
+}

--- a/tests/external/libcxx/vector/vector.modifiers/emplace_extra.pass.cpp
+++ b/tests/external/libcxx/vector/vector.modifiers/emplace_extra.pass.cpp
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <vector>
+
+// template <class... Args> iterator emplace(const_iterator pos, Args&&... args);
+
+#include <vector>
+#include <cassert>
+
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+        std::vector<int> v;
+        v.reserve(3);
+        assert(is_contiguous_container_asan_correct(v));
+        v = { 1, 2, 3 };
+        v.emplace(v.begin(), v.back());
+        assert(v[0] == 3);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+    {
+        std::vector<int> v;
+        v.reserve(4);
+        assert(is_contiguous_container_asan_correct(v));
+        v = { 1, 2, 3 };
+        v.emplace(v.begin(), v.back());
+        assert(v[0] == 3);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+    {
+        std::vector<int, min_allocator<int>> v;
+        v.reserve(3);
+        assert(is_contiguous_container_asan_correct(v));
+        v = { 1, 2, 3 };
+        v.emplace(v.begin(), v.back());
+        assert(v[0] == 3);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+    {
+        std::vector<int, min_allocator<int>> v;
+        v.reserve(4);
+        assert(is_contiguous_container_asan_correct(v));
+        v = { 1, 2, 3 };
+        v.emplace(v.begin(), v.back());
+        assert(v[0] == 3);
+        assert(is_contiguous_container_asan_correct(v));
+    }
+}

--- a/tests/external/libcxx/vector/vector.modifiers/erase_iter.pass.cpp
+++ b/tests/external/libcxx/vector/vector.modifiers/erase_iter.pass.cpp
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// iterator erase(const_iterator position);
+
+#include <vector>
+#include <iterator>
+#include <cassert>
+
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+#ifndef TEST_HAS_NO_EXCEPTIONS
+struct Throws {
+    Throws() : v_(0) {}
+    Throws(int v) : v_(v) {}
+    Throws(const Throws  &rhs) : v_(rhs.v_) { if (sThrows) throw 1; }
+    Throws(      Throws &&rhs) : v_(rhs.v_) { if (sThrows) throw 1; }
+    Throws& operator=(const Throws  &rhs) { v_ = rhs.v_; return *this; }
+    Throws& operator=(      Throws &&rhs) { v_ = rhs.v_; return *this; }
+    int v_;
+    static bool sThrows;
+    };
+
+bool Throws::sThrows = false;
+#endif
+
+int main()
+{
+    {
+    int a1[] = {1, 2, 3};
+    std::vector<int> l1(a1, a1+3);
+    std::vector<int>::const_iterator i = l1.begin();
+    assert(is_contiguous_container_asan_correct(l1));
+    ++i;
+    std::vector<int>::iterator j = l1.erase(i);
+    assert(l1.size() == 2);
+    assert(distance(l1.begin(), l1.end()) == 2);
+    assert(*j == 3);
+    assert(*l1.begin() == 1);
+    assert(*next(l1.begin()) == 3);
+    assert(is_contiguous_container_asan_correct(l1));
+    j = l1.erase(j);
+    assert(j == l1.end());
+    assert(l1.size() == 1);
+    assert(distance(l1.begin(), l1.end()) == 1);
+    assert(*l1.begin() == 1);
+    assert(is_contiguous_container_asan_correct(l1));
+    j = l1.erase(l1.begin());
+    assert(j == l1.end());
+    assert(l1.size() == 0);
+    assert(distance(l1.begin(), l1.end()) == 0);
+    assert(is_contiguous_container_asan_correct(l1));
+    }
+#if TEST_STD_VER >= 11
+    {
+    int a1[] = {1, 2, 3};
+    std::vector<int, min_allocator<int>> l1(a1, a1+3);
+    std::vector<int, min_allocator<int>>::const_iterator i = l1.begin();
+    assert(is_contiguous_container_asan_correct(l1));
+    ++i;
+    std::vector<int, min_allocator<int>>::iterator j = l1.erase(i);
+    assert(l1.size() == 2);
+    assert(distance(l1.begin(), l1.end()) == 2);
+    assert(*j == 3);
+    assert(*l1.begin() == 1);
+    assert(*next(l1.begin()) == 3);
+    assert(is_contiguous_container_asan_correct(l1));
+    j = l1.erase(j);
+    assert(j == l1.end());
+    assert(l1.size() == 1);
+    assert(distance(l1.begin(), l1.end()) == 1);
+    assert(*l1.begin() == 1);
+    assert(is_contiguous_container_asan_correct(l1));
+    j = l1.erase(l1.begin());
+    assert(j == l1.end());
+    assert(l1.size() == 0);
+    assert(distance(l1.begin(), l1.end()) == 0);
+    assert(is_contiguous_container_asan_correct(l1));
+    }
+#endif
+#ifndef TEST_HAS_NO_EXCEPTIONS
+// Test for LWG2853:
+// Throws: Nothing unless an exception is thrown by the assignment operator or move assignment operator of T.
+    {
+    Throws arr[] = {1, 2, 3};
+    std::vector<Throws> v(arr, arr+3);
+    Throws::sThrows = true;
+    v.erase(v.begin());
+    v.erase(--v.end());
+    v.erase(v.begin());
+    assert(v.size() == 0);
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.modifiers/erase_iter_iter.pass.cpp
+++ b/tests/external/libcxx/vector/vector.modifiers/erase_iter_iter.pass.cpp
@@ -1,0 +1,156 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// iterator erase(const_iterator first, const_iterator last);
+
+#include <vector>
+#include <iterator>
+#include <cassert>
+
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+#ifndef TEST_HAS_NO_EXCEPTIONS
+struct Throws {
+    Throws() : v_(0) {}
+    Throws(int v) : v_(v) {}
+    Throws(const Throws  &rhs) : v_(rhs.v_) { if (sThrows) throw 1; }
+    Throws(      Throws &&rhs) : v_(rhs.v_) { if (sThrows) throw 1; }
+    Throws& operator=(const Throws  &rhs) { v_ = rhs.v_; return *this; }
+    Throws& operator=(      Throws &&rhs) { v_ = rhs.v_; return *this; }
+    int v_;
+    static bool sThrows;
+    };
+
+bool Throws::sThrows = false;
+#endif
+
+int main()
+{
+    int a1[] = {1, 2, 3};
+    {
+        std::vector<int> l1(a1, a1+3);
+        assert(is_contiguous_container_asan_correct(l1));
+        std::vector<int>::iterator i = l1.erase(l1.cbegin(), l1.cbegin());
+        assert(l1.size() == 3);
+        assert(distance(l1.cbegin(), l1.cend()) == 3);
+        assert(i == l1.begin());
+        assert(is_contiguous_container_asan_correct(l1));
+    }
+    {
+        std::vector<int> l1(a1, a1+3);
+        assert(is_contiguous_container_asan_correct(l1));
+        std::vector<int>::iterator i = l1.erase(l1.cbegin(), next(l1.cbegin()));
+        assert(l1.size() == 2);
+        assert(distance(l1.cbegin(), l1.cend()) == 2);
+        assert(i == l1.begin());
+        assert(l1 == std::vector<int>(a1+1, a1+3));
+        assert(is_contiguous_container_asan_correct(l1));
+    }
+    {
+        std::vector<int> l1(a1, a1+3);
+        assert(is_contiguous_container_asan_correct(l1));
+        std::vector<int>::iterator i = l1.erase(l1.cbegin(), next(l1.cbegin(), 2));
+        assert(l1.size() == 1);
+        assert(distance(l1.cbegin(), l1.cend()) == 1);
+        assert(i == l1.begin());
+        assert(l1 == std::vector<int>(a1+2, a1+3));
+        assert(is_contiguous_container_asan_correct(l1));
+    }
+    {
+        std::vector<int> l1(a1, a1+3);
+        assert(is_contiguous_container_asan_correct(l1));
+        std::vector<int>::iterator i = l1.erase(l1.cbegin(), next(l1.cbegin(), 3));
+        assert(l1.size() == 0);
+        assert(distance(l1.cbegin(), l1.cend()) == 0);
+        assert(i == l1.begin());
+        assert(is_contiguous_container_asan_correct(l1));
+    }
+    {
+        std::vector<std::vector<int> > outer(2, std::vector<int>(1));
+        assert(is_contiguous_container_asan_correct(outer));
+        assert(is_contiguous_container_asan_correct(outer[0]));
+        assert(is_contiguous_container_asan_correct(outer[1]));
+        outer.erase(outer.begin(), outer.begin());
+        assert(outer.size() == 2);
+        assert(outer[0].size() == 1);
+        assert(outer[1].size() == 1);
+        assert(is_contiguous_container_asan_correct(outer));
+        assert(is_contiguous_container_asan_correct(outer[0]));
+        assert(is_contiguous_container_asan_correct(outer[1]));
+    }
+#if TEST_STD_VER >= 11
+    {
+        std::vector<int, min_allocator<int>> l1(a1, a1+3);
+        assert(is_contiguous_container_asan_correct(l1));
+        std::vector<int, min_allocator<int>>::iterator i = l1.erase(l1.cbegin(), l1.cbegin());
+        assert(l1.size() == 3);
+        assert(distance(l1.cbegin(), l1.cend()) == 3);
+        assert(i == l1.begin());
+        assert(is_contiguous_container_asan_correct(l1));
+    }
+    {
+        std::vector<int, min_allocator<int>> l1(a1, a1+3);
+        assert(is_contiguous_container_asan_correct(l1));
+        std::vector<int, min_allocator<int>>::iterator i = l1.erase(l1.cbegin(), next(l1.cbegin()));
+        assert(l1.size() == 2);
+        assert(distance(l1.cbegin(), l1.cend()) == 2);
+        assert(i == l1.begin());
+        assert((l1 == std::vector<int, min_allocator<int>>(a1+1, a1+3)));
+        assert(is_contiguous_container_asan_correct(l1));
+    }
+    {
+        std::vector<int, min_allocator<int>> l1(a1, a1+3);
+        assert(is_contiguous_container_asan_correct(l1));
+        std::vector<int, min_allocator<int>>::iterator i = l1.erase(l1.cbegin(), next(l1.cbegin(), 2));
+        assert(l1.size() == 1);
+        assert(distance(l1.cbegin(), l1.cend()) == 1);
+        assert(i == l1.begin());
+        assert((l1 == std::vector<int, min_allocator<int>>(a1+2, a1+3)));
+        assert(is_contiguous_container_asan_correct(l1));
+    }
+    {
+        std::vector<int, min_allocator<int>> l1(a1, a1+3);
+        assert(is_contiguous_container_asan_correct(l1));
+        std::vector<int, min_allocator<int>>::iterator i = l1.erase(l1.cbegin(), next(l1.cbegin(), 3));
+        assert(l1.size() == 0);
+        assert(distance(l1.cbegin(), l1.cend()) == 0);
+        assert(i == l1.begin());
+        assert(is_contiguous_container_asan_correct(l1));
+    }
+    {
+        std::vector<std::vector<int, min_allocator<int>>, min_allocator<std::vector<int, min_allocator<int>>>> outer(2, std::vector<int, min_allocator<int>>(1));
+        assert(is_contiguous_container_asan_correct(outer));
+        assert(is_contiguous_container_asan_correct(outer[0]));
+        assert(is_contiguous_container_asan_correct(outer[1]));
+        outer.erase(outer.begin(), outer.begin());
+        assert(outer.size() == 2);
+        assert(outer[0].size() == 1);
+        assert(outer[1].size() == 1);
+        assert(is_contiguous_container_asan_correct(outer));
+        assert(is_contiguous_container_asan_correct(outer[0]));
+        assert(is_contiguous_container_asan_correct(outer[1]));
+    }
+#endif
+#ifndef TEST_HAS_NO_EXCEPTIONS
+// Test for LWG2853:
+// Throws: Nothing unless an exception is thrown by the assignment operator or move assignment operator of T.
+    {
+    Throws arr[] = {1, 2, 3};
+    std::vector<Throws> v(arr, arr+3);
+    Throws::sThrows = true;
+    v.erase(v.begin(), --v.end());
+    assert(v.size() == 1);
+    v.erase(v.begin(), v.end());
+    assert(v.size() == 0);
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.modifiers/insert_iter_initializer_list.pass.cpp
+++ b/tests/external/libcxx/vector/vector.modifiers/insert_iter_initializer_list.pass.cpp
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <vector>
+
+// iterator insert(const_iterator p, initializer_list<value_type> il);
+
+#include <vector>
+#include <cassert>
+
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+    std::vector<int> d(10, 1);
+    std::vector<int>::iterator i = d.insert(d.cbegin() + 2, {3, 4, 5, 6});
+    assert(d.size() == 14);
+    assert(is_contiguous_container_asan_correct(d));
+    assert(i == d.begin() + 2);
+    assert(d[0] == 1);
+    assert(d[1] == 1);
+    assert(d[2] == 3);
+    assert(d[3] == 4);
+    assert(d[4] == 5);
+    assert(d[5] == 6);
+    assert(d[6] == 1);
+    assert(d[7] == 1);
+    assert(d[8] == 1);
+    assert(d[9] == 1);
+    assert(d[10] == 1);
+    assert(d[11] == 1);
+    assert(d[12] == 1);
+    assert(d[13] == 1);
+    }
+    {
+    std::vector<int, min_allocator<int>> d(10, 1);
+    std::vector<int, min_allocator<int>>::iterator i = d.insert(d.cbegin() + 2, {3, 4, 5, 6});
+    assert(d.size() == 14);
+    assert(is_contiguous_container_asan_correct(d));
+    assert(i == d.begin() + 2);
+    assert(d[0] == 1);
+    assert(d[1] == 1);
+    assert(d[2] == 3);
+    assert(d[3] == 4);
+    assert(d[4] == 5);
+    assert(d[5] == 6);
+    assert(d[6] == 1);
+    assert(d[7] == 1);
+    assert(d[8] == 1);
+    assert(d[9] == 1);
+    assert(d[10] == 1);
+    assert(d[11] == 1);
+    assert(d[12] == 1);
+    assert(d[13] == 1);
+    }
+}

--- a/tests/external/libcxx/vector/vector.modifiers/insert_iter_iter_iter.pass.cpp
+++ b/tests/external/libcxx/vector/vector.modifiers/insert_iter_iter_iter.pass.cpp
@@ -1,0 +1,167 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// template <class Iter>
+//   iterator insert(const_iterator position, Iter first, Iter last);
+
+#include <vector>
+#include <cassert>
+#include <cstddef>
+
+#include "test_macros.h"
+#include "test_allocator.h"
+#include "test_iterators.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+        std::vector<int> v(100);
+        int a[] = {1, 2, 3, 4, 5};
+        const int N = sizeof(a)/sizeof(a[0]);
+        std::vector<int>::iterator i = v.insert(v.cbegin() + 10, input_iterator<const int*>(a),
+                                        input_iterator<const int*>(a+N));
+        assert(v.size() == 100 + N);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        for (std::size_t k = 0; k < N; ++j, ++k)
+            assert(v[j] == a[k]);
+        for (; j < 105; ++j)
+            assert(v[j] == 0);
+    }
+    {
+        std::vector<int> v(100);
+        int a[] = {1, 2, 3, 4, 5};
+        const int N = sizeof(a)/sizeof(a[0]);
+        std::vector<int>::iterator i = v.insert(v.cbegin() + 10, forward_iterator<const int*>(a),
+                                        forward_iterator<const int*>(a+N));
+        assert(v.size() == 100 + N);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        for (std::size_t k = 0; k < N; ++j, ++k)
+            assert(v[j] == a[k]);
+        for (; j < 105; ++j)
+            assert(v[j] == 0);
+    }
+    {
+        std::vector<int> v(100);
+        while(v.size() < v.capacity()) v.push_back(0); // force reallocation
+        size_t sz = v.size();
+        int a[] = {1, 2, 3, 4, 5};
+        const unsigned N = sizeof(a)/sizeof(a[0]);
+        std::vector<int>::iterator i = v.insert(v.cbegin() + 10, forward_iterator<const int*>(a),
+                                        forward_iterator<const int*>(a+N));
+        assert(v.size() == sz + N);
+        assert(i == v.begin() + 10);
+        std::size_t j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        for (std::size_t k = 0; k < N; ++j, ++k)
+            assert(v[j] == a[k]);
+        for (; j < v.size(); ++j)
+            assert(v[j] == 0);
+    }
+    {
+        std::vector<int> v(100);
+        v.reserve(128); // force no reallocation
+        size_t sz = v.size();
+        int a[] = {1, 2, 3, 4, 5};
+        const unsigned N = sizeof(a)/sizeof(a[0]);
+        std::vector<int>::iterator i = v.insert(v.cbegin() + 10, forward_iterator<const int*>(a),
+                                        forward_iterator<const int*>(a+N));
+        assert(v.size() == sz + N);
+        assert(i == v.begin() + 10);
+        std::size_t j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        for (std::size_t k = 0; k < N; ++j, ++k)
+            assert(v[j] == a[k]);
+        for (; j < v.size(); ++j)
+            assert(v[j] == 0);
+    }
+    {
+        std::vector<int, limited_allocator<int, 308> > v(100);
+        int a[] = {1, 2, 3, 4, 5};
+        const int N = sizeof(a)/sizeof(a[0]);
+        std::vector<int>::iterator i = v.insert(v.cbegin() + 10, input_iterator<const int*>(a),
+                                        input_iterator<const int*>(a+N));
+        assert(v.size() == 100 + N);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        for (std::size_t k = 0; k < N; ++j, ++k)
+            assert(v[j] == a[k]);
+        for (; j < 105; ++j)
+            assert(v[j] == 0);
+    }
+    {
+        std::vector<int, limited_allocator<int, 300> > v(100);
+        int a[] = {1, 2, 3, 4, 5};
+        const int N = sizeof(a)/sizeof(a[0]);
+        std::vector<int>::iterator i = v.insert(v.cbegin() + 10, forward_iterator<const int*>(a),
+                                        forward_iterator<const int*>(a+N));
+        assert(v.size() == 100 + N);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        for (std::size_t k = 0; k < N; ++j, ++k)
+            assert(v[j] == a[k]);
+        for (; j < 105; ++j)
+            assert(v[j] == 0);
+    }
+#if TEST_STD_VER >= 11
+    {
+        std::vector<int, min_allocator<int>> v(100);
+        int a[] = {1, 2, 3, 4, 5};
+        const int N = sizeof(a)/sizeof(a[0]);
+        std::vector<int, min_allocator<int>>::iterator i = v.insert(v.cbegin() + 10, input_iterator<const int*>(a),
+                                        input_iterator<const int*>(a+N));
+        assert(v.size() == 100 + N);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        for (std::size_t k = 0; k < N; ++j, ++k)
+            assert(v[j] == a[k]);
+        for (; j < 105; ++j)
+            assert(v[j] == 0);
+    }
+    {
+        std::vector<int, min_allocator<int>> v(100);
+        int a[] = {1, 2, 3, 4, 5};
+        const int N = sizeof(a)/sizeof(a[0]);
+        std::vector<int, min_allocator<int>>::iterator i = v.insert(v.cbegin() + 10, forward_iterator<const int*>(a),
+                                        forward_iterator<const int*>(a+N));
+        assert(v.size() == 100 + N);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        for (std::size_t k = 0; k < N; ++j, ++k)
+            assert(v[j] == a[k]);
+        for (; j < 105; ++j)
+            assert(v[j] == 0);
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.modifiers/insert_iter_rvalue.pass.cpp
+++ b/tests/external/libcxx/vector/vector.modifiers/insert_iter_rvalue.pass.cpp
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <vector>
+
+// iterator insert(const_iterator position, value_type&& x);
+
+#include <vector>
+#include <cassert>
+
+#include "test_macros.h"
+#include "test_allocator.h"
+#include "MoveOnly.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+        std::vector<MoveOnly> v(100);
+        std::vector<MoveOnly>::iterator i = v.insert(v.cbegin() + 10, MoveOnly(3));
+        assert(v.size() == 101);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == MoveOnly());
+        assert(v[j] == MoveOnly(3));
+        for (++j; j < 101; ++j)
+            assert(v[j] == MoveOnly());
+    }
+    {
+        std::vector<MoveOnly, limited_allocator<MoveOnly, 300> > v(100);
+        std::vector<MoveOnly, limited_allocator<MoveOnly, 300> >::iterator i = v.insert(v.cbegin() + 10, MoveOnly(3));
+        assert(v.size() == 101);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == MoveOnly());
+        assert(v[j] == MoveOnly(3));
+        for (++j; j < 101; ++j)
+            assert(v[j] == MoveOnly());
+    }
+    {
+        std::vector<MoveOnly, min_allocator<MoveOnly>> v(100);
+        std::vector<MoveOnly, min_allocator<MoveOnly>>::iterator i = v.insert(v.cbegin() + 10, MoveOnly(3));
+        assert(v.size() == 101);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == MoveOnly());
+        assert(v[j] == MoveOnly(3));
+        for (++j; j < 101; ++j)
+            assert(v[j] == MoveOnly());
+    }
+}

--- a/tests/external/libcxx/vector/vector.modifiers/insert_iter_size_value.pass.cpp
+++ b/tests/external/libcxx/vector/vector.modifiers/insert_iter_size_value.pass.cpp
@@ -1,0 +1,115 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// iterator insert(const_iterator position, size_type n, const value_type& x);
+
+#include <vector>
+#include <cassert>
+#include <cstddef>
+
+#include "test_macros.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+        std::vector<int> v(100);
+        std::vector<int>::iterator i = v.insert(v.cbegin() + 10, 5, 1);
+        assert(v.size() == 105);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        for (; j < 15; ++j)
+            assert(v[j] == 1);
+        for (++j; j < 105; ++j)
+            assert(v[j] == 0);
+    }
+    {
+        std::vector<int> v(100);
+        while(v.size() < v.capacity()) v.push_back(0); // force reallocation
+        size_t sz = v.size();
+        std::vector<int>::iterator i = v.insert(v.cbegin() + 10, 5, 1);
+        assert(v.size() == sz + 5);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        std::size_t j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        for (; j < 15; ++j)
+            assert(v[j] == 1);
+        for (++j; j < v.size(); ++j)
+            assert(v[j] == 0);
+    }
+    {
+        std::vector<int> v(100);
+        v.reserve(128); // force no reallocation
+        size_t sz = v.size();
+        std::vector<int>::iterator i = v.insert(v.cbegin() + 10, 5, 1);
+        assert(v.size() == sz + 5);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        std::size_t j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        for (; j < 15; ++j)
+            assert(v[j] == 1);
+        for (++j; j < v.size(); ++j)
+            assert(v[j] == 0);
+    }
+    {
+        std::vector<int, limited_allocator<int, 300> > v(100);
+        std::vector<int, limited_allocator<int, 300> >::iterator i = v.insert(v.cbegin() + 10, 5, 1);
+        assert(v.size() == 105);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        for (; j < 15; ++j)
+            assert(v[j] == 1);
+        for (++j; j < 105; ++j)
+            assert(v[j] == 0);
+    }
+#if TEST_STD_VER >= 11
+    {
+        std::vector<int, min_allocator<int>> v(100);
+        std::vector<int, min_allocator<int>>::iterator i = v.insert(v.cbegin() + 10, 5, 1);
+        assert(v.size() == 105);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        for (; j < 15; ++j)
+            assert(v[j] == 1);
+        for (++j; j < 105; ++j)
+            assert(v[j] == 0);
+    }
+    {
+        std::vector<int, min_allocator<int>> v(100);
+        std::vector<int, min_allocator<int>>::iterator i = v.insert(v.cbegin() + 10, 5, 1);
+        assert(v.size() == 105);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        for (; j < 15; ++j)
+            assert(v[j] == 1);
+        for (++j; j < 105; ++j)
+            assert(v[j] == 0);
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.modifiers/insert_iter_value.pass.cpp
+++ b/tests/external/libcxx/vector/vector.modifiers/insert_iter_value.pass.cpp
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// iterator insert(const_iterator position, const value_type& x);
+
+#include <vector>
+#include <cassert>
+#include <cstddef>
+
+#include "test_macros.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+        std::vector<int> v(100);
+        std::vector<int>::iterator i = v.insert(v.cbegin() + 10, 1);
+        assert(v.size() == 101);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        assert(v[j] == 1);
+        for (++j; j < 101; ++j)
+            assert(v[j] == 0);
+    }
+    {
+        std::vector<int> v(100);
+        while(v.size() < v.capacity()) v.push_back(0); // force reallocation
+        size_t sz = v.size();
+        std::vector<int>::iterator i = v.insert(v.cbegin() + 10, 1);
+        assert(v.size() == sz + 1);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        std::size_t j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        assert(v[j] == 1);
+        for (++j; j < v.size(); ++j)
+            assert(v[j] == 0);
+    }
+    {
+        std::vector<int> v(100);
+        while(v.size() < v.capacity()) v.push_back(0);
+        v.pop_back(); v.pop_back(); // force no reallocation
+        size_t sz = v.size();
+        std::vector<int>::iterator i = v.insert(v.cbegin() + 10, 1);
+        assert(v.size() == sz + 1);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        std::size_t j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        assert(v[j] == 1);
+        for (++j; j < v.size(); ++j)
+            assert(v[j] == 0);
+    }
+    {
+        std::vector<int, limited_allocator<int, 300> > v(100);
+        std::vector<int, limited_allocator<int, 300> >::iterator i = v.insert(v.cbegin() + 10, 1);
+        assert(v.size() == 101);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        assert(v[j] == 1);
+        for (++j; j < 101; ++j)
+            assert(v[j] == 0);
+    }
+#if TEST_STD_VER >= 11
+    {
+        std::vector<int, min_allocator<int>> v(100);
+        std::vector<int, min_allocator<int>>::iterator i = v.insert(v.cbegin() + 10, 1);
+        assert(v.size() == 101);
+        assert(is_contiguous_container_asan_correct(v));
+        assert(i == v.begin() + 10);
+        int j;
+        for (j = 0; j < 10; ++j)
+            assert(v[j] == 0);
+        assert(v[j] == 1);
+        for (++j; j < 101; ++j)
+            assert(v[j] == 0);
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.modifiers/pop_back.pass.cpp
+++ b/tests/external/libcxx/vector/vector.modifiers/pop_back.pass.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// void pop_back();
+
+#include <vector>
+#include <cassert>
+
+#include "test_macros.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+
+
+int main()
+{
+    {
+        std::vector<int> c;
+        c.push_back(1);
+        assert(c.size() == 1);
+        c.pop_back();
+        assert(c.size() == 0);
+
+    }
+#if TEST_STD_VER >= 11
+    {
+        std::vector<int, min_allocator<int>> c;
+        c.push_back(1);
+        assert(c.size() == 1);
+        c.pop_back();
+        assert(c.size() == 0);
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.modifiers/push_back.pass.cpp
+++ b/tests/external/libcxx/vector/vector.modifiers/push_back.pass.cpp
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// void push_back(const value_type& x);
+
+#include <vector>
+#include <cassert>
+#include <cstddef>
+#include "test_allocator.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+        std::vector<int> c;
+        c.push_back(0);
+        assert(c.size() == 1);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == j);
+        c.push_back(1);
+        assert(c.size() == 2);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == j);
+        c.push_back(2);
+        assert(c.size() == 3);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == j);
+        c.push_back(3);
+        assert(c.size() == 4);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == j);
+        c.push_back(4);
+        assert(c.size() == 5);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == j);
+    }
+    {
+        // libc++ needs 15 because it grows by 2x (1 + 2 + 4 + 8).
+        // Use 17 for implementations that dynamically allocate a container proxy
+        // and grow by 1.5x (1 for proxy + 1 + 2 + 3 + 4 + 6).
+        std::vector<int, limited_allocator<int, 17> > c;
+        c.push_back(0);
+        assert(c.size() == 1);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == j);
+        c.push_back(1);
+        assert(c.size() == 2);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == j);
+        c.push_back(2);
+        assert(c.size() == 3);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == j);
+        c.push_back(3);
+        assert(c.size() == 4);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == j);
+        c.push_back(4);
+        assert(c.size() == 5);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == j);
+    }
+#if TEST_STD_VER >= 11
+    {
+        std::vector<int, min_allocator<int>> c;
+        c.push_back(0);
+        assert(c.size() == 1);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == j);
+        c.push_back(1);
+        assert(c.size() == 2);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == j);
+        c.push_back(2);
+        assert(c.size() == 3);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == j);
+        c.push_back(3);
+        assert(c.size() == 4);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == j);
+        c.push_back(4);
+        assert(c.size() == 5);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == j);
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.modifiers/push_back_exception_safety.pass.cpp
+++ b/tests/external/libcxx/vector/vector.modifiers/push_back_exception_safety.pass.cpp
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// void push_back(const value_type& x);
+
+#include <vector>
+#include <cassert>
+
+#include "asan_testing.h"
+#include "test_macros.h"
+
+// Flag that makes the copy constructor for CMyClass throw an exception
+static bool gCopyConstructorShouldThrow = false;
+
+class CMyClass {
+    public: CMyClass(int tag);
+    public: CMyClass(const CMyClass& iOther);
+    public: ~CMyClass();
+
+    bool equal(const CMyClass &rhs) const
+        { return fTag == rhs.fTag && fMagicValue == rhs.fMagicValue; }
+    private:
+        int fMagicValue;
+        int fTag;
+
+    private: static int kStartedConstructionMagicValue;
+    private: static int kFinishedConstructionMagicValue;
+};
+
+// Value for fMagicValue when the constructor has started running, but not yet finished
+int CMyClass::kStartedConstructionMagicValue = 0;
+// Value for fMagicValue when the constructor has finished running
+int CMyClass::kFinishedConstructionMagicValue = 12345;
+
+CMyClass::CMyClass(int tag) :
+    fMagicValue(kStartedConstructionMagicValue), fTag(tag)
+{
+    // Signal that the constructor has finished running
+    fMagicValue = kFinishedConstructionMagicValue;
+}
+
+CMyClass::CMyClass(const CMyClass& iOther) :
+    fMagicValue(kStartedConstructionMagicValue), fTag(iOther.fTag)
+{
+    // If requested, throw an exception _before_ setting fMagicValue to kFinishedConstructionMagicValue
+    if (gCopyConstructorShouldThrow) {
+        TEST_THROW(std::exception());
+    }
+    // Signal that the constructor has finished running
+    fMagicValue = kFinishedConstructionMagicValue;
+}
+
+CMyClass::~CMyClass() {
+    // Only instances for which the constructor has finished running should be destructed
+    assert(fMagicValue == kFinishedConstructionMagicValue);
+}
+
+bool operator==(const CMyClass &lhs, const CMyClass &rhs) { return lhs.equal(rhs); }
+
+int main()
+{
+    CMyClass instance(42);
+    std::vector<CMyClass> vec;
+
+    vec.push_back(instance);
+    std::vector<CMyClass> vec2(vec);
+    assert(is_contiguous_container_asan_correct(vec));
+    assert(is_contiguous_container_asan_correct(vec2));
+
+#ifndef TEST_HAS_NO_EXCEPTIONS
+    gCopyConstructorShouldThrow = true;
+    try {
+        vec.push_back(instance);
+        assert(false);
+    }
+    catch (...) {
+        assert(vec==vec2);
+        assert(is_contiguous_container_asan_correct(vec));
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.modifiers/push_back_rvalue.pass.cpp
+++ b/tests/external/libcxx/vector/vector.modifiers/push_back_rvalue.pass.cpp
@@ -1,0 +1,113 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <vector>
+
+// void push_back(value_type&& x);
+
+#include <vector>
+#include <cassert>
+#include <cstddef>
+#include "MoveOnly.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+        std::vector<MoveOnly> c;
+        c.push_back(MoveOnly(0));
+        assert(c.size() == 1);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == MoveOnly(j));
+        c.push_back(MoveOnly(1));
+        assert(c.size() == 2);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == MoveOnly(j));
+        c.push_back(MoveOnly(2));
+        assert(c.size() == 3);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == MoveOnly(j));
+        c.push_back(MoveOnly(3));
+        assert(c.size() == 4);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == MoveOnly(j));
+        c.push_back(MoveOnly(4));
+        assert(c.size() == 5);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == MoveOnly(j));
+    }
+    {
+        // libc++ needs 15 because it grows by 2x (1 + 2 + 4 + 8).
+        // Use 17 for implementations that dynamically allocate a container proxy
+        // and grow by 1.5x (1 for proxy + 1 + 2 + 3 + 4 + 6).
+        std::vector<MoveOnly, limited_allocator<MoveOnly, 17> > c;
+        c.push_back(MoveOnly(0));
+        assert(c.size() == 1);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == MoveOnly(j));
+        c.push_back(MoveOnly(1));
+        assert(c.size() == 2);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == MoveOnly(j));
+        c.push_back(MoveOnly(2));
+        assert(c.size() == 3);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == MoveOnly(j));
+        c.push_back(MoveOnly(3));
+        assert(c.size() == 4);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == MoveOnly(j));
+        c.push_back(MoveOnly(4));
+        assert(c.size() == 5);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == MoveOnly(j));
+    }
+    {
+        std::vector<MoveOnly, min_allocator<MoveOnly>> c;
+        c.push_back(MoveOnly(0));
+        assert(c.size() == 1);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == MoveOnly(j));
+        c.push_back(MoveOnly(1));
+        assert(c.size() == 2);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == MoveOnly(j));
+        c.push_back(MoveOnly(2));
+        assert(c.size() == 3);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == MoveOnly(j));
+        c.push_back(MoveOnly(3));
+        assert(c.size() == 4);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == MoveOnly(j));
+        c.push_back(MoveOnly(4));
+        assert(c.size() == 5);
+        assert(is_contiguous_container_asan_correct(c));
+        for (int j = 0; static_cast<std::size_t>(j) < c.size(); ++j)
+            assert(c[j] == MoveOnly(j));
+    }
+}

--- a/tests/external/libcxx/vector/vector.special/swap.pass.cpp
+++ b/tests/external/libcxx/vector/vector.special/swap.pass.cpp
@@ -1,0 +1,182 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// template <class T, class Alloc>
+//   void swap(vector<T,Alloc>& x, vector<T,Alloc>& y);
+
+#include <vector>
+#include <iterator>
+#include <cassert>
+#include "test_allocator.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+int main()
+{
+    {
+        int a1[] = {1, 3, 7, 9, 10};
+        int a2[] = {0, 2, 4, 5, 6, 8, 11};
+        std::vector<int> c1(a1, a1+sizeof(a1)/sizeof(a1[0]));
+        std::vector<int> c2(a2, a2+sizeof(a2)/sizeof(a2[0]));
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+        swap(c1, c2);
+        assert(c1 == std::vector<int>(a2, a2+sizeof(a2)/sizeof(a2[0])));
+        assert(c2 == std::vector<int>(a1, a1+sizeof(a1)/sizeof(a1[0])));
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+    }
+    {
+        int a1[] = {1, 3, 7, 9, 10};
+        int a2[] = {0, 2, 4, 5, 6, 8, 11};
+        std::vector<int> c1(a1, a1);
+        std::vector<int> c2(a2, a2+sizeof(a2)/sizeof(a2[0]));
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+        swap(c1, c2);
+        assert(c1 == std::vector<int>(a2, a2+sizeof(a2)/sizeof(a2[0])));
+        assert(c2.empty());
+        assert(distance(c2.begin(), c2.end()) == 0);
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+    }
+    {
+        int a1[] = {1, 3, 7, 9, 10};
+        int a2[] = {0, 2, 4, 5, 6, 8, 11};
+        std::vector<int> c1(a1, a1+sizeof(a1)/sizeof(a1[0]));
+        std::vector<int> c2(a2, a2);
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+        swap(c1, c2);
+        assert(c1.empty());
+        assert(distance(c1.begin(), c1.end()) == 0);
+        assert(c2 == std::vector<int>(a1, a1+sizeof(a1)/sizeof(a1[0])));
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+    }
+    {
+        int a1[] = {1, 3, 7, 9, 10};
+        int a2[] = {0, 2, 4, 5, 6, 8, 11};
+        std::vector<int> c1(a1, a1);
+        std::vector<int> c2(a2, a2);
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+        swap(c1, c2);
+        assert(c1.empty());
+        assert(distance(c1.begin(), c1.end()) == 0);
+        assert(c2.empty());
+        assert(distance(c2.begin(), c2.end()) == 0);
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+    }
+    {
+        int a1[] = {1, 3, 7, 9, 10};
+        int a2[] = {0, 2, 4, 5, 6, 8, 11};
+        typedef test_allocator<int> A;
+        std::vector<int, A> c1(a1, a1+sizeof(a1)/sizeof(a1[0]), A(1, 1));
+        std::vector<int, A> c2(a2, a2+sizeof(a2)/sizeof(a2[0]), A(1, 2));
+        swap(c1, c2);
+        assert((c1 == std::vector<int, A>(a2, a2+sizeof(a2)/sizeof(a2[0]))));
+        assert(c1.get_allocator().get_id() == 1);
+        assert((c2 == std::vector<int, A>(a1, a1+sizeof(a1)/sizeof(a1[0]))));
+        assert(c2.get_allocator().get_id() == 2);
+    }
+    {
+        int a1[] = {1, 3, 7, 9, 10};
+        int a2[] = {0, 2, 4, 5, 6, 8, 11};
+        typedef other_allocator<int> A;
+        std::vector<int, A> c1(a1, a1+sizeof(a1)/sizeof(a1[0]), A(1));
+        std::vector<int, A> c2(a2, a2+sizeof(a2)/sizeof(a2[0]), A(2));
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+        swap(c1, c2);
+        assert((c1 == std::vector<int, A>(a2, a2+sizeof(a2)/sizeof(a2[0]))));
+        assert(c1.get_allocator() == A(2));
+        assert((c2 == std::vector<int, A>(a1, a1+sizeof(a1)/sizeof(a1[0]))));
+        assert(c2.get_allocator() == A(1));
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+    }
+#if TEST_STD_VER >= 11
+    {
+        int a1[] = {1, 3, 7, 9, 10};
+        int a2[] = {0, 2, 4, 5, 6, 8, 11};
+        std::vector<int, min_allocator<int>> c1(a1, a1+sizeof(a1)/sizeof(a1[0]));
+        std::vector<int, min_allocator<int>> c2(a2, a2+sizeof(a2)/sizeof(a2[0]));
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+        swap(c1, c2);
+        assert((c1 == std::vector<int, min_allocator<int>>(a2, a2+sizeof(a2)/sizeof(a2[0]))));
+        assert((c2 == std::vector<int, min_allocator<int>>(a1, a1+sizeof(a1)/sizeof(a1[0]))));
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+    }
+    {
+        int a1[] = {1, 3, 7, 9, 10};
+        int a2[] = {0, 2, 4, 5, 6, 8, 11};
+        std::vector<int, min_allocator<int>> c1(a1, a1);
+        std::vector<int, min_allocator<int>> c2(a2, a2+sizeof(a2)/sizeof(a2[0]));
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+        swap(c1, c2);
+        assert((c1 == std::vector<int, min_allocator<int>>(a2, a2+sizeof(a2)/sizeof(a2[0]))));
+        assert(c2.empty());
+        assert(distance(c2.begin(), c2.end()) == 0);
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+    }
+    {
+        int a1[] = {1, 3, 7, 9, 10};
+        int a2[] = {0, 2, 4, 5, 6, 8, 11};
+        std::vector<int, min_allocator<int>> c1(a1, a1+sizeof(a1)/sizeof(a1[0]));
+        std::vector<int, min_allocator<int>> c2(a2, a2);
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+        swap(c1, c2);
+        assert(c1.empty());
+        assert(distance(c1.begin(), c1.end()) == 0);
+        assert((c2 == std::vector<int, min_allocator<int>>(a1, a1+sizeof(a1)/sizeof(a1[0]))));
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+    }
+    {
+        int a1[] = {1, 3, 7, 9, 10};
+        int a2[] = {0, 2, 4, 5, 6, 8, 11};
+        std::vector<int, min_allocator<int>> c1(a1, a1);
+        std::vector<int, min_allocator<int>> c2(a2, a2);
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+        swap(c1, c2);
+        assert(c1.empty());
+        assert(distance(c1.begin(), c1.end()) == 0);
+        assert(c2.empty());
+        assert(distance(c2.begin(), c2.end()) == 0);
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+    }
+    {
+        int a1[] = {1, 3, 7, 9, 10};
+        int a2[] = {0, 2, 4, 5, 6, 8, 11};
+        typedef min_allocator<int> A;
+        std::vector<int, A> c1(a1, a1+sizeof(a1)/sizeof(a1[0]), A());
+        std::vector<int, A> c2(a2, a2+sizeof(a2)/sizeof(a2[0]), A());
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+        swap(c1, c2);
+        assert((c1 == std::vector<int, A>(a2, a2+sizeof(a2)/sizeof(a2[0]))));
+        assert(c1.get_allocator() == A());
+        assert((c2 == std::vector<int, A>(a1, a1+sizeof(a1)/sizeof(a1[0]))));
+        assert(c2.get_allocator() == A());
+        assert(is_contiguous_container_asan_correct(c1));
+        assert(is_contiguous_container_asan_correct(c2));
+    }
+#endif
+}

--- a/tests/external/libcxx/vector/vector.special/swap_noexcept.pass.cpp
+++ b/tests/external/libcxx/vector/vector.special/swap_noexcept.pass.cpp
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <vector>
+
+// void swap(vector& c)
+//     noexcept(!allocator_type::propagate_on_container_swap::value ||
+//              __is_nothrow_swappable<allocator_type>::value);
+//
+//  In C++17, the standard says that swap shall have:
+//     noexcept(allocator_traits<Allocator>::propagate_on_container_swap::value ||
+//              allocator_traits<Allocator>::is_always_equal::value);
+
+// This tests a conforming extension
+
+#include <vector>
+#include <utility>
+#include <cassert>
+
+#include "test_macros.h"
+#include "MoveOnly.h"
+#include "test_allocator.h"
+
+template <class T>
+struct some_alloc
+{
+    typedef T value_type;
+
+    some_alloc() {}
+    some_alloc(const some_alloc&);
+    void deallocate(void*, unsigned) {}
+
+    typedef std::true_type propagate_on_container_swap;
+};
+
+template <class T>
+struct some_alloc2
+{
+    typedef T value_type;
+
+    some_alloc2() {}
+    some_alloc2(const some_alloc2&);
+    void deallocate(void*, unsigned) {}
+
+    typedef std::false_type propagate_on_container_swap;
+    typedef std::true_type is_always_equal;
+};
+
+int main()
+{
+    {
+        typedef std::vector<MoveOnly> C;
+        static_assert(noexcept(swap(std::declval<C&>(), std::declval<C&>())), "");
+    }
+#if defined(_LIBCPP_VERSION)
+    {
+        typedef std::vector<MoveOnly, test_allocator<MoveOnly>> C;
+        static_assert(noexcept(swap(std::declval<C&>(), std::declval<C&>())), "");
+    }
+#endif // _LIBCPP_VERSION
+    {
+        typedef std::vector<MoveOnly, other_allocator<MoveOnly>> C;
+        static_assert(noexcept(swap(std::declval<C&>(), std::declval<C&>())), "");
+    }
+    {
+        typedef std::vector<MoveOnly, some_alloc<MoveOnly>> C;
+#if TEST_STD_VER >= 14
+    //  In C++14, if POCS is set, swapping the allocator is required not to throw
+        static_assert( noexcept(swap(std::declval<C&>(), std::declval<C&>())), "");
+#else
+        static_assert(!noexcept(swap(std::declval<C&>(), std::declval<C&>())), "");
+#endif
+    }
+#if TEST_STD_VER >= 14
+    {
+        typedef std::vector<MoveOnly, some_alloc2<MoveOnly>> C;
+    //  if the allocators are always equal, then the swap can be noexcept
+        static_assert( noexcept(swap(std::declval<C&>(), std::declval<C&>())), "");
+    }
+#endif
+}


### PR DESCRIPTION
Copy remaining libcxx vector tests.
Those test should be ported to test persistent vetctor.
Imported from llvm-mirror/libcxx@5ae92f0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/156)
<!-- Reviewable:end -->
