### PR TITLE
Introduce flag parameter to make_persistent(atomic)

### DIFF
--- a/include/libpmemobj++/allocation_flag.hpp
+++ b/include/libpmemobj++/allocation_flag.hpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * allocation_flag - defines flags which can be passed to make_persistent
+ */
+
+#ifndef LIBPMEMOBJ_CPP_ALLOCATION_FLAG_HPP
+#define LIBPMEMOBJ_CPP_ALLOCATION_FLAG_HPP
+
+#include <libpmemobj/base.h>
+
+namespace pmem
+{
+
+namespace obj
+{
+
+/**
+ * Type of flag which can be passed to make_persistent.
+ *
+ * Allowed flags are:
+ * - allocation_flag::class_id(id) - allocate the object from the allocation
+ *   class with id equal to id.
+ * - allocation_flag::no_flush() - skip flush on commit.
+ * - allocation_flag::none() - do not change allocator behaviour.
+ *
+ * Flags can be combined with each other using operator|()
+ */
+struct allocation_flag {
+	allocation_flag() = delete;
+
+	/**
+	 * Allocate the object from the allocation class with id equal to id.
+	 */
+	static allocation_flag
+	class_id(uint64_t id)
+	{
+		return {POBJ_CLASS_ID(id)};
+	}
+
+	/**
+	 * Skip flush on commit.
+	 */
+	static allocation_flag
+	no_flush()
+	{
+		return {POBJ_XALLOC_NO_FLUSH};
+	}
+
+	/**
+	 * Do not change allocator behaviour.
+	 */
+	static allocation_flag
+	none()
+	{
+		return {0};
+	}
+
+	/**
+	 * Check if flag is set.
+	 */
+	bool
+	is_set(const allocation_flag &rhs)
+	{
+		return value & rhs.value;
+	}
+
+	allocation_flag
+	operator|(const allocation_flag &rhs)
+	{
+		return {value | rhs.value};
+	}
+
+	uint64_t value;
+};
+
+/**
+ * Type of flag which can be passed to make_persistent_atomic.
+ *
+ * Allowed flags are:
+ * - allocation_flag_atomic::class_id(id) - allocate the object from the
+ *   allocation class with id equal to id.
+ * - allocation_flag_atomic::none() - do not change allocator behaviour.
+ *
+ * Flags can be combined with each other using operator|()
+ */
+struct allocation_flag_atomic {
+	allocation_flag_atomic() = delete;
+
+	/**
+	 * Allocate the object from the allocation class with id equal to id.
+	 */
+	static allocation_flag_atomic
+	class_id(uint64_t id)
+	{
+		return {POBJ_CLASS_ID(id)};
+	}
+
+	/**
+	 * Do not change allocator behaviour.
+	 */
+	static allocation_flag_atomic
+	none()
+	{
+		return {0};
+	}
+
+	/**
+	 * Check if flag is set.
+	 */
+	bool
+	is_set(const allocation_flag_atomic &rhs)
+	{
+		return value & rhs.value;
+	}
+
+	allocation_flag_atomic
+	operator|(const allocation_flag_atomic &rhs)
+	{
+		return {value | rhs.value};
+	}
+
+	uint64_t value;
+};
+
+} /* namespace obj */
+
+} /* namespace pmem */
+
+#endif /* LIBPMEMOBJ_CPP_ALLOCATION_FLAG_HPP */

--- a/include/libpmemobj++/detail/variadic.hpp
+++ b/include/libpmemobj++/detail/variadic.hpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * Helper functionality for handling variadic templates.
+ */
+
+#ifndef LIBPMEMOBJ_CPP_VARIADIC_HPP
+#define LIBPMEMOBJ_CPP_VARIADIC_HPP
+
+namespace pmem
+{
+
+namespace detail
+{
+
+/*
+ * Checks if T is the same type as first type in Args.
+ * General case (for sizeof...(Args) == 0).
+ */
+template <class T, class... Args>
+struct is_first_arg_same {
+	static constexpr bool value = false;
+};
+
+/*
+ * Checks if T is the same type as first type in Args.
+ * Specialization (for sizeof...(Args) > 0).
+ */
+template <class T, class FirstArg, class... Args>
+struct is_first_arg_same<T, FirstArg, Args...> {
+	static constexpr bool value = std::is_same<T, FirstArg>::value;
+};
+
+} /* namespace detail */
+
+} /* namespace pmem */
+
+#endif /* LIBPMEMOBJ_CPP_VARIADIC_HPP */

