### PR TITLE
vector: change capacity to fit size (in ctors)

### DIFF
--- a/include/libpmemobj++/experimental/vector.hpp
+++ b/include/libpmemobj++/experimental/vector.hpp
@@ -248,7 +248,7 @@ vector<T>::vector()
  * @pre must be called in transaction scope.
  *
  * @post size() == count
- * @post capacity() == detail::next_pow_2(size())
+ * @post capacity() == size()
  *
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for underlying
@@ -269,7 +269,7 @@ vector<T>::vector(size_type count, const value_type &value)
 
 	_data = nullptr;
 	_size = 0;
-	_alloc(detail::next_pow_2(count));
+	_alloc(count);
 	_grow(count, value);
 }
 
@@ -281,7 +281,7 @@ vector<T>::vector(size_type count, const value_type &value)
  * @pre must be called in transaction scope.
  *
  * @post size() == count
- * @post capacity() == detail::next_pow_2(_size)
+ * @post capacity() == size()
  *
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for underlying
@@ -302,7 +302,7 @@ vector<T>::vector(size_type count)
 
 	_data = nullptr;
 	_size = 0;
-	_alloc(detail::next_pow_2(count));
+	_alloc(count);
 	// XXX: after "capacity" methods will be merged, _grow() overload
 	// without parameters will be available. After that, following lines
 	// should be replaced with _grow()
@@ -326,7 +326,7 @@ vector<T>::vector(size_type count)
  * @pre must be called in transaction scope.
  *
  * @post size() == std::distance(first, last)
- * @post capacity() == detail::next_pow_2(size())
+ * @post capacity() == size()
  *
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for underlying
@@ -355,8 +355,7 @@ vector<T>::vector(InputIt first, InputIt last)
 
 	_data = nullptr;
 	_size = 0;
-	_alloc(detail::next_pow_2(
-		static_cast<size_type>(std::distance(first, last))));
+	_alloc(static_cast<size_type>(std::distance(first, last)));
 	_grow(first, last);
 }
 
@@ -390,7 +389,7 @@ vector<T>::vector(const vector &other)
 
 	_data = nullptr;
 	_size = 0;
-	_alloc(other._capacity);
+	_alloc(other.capacity());
 	_grow(other.begin(), other.end());
 }
 
@@ -424,8 +423,8 @@ vector<T>::vector(vector &&other)
 			"Move constructor called out of transaction scope.");
 
 	_data = other._data;
-	_capacity = other._capacity;
-	_size = other._size;
+	_capacity = other.capacity();
+	_size = other.size();
 	other._data = nullptr;
 	other._capacity = other._size = 0;
 }
@@ -438,7 +437,7 @@ vector<T>::vector(vector &&other)
  * @pre must be called in transaction scope.
  *
  * @post size() == init.size()
- * @post capacity() == detail::next_pow_2(size())
+ * @post capacity() == size()
  *
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for underlying

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -282,6 +282,11 @@ add_test_generic(vector_ctor_move none)
 add_test_generic(vector_ctor_move memcheck)
 add_test_generic(vector_ctor_move pmemcheck)
 
+build_test(vector_ctor_capacity vector_ctor_capacity/vector_ctor_capacity.cpp)
+add_test_generic(vector_ctor_capacity none)
+add_test_generic(vector_ctor_capacity memcheck)
+add_test_generic(vector_ctor_capacity pmemcheck)
+
 build_test(vector_dtor vector_dtor/vector_dtor.cpp)
 add_test_generic(vector_dtor none)
 add_test_generic(vector_dtor memcheck)

--- a/tests/vector_ctor_capacity/vector_ctor_capacity.cpp
+++ b/tests/vector_ctor_capacity/vector_ctor_capacity.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "unittest.hpp"
+
+#include <libpmemobj++/experimental/vector.hpp>
+#include <libpmemobj++/make_persistent.hpp>
+#include <libpmemobj++/pool.hpp>
+
+namespace nvobj = pmem::obj;
+namespace pmem_exp = nvobj::experimental;
+
+const static size_t pool_size = PMEMOBJ_MIN_POOL;
+const static size_t test_val1 = 123U;
+
+using vector_type = pmem_exp::vector<int>;
+
+struct root {
+	nvobj::persistent_ptr<vector_type> pptr1;
+	nvobj::persistent_ptr<vector_type> pptr2;
+};
+
+int
+main(int argc, char *argv[])
+{
+	START();
+
+	if (argc < 2) {
+		std::cerr << "usage: " << argv[0] << " file-name" << std::endl;
+		return 1;
+	}
+
+	auto path = argv[1];
+	auto pop = nvobj::pool<root>::create(path,
+					     "VectorTest: vector_ctor_capacity",
+					     pool_size, S_IWUSR | S_IRUSR);
+
+	auto r = pop.root();
+
+	try {
+		nvobj::transaction::run(pop, [&] {
+			r->pptr1 = nvobj::make_persistent<vector_type>();
+			/* test capacity of default-constructed vector */
+			UT_ASSERT(0 == r->pptr1->capacity());
+			nvobj::delete_persistent<vector_type>(r->pptr1);
+
+			r->pptr1 = nvobj::make_persistent<vector_type>(
+				test_val1, 0);
+			/* test capacity of size-value-constructed vector */
+			UT_ASSERT(test_val1 == r->pptr1->capacity());
+
+			r->pptr2 = nvobj::make_persistent<vector_type>(
+				r->pptr1->begin(), r->pptr1->end());
+			/* test capacity of iter-iter-constructed vector */
+			UT_ASSERT(test_val1 == r->pptr2->capacity());
+			nvobj::delete_persistent<vector_type>(r->pptr2);
+
+			r->pptr2 =
+				nvobj::make_persistent<vector_type>(*r->pptr1);
+			/* test capacity of copy-constructed vector */
+			UT_ASSERT(test_val1 == r->pptr2->capacity());
+			nvobj::delete_persistent<vector_type>(r->pptr2);
+
+			r->pptr2 = nvobj::make_persistent<vector_type>(
+				std::move(*r->pptr1));
+			/* test capacity of move-constructed vector */
+			UT_ASSERT(test_val1 == r->pptr2->capacity());
+			nvobj::delete_persistent<vector_type>(r->pptr2);
+			nvobj::delete_persistent<vector_type>(r->pptr1);
+		});
+	} catch (std::exception &e) {
+		UT_FATALexc(e);
+	}
+
+	pop.close();
+
+	return 0;
+}

--- a/tests/vector_ctor_capacity/vector_ctor_capacity_0.cmake
+++ b/tests/vector_ctor_capacity/vector_ctor_capacity_0.cmake
@@ -1,0 +1,38 @@
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+include(${SRC_DIR}/../helpers.cmake)
+
+setup()
+
+execute(${TEST_EXECUTABLE} ${DIR}/testfile)
+
+finish()


### PR DESCRIPTION
Capacity of newly-created vector is not specified by standard.
STL vector constructs a container with capacity equal to size. We should do the same in PMEM vector for compatibility reasons.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/163)
<!-- Reviewable:end -->
