### PR TITLE
 Disable some libcxx tests for old g++ compilers.

### DIFF
--- a/tests/ctest_helpers.cmake
+++ b/tests/ctest_helpers.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -90,6 +90,15 @@ else()
 	set(NO_CLANG_TEMPLATE_BUG TRUE)
 	set(NO_CHRONO_BUG TRUE)
 endif()
+
+set(CMAKE_REQUIRED_FLAGS "--std=c++${CMAKE_CXX_STANDARD} -c")
+CHECK_CXX_SOURCE_COMPILES(
+	"#include <cstddef>
+	int main() {
+	    std::max_align_t var;
+	    return 0;
+	}"
+	MAX_ALIGN_TYPE_EXISTS)
 
 set(CMAKE_REQUIRED_FLAGS ${SAVED_CMAKE_REQUIRED_FLAGS})
 set(CMAKE_REQUIRED_INCLUDES ${SAVED_CMAKE_REQUIRED_INCLUDES})

--- a/tests/external/CMakeLists.txt
+++ b/tests/external/CMakeLists.txt
@@ -86,8 +86,10 @@ add_test_default(array_indexing none)
 build_test(array_max_size libcxx/array/max_size.pass.cpp)
 add_test_default(array_max_size none)
 
-build_test(array_size_and_alignment libcxx/array/size_and_alignment.pass.cpp)
-add_test_default(array_size_and_alignment none)
+if (MAX_ALIGN_TYPE_EXISTS)
+	build_test(array_size_and_alignment libcxx/array/size_and_alignment.pass.cpp)
+	add_test_default(array_size_and_alignment none)
+endif()
 
 build_test(array_types libcxx/array/types.pass.cpp)
 add_test_default(array_types none)
@@ -107,11 +109,15 @@ add_test_default(array_cons_implicit_copy none)
 build_test(array_initializer_list libcxx/array/array.cons/initializer_list.pass.cpp)
 add_test_default(array_initializer_list none)
 
-build_test(array_data_const libcxx/array/array.data/data_const.pass.cpp)
-add_test_default(array_data_const none)
+if (MAX_ALIGN_TYPE_EXISTS)
+	build_test(array_data_const libcxx/array/array.data/data_const.pass.cpp)
+	add_test_default(array_data_const none)
+endif()
 
-build_test(array_data libcxx/array/array.data/data.pass.cpp)
-add_test_default(array_data none)
+if (MAX_ALIGN_TYPE_EXISTS)
+	build_test(array_data libcxx/array/array.data/data.pass.cpp)
+	add_test_default(array_data none)
+endif()
 
 add_test_expect_failure(array_fill libcxx/array/array.fill/fill.fail.cpp)
 

--- a/tests/external/libcxx/array/array.swap/swap.pass.cpp
+++ b/tests/external/libcxx/array/array.swap/swap.pass.cpp
@@ -37,8 +37,8 @@ private:
 struct Testcase1 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	C c1 = {1, 2, 3.5};
-	C c2 = {4, 5, 6.5};
+	C c1 = {{1, 2, 3.5}};
+	C c2 = {{4, 5, 6.5}};
 
 	void
 	run()
@@ -58,8 +58,8 @@ struct Testcase1 {
 struct Testcase2 {
 	typedef double T;
 	typedef pmem_exp::array<T, 3> C;
-	C c1 = {1, 2, 3.5};
-	C c2 = {4, 5, 6.5};
+	C c1 = {{1, 2, 3.5}};
+	C c2 = {{4, 5, 6.5}};
 
 	void
 	run()
@@ -79,8 +79,8 @@ struct Testcase2 {
 struct Testcase3 {
 	typedef double T;
 	typedef pmem_exp::array<T, 0> C;
-	C c1 = {};
-	C c2 = {};
+	C c1 = {{}};
+	C c2 = {{}};
 	void
 	run()
 	{
@@ -93,8 +93,8 @@ struct Testcase3 {
 struct Testcase4 {
 	typedef double T;
 	typedef pmem_exp::array<T, 0> C;
-	C c1 = {};
-	C c2 = {};
+	C c1 = {{}};
+	C c2 = {{}};
 
 	void
 	run()
@@ -108,8 +108,8 @@ struct Testcase4 {
 struct Testcase5 {
 	typedef NonSwappable T;
 	typedef pmem_exp::array<T, 0> C0;
-	C0 l = {};
-	C0 r = {};
+	C0 l = {{}};
+	C0 r = {{}};
 
 	void
 	run()


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/169)
<!-- Reviewable:end -->