--- a/include/libpmemobj++/make_persistent.hpp
+++ b/include/libpmemobj++/make_persistent.hpp
@@ -109,8 +109,9 @@ make_persistent(allocation_flag flag, Args &&... args)
  * @throw rethrow exception from T constructor
  */
 template <typename T, typename... Args>
-typename std::enable_if<!detail::is_first_arg_same<allocation_flag, Args...>,
-			typename detail::pp_if_not_array<T>::type>::type
+typename std::enable_if<
+	!detail::is_first_arg_same<allocation_flag, Args...>::value,
+	typename detail::pp_if_not_array<T>::type>::type
 make_persistent(Args &&... args)
 {
 	return make_persistent<T>(allocation_flag::none(),

--- a/include/libpmemobj++/make_persistent.hpp
+++ b/include/libpmemobj++/make_persistent.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,10 +40,12 @@
 #ifndef LIBPMEMOBJ_CPP_MAKE_PERSISTENT_HPP
 #define LIBPMEMOBJ_CPP_MAKE_PERSISTENT_HPP
 
+#include <libpmemobj++/allocation_flag.hpp>
 #include <libpmemobj++/detail/check_persistent_ptr_array.hpp>
 #include <libpmemobj++/detail/common.hpp>
 #include <libpmemobj++/detail/life.hpp>
 #include <libpmemobj++/detail/pexceptions.hpp>
+#include <libpmemobj++/detail/variadic.hpp>
 #include <libpmemobj/tx_base.h>
 
 #include <new>
@@ -61,6 +63,7 @@ namespace obj
  * This function can be used to *transactionally* allocate an object.
  * Cannot be used for array types.
  *
+ * @param[in] flag affects behaviour of allocator
  * @param[in,out] args a list of parameters passed to the constructor.
  *
  * @return persistent_ptr<T> on success
@@ -72,14 +75,14 @@ namespace obj
  */
 template <typename T, typename... Args>
 typename detail::pp_if_not_array<T>::type
-make_persistent(Args &&... args)
+make_persistent(allocation_flag flag, Args &&... args)
 {
 	if (pmemobj_tx_stage() != TX_STAGE_WORK)
 		throw transaction_scope_error(
 			"refusing to allocate memory outside of transaction scope");
 
 	persistent_ptr<T> ptr =
-		pmemobj_tx_alloc(sizeof(T), detail::type_num<T>());
+		pmemobj_tx_xalloc(sizeof(T), detail::type_num<T>(), flag.value);
 
 	if (ptr == nullptr)
 		throw transaction_alloc_error(
@@ -88,6 +91,30 @@ make_persistent(Args &&... args)
 	detail::create<T, Args...>(ptr.get(), std::forward<Args>(args)...);
 
 	return ptr;
+}
+
+/**
+ * Transactionally allocate and construct an object of type T.
+ *
+ * This function can be used to *transactionally* allocate an object.
+ * Cannot be used for array types.
+ *
+ * @param[in,out] args a list of parameters passed to the constructor.
+ *
+ * @return persistent_ptr<T> on success
+ *
+ * @throw transaction_scope_error if called outside of an active
+ * transaction
+ * @throw transaction_alloc_error on transactional allocation failure.
+ * @throw rethrow exception from T constructor
+ */
+template <typename T, typename... Args>
+typename std::enable_if<!detail::is_first_arg_same<allocation_flag, Args...>,
+			typename detail::pp_if_not_array<T>::type>::type
+make_persistent(Args &&... args)
+{
+	return make_persistent<T>(allocation_flag::none(),
+				  std::forward<Args>(args)...);
 }
 
 /**

--- a/include/libpmemobj++/make_persistent_array.hpp
+++ b/include/libpmemobj++/make_persistent_array.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,11 +40,13 @@
 #ifndef LIBPMEMOBJ_CPP_MAKE_PERSISTENT_ARRAY_HPP
 #define LIBPMEMOBJ_CPP_MAKE_PERSISTENT_ARRAY_HPP
 
+#include <libpmemobj++/allocation_flag.hpp>
 #include <libpmemobj++/detail/array_traits.hpp>
 #include <libpmemobj++/detail/check_persistent_ptr_array.hpp>
 #include <libpmemobj++/detail/common.hpp>
 #include <libpmemobj++/detail/life.hpp>
 #include <libpmemobj++/detail/pexceptions.hpp>
+#include <libpmemobj++/detail/variadic.hpp>
 #include <libpmemobj/tx_base.h>
 
 #include <cassert>
@@ -63,6 +65,7 @@ namespace obj
  * This overload only participates in overload resolution if T is an array.
  *
  * @param[in] N the number of array elements.
+ * @param[in] flag affects behaviour of allocator
  *
  * @return persistent_ptr<T[]> on success
  *
@@ -73,7 +76,7 @@ namespace obj
  */
 template <typename T>
 typename detail::pp_if_array<T>::type
-make_persistent(std::size_t N)
+make_persistent(std::size_t N, allocation_flag flag = allocation_flag::none())
 {
 	typedef typename detail::pp_array_type<T>::type I;
 
@@ -89,8 +92,8 @@ make_persistent(std::size_t N)
 		throw transaction_scope_error(
 			"refusing to allocate memory outside of transaction scope");
 
-	persistent_ptr<T> ptr =
-		pmemobj_tx_alloc(sizeof(I) * N, detail::type_num<I>());
+	persistent_ptr<T> ptr = pmemobj_tx_xalloc(
+		sizeof(I) * N, detail::type_num<I>(), flag.value);
 
 	if (ptr == nullptr)
 		throw transaction_alloc_error(
@@ -116,6 +119,8 @@ make_persistent(std::size_t N)
  * This function can be used to *transactionally* allocate an array.
  * This overload only participates in overload resolution if T is an array.
  *
+ * @param[in] flag affects behaviour of allocator
+ *
  * @return persistent_ptr<T[N]> on success
  *
  * @throw transaction_scope_error if called outside of an active
@@ -125,7 +130,7 @@ make_persistent(std::size_t N)
  */
 template <typename T>
 typename detail::pp_if_size_array<T>::type
-make_persistent()
+make_persistent(allocation_flag flag = allocation_flag::none())
 {
 	typedef typename detail::pp_array_type<T>::type I;
 	enum { N = detail::pp_array_elems<T>::elems };
@@ -134,8 +139,8 @@ make_persistent()
 		throw transaction_scope_error(
 			"refusing to allocate memory outside of transaction scope");
 
-	persistent_ptr<T> ptr =
-		pmemobj_tx_alloc(sizeof(I) * N, detail::type_num<I>());
+	persistent_ptr<T> ptr = pmemobj_tx_xalloc(
+		sizeof(I) * N, detail::type_num<I>(), flag.value);
 
 	if (ptr == nullptr)
 		throw transaction_alloc_error(

--- a/include/libpmemobj++/make_persistent_atomic.hpp
+++ b/include/libpmemobj++/make_persistent_atomic.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,10 +40,12 @@
 #ifndef LIBPMEMOBJ_CPP_MAKE_PERSISTENT_ATOMIC_HPP
 #define LIBPMEMOBJ_CPP_MAKE_PERSISTENT_ATOMIC_HPP
 
+#include <libpmemobj++/allocation_flag.hpp>
 #include <libpmemobj++/detail/check_persistent_ptr_array.hpp>
 #include <libpmemobj++/detail/common.hpp>
 #include <libpmemobj++/detail/make_atomic_impl.hpp>
 #include <libpmemobj++/detail/pexceptions.hpp>
+#include <libpmemobj++/detail/variadic.hpp>
 #include <libpmemobj++/pool.hpp>
 #include <libpmemobj/atomic_base.h>
 
@@ -65,6 +67,7 @@ namespace obj
  * @param[in,out] pool the pool from which the object will be allocated.
  * @param[in,out] ptr the persistent pointer to which the allocation
  * will take place.
+ * @param[in] flag affects behaviour of allocator
  * @param[in] args variadic function parameter containing all parameters
  * passed to the objects constructor.
  *
@@ -74,16 +77,42 @@ template <typename T, typename... Args>
 void
 make_persistent_atomic(pool_base &pool,
 		       typename detail::pp_if_not_array<T>::type &ptr,
-		       Args &&... args)
+		       allocation_flag_atomic flag, Args &&... args)
 {
 	std::tuple<Args &...> arg_pack{args...};
-	auto ret = pmemobj_alloc(pool.handle(), ptr.raw_ptr(), sizeof(T),
-				 detail::type_num<T>(),
-				 &detail::obj_constructor<T, Args...>,
-				 static_cast<void *>(&arg_pack));
+	auto ret = pmemobj_xalloc(pool.handle(), ptr.raw_ptr(), sizeof(T),
+				  detail::type_num<T>(), flag.value,
+				  &detail::obj_constructor<T, Args...>,
+				  static_cast<void *>(&arg_pack));
 
 	if (ret != 0)
 		throw std::bad_alloc();
+}
+
+/**
+ * Atomically allocate and construct an object.
+ *
+ * Constructor parameters are passed through variadic parameters. Do *NOT* use
+ * this inside transactions, as it might lead to undefined behavior in the
+ * presence of transaction aborts.
+ *
+ * @param[in,out] pool the pool from which the object will be allocated.
+ * @param[in,out] ptr the persistent pointer to which the allocation
+ * will take place.
+ * @param[in] args variadic function parameter containing all parameters
+ * passed to the objects constructor.
+ *
+ * @throw std::bad_alloc on allocation failure.
+ */
+template <typename T, typename... Args>
+typename std::enable_if<
+	!detail::is_first_arg_same<allocation_flag_atomic, Args...>>::type
+make_persistent_atomic(pool_base &pool,
+		       typename detail::pp_if_not_array<T>::type &ptr,
+		       Args &&... args)
+{
+	make_persistent_atomic<T>(pool, ptr, allocation_flag_atomic::none(),
+				  std::forward<Args>(args)...);
 }
 
 /**

--- a/include/libpmemobj++/make_persistent_atomic.hpp
+++ b/include/libpmemobj++/make_persistent_atomic.hpp
@@ -105,8 +105,8 @@ make_persistent_atomic(pool_base &pool,
  * @throw std::bad_alloc on allocation failure.
  */
 template <typename T, typename... Args>
-typename std::enable_if<
-	!detail::is_first_arg_same<allocation_flag_atomic, Args...>>::type
+typename std::enable_if<!detail::is_first_arg_same<allocation_flag_atomic,
+						   Args...>::value>::type
 make_persistent_atomic(pool_base &pool,
 		       typename detail::pp_if_not_array<T>::type &ptr,
 		       Args &&... args)

--- a/tests/make_persistent_array/make_persistent_array.cpp
+++ b/tests/make_persistent_array/make_persistent_array.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,11 +36,13 @@
 
 #include "unittest.hpp"
 
+#include <iostream>
 #include <libpmemobj++/make_persistent_array.hpp>
 #include <libpmemobj++/p.hpp>
 #include <libpmemobj++/persistent_ptr.hpp>
 #include <libpmemobj++/pool.hpp>
 #include <libpmemobj++/transaction.hpp>
+#include <libpmemobj/ctl.h>
 
 #define LAYOUT "cpp"
 
@@ -371,6 +373,64 @@ test_exceptions_handling_sized(nvobj::pool<struct root> &pop)
 	} catch (int &e) {
 		UT_ASSERT(e == struct_throwing::magic_number);
 	}
+
+	try {
+		nvobj::transaction::run(pop, [&] {
+			nvobj::delete_persistent<foo[10]>(r->pfoo_sized);
+			r->pfoo_sized = nullptr;
+
+			nvobj::delete_persistent<foo[]>(r->pfoo, 10);
+			r->pfoo = nullptr;
+		});
+	} catch (std::exception &e) {
+		UT_FATALexc(e);
+	}
+}
+
+/*
+ * test_flags -- (internal) test proper handling of flags
+ */
+void
+test_flags(nvobj::pool<struct root> &pop)
+{
+	nvobj::persistent_ptr<root> r = pop.root();
+
+	auto alloc_class = pop.ctl_set<struct pobj_alloc_class_desc>(
+		"heap.alloc_class.new.desc",
+		{sizeof(foo), 0, 100, POBJ_HEADER_COMPACT, 0});
+
+	try {
+		nvobj::transaction::run(pop, [&] {
+			UT_ASSERT(r->pfoo_sized == nullptr);
+			r->pfoo_sized = nvobj::make_persistent<foo[10]>(
+				nvobj::allocation_flag::class_id(
+					alloc_class.class_id));
+
+			UT_ASSERT(r->pfoo == nullptr);
+			r->pfoo = nvobj::make_persistent<foo[]>(
+				10,
+				nvobj::allocation_flag::class_id(
+					alloc_class.class_id));
+		});
+	} catch (std::exception &e) {
+		UT_FATALexc(e);
+	}
+
+	UT_ASSERTeq(pmemobj_alloc_usable_size(r->pfoo.raw()), sizeof(foo) * 10);
+	UT_ASSERTeq(pmemobj_alloc_usable_size(r->pfoo_sized.raw()),
+		    sizeof(foo) * 10);
+
+	try {
+		nvobj::transaction::run(pop, [&] {
+			nvobj::delete_persistent<foo[10]>(r->pfoo_sized);
+			r->pfoo_sized = nullptr;
+
+			nvobj::delete_persistent<foo[]>(r->pfoo, 10);
+			r->pfoo = nullptr;
+		});
+	} catch (std::exception &e) {
+		UT_FATALexc(e);
+	}
 }
 }
 
@@ -398,6 +458,7 @@ main(int argc, char *argv[])
 	test_abort_revert(pop);
 	test_exceptions_handling(pop);
 	test_exceptions_handling_sized(pop);
+	test_flags(pop);
 
 	pop.close();
 

--- a/tests/make_persistent_atomic/make_persistent_atomic.cpp
+++ b/tests/make_persistent_atomic/make_persistent_atomic.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,6 +41,7 @@
 #include <libpmemobj++/p.hpp>
 #include <libpmemobj++/persistent_ptr.hpp>
 #include <libpmemobj++/pool.hpp>
+#include <libpmemobj/ctl.h>
 
 #define LAYOUT "cpp"
 
@@ -142,6 +143,56 @@ test_delete_null(nvobj::pool<struct root> &pop)
 		UT_ASSERT(0);
 	}
 }
+
+/*
+ * test_flags -- (internal) test proper handling of flags
+ */
+void
+test_flags(nvobj::pool<struct root> &pop)
+{
+	nvobj::persistent_ptr<root> r = pop.root();
+
+	auto alloc_class = pop.ctl_set<struct pobj_alloc_class_desc>(
+		"heap.alloc_class.new.desc",
+		{sizeof(foo) + 16, 0, 200, POBJ_HEADER_COMPACT, 0});
+
+	try {
+		nvobj::make_persistent_atomic<foo>(
+			pop, r->pfoo,
+			nvobj::allocation_flag_atomic::class_id(
+				alloc_class.class_id));
+	} catch (std::exception &e) {
+		UT_FATALexc(e);
+	}
+
+	UT_ASSERTeq(pmemobj_alloc_usable_size(r->pfoo.raw()), sizeof(foo));
+
+	try {
+		nvobj::delete_persistent_atomic<foo>(r->pfoo);
+	} catch (std::exception &e) {
+		UT_FATALexc(e);
+	}
+
+	try {
+		nvobj::make_persistent_atomic<foo>(
+			pop, r->pfoo,
+			nvobj::allocation_flag_atomic::class_id(
+				alloc_class.class_id),
+			1, 2);
+	} catch (std::exception &e) {
+		UT_FATALexc(e);
+	}
+
+	r->pfoo->check_foo(1, 2);
+
+	UT_ASSERTeq(pmemobj_alloc_usable_size(r->pfoo.raw()), sizeof(foo));
+
+	try {
+		nvobj::delete_persistent_atomic<foo>(r->pfoo);
+	} catch (std::exception &e) {
+		UT_FATALexc(e);
+	}
+}
 }
 
 int
@@ -166,6 +217,7 @@ main(int argc, char *argv[])
 	test_make_no_args(pop);
 	test_make_args(pop);
 	test_delete_null(pop);
+	test_flags(pop);
 
 	pop.close();
 


### PR DESCRIPTION
This patch adds flag argument to make_persistent in following way:
* for non array types, allocation flag is expected as first argument: if first argument is of type `allocation_flag` then it is treated as flag and passed to pmemobj_tx_xalloc, if it's type is something else make_persistent behaves normally (e.g. treats it as argument to the constructor).
* for array types, allocation flag is last argument (`0` by default)

API for make_persistent_atomic is analogous.

We could also not rely on flag to be of type `allocation_flag` and instead create additional function `xmake_persistent(allocation_flag, args...)` but I think it's better to stay with just `make_persistent`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/157)
<!-- Reviewable:end -->
