### PR TITLE
Fix gcc trivially copyable

### DIFF
--- a/include/libpmemobj++/detail/common.hpp
+++ b/include/libpmemobj++/detail/common.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,6 +48,19 @@
 #define POBJ_CPP_DEPRECATED __declspec(deprecated)
 #else
 #define POBJ_CPP_DEPRECATED
+#endif
+
+/*
+ * Workaround for missing "is_trivially_copyable" in gcc < 5.0.
+ * Be aware of a difference between __has_trivial_copy and is_trivially_copyable
+ * e.g. for deleted copy constructors __has_trivial_copy(A) returns 1 in clang
+ * and 0 in gcc. It means that for gcc < 5 IS_TRIVIALLY_COPYABLE is more
+ * restrictive than is_trivially_copyable.
+ */
+#if !defined(__clang__) && defined(__GNUG__) && __GNUC__ < 5
+#define IS_TRIVIALLY_COPYABLE(T) __has_trivial_copy(T)
+#else
+#define IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value
 #endif
 
 namespace pmem

--- a/include/libpmemobj++/transaction.hpp
+++ b/include/libpmemobj++/transaction.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -455,7 +455,7 @@ public:
 	 * supplied block of memory has to be within the pool registered in the
 	 * transaction. This function must be called during transaction. This
 	 * overload only participates in overload resolution of function
-	 * template if T satisfies requirements of std::is_trivially_copyable.
+	 * template if T satisfies requirements of IS_TRIVIALLY_COPYABLE macro.
 	 *
 	 * @param[in] addr pointer to the first object to be snapshotted.
 	 * @param[in] num number of elements to be snapshotted.
@@ -466,8 +466,8 @@ public:
 	 * wasn't called during transaction.
 	 */
 	template <typename T,
-		  typename std::enable_if<std::is_trivially_copyable<T>::value,
-					  T>::type * = nullptr>
+		  typename std::enable_if<IS_TRIVIALLY_COPYABLE(T), T>::type * =
+			  nullptr>
 	static void
 	snapshot(const T *addr, size_t num = 1)
 	{


### PR DESCRIPTION
 Workaround for missing "is_trivially_copyable" in gcc < 5.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/162)
<!-- Reviewable:end -->
