### PR TITLE
Change implementation of canonical iterators for tests.

### DIFF
--- a/tests/common/iterators_support.hpp
+++ b/tests/common/iterators_support.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Intel Corporation
+ * Copyright 2018-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,18 +50,19 @@ namespace test_support
  * - can be incremented
  * - can be dereferenced as an lvalue
  */
-template <typename T>
+template <typename It>
 class output_it {
 public:
 	using iterator_category = std::output_iterator_tag;
-	using value_type = T;
-	using difference_type = std::ptrdiff_t;
-	using pointer = T *;
-	using reference = T &;
+	using value_type = typename std::iterator_traits<It>::value_type;
+	using difference_type =
+		typename std::iterator_traits<It>::difference_type;
+	using pointer = typename std::iterator_traits<It>::pointer;
+	using reference = typename std::iterator_traits<It>::reference;
 
 	output_it() = delete;
 
-	explicit output_it(pointer it) : _it(it)
+	explicit output_it(It it) : _it(it)
 	{
 	}
 
@@ -90,7 +91,7 @@ public:
 	}
 
 private:
-	pointer _it;
+	It _it;
 };
 
 /**
@@ -102,18 +103,19 @@ private:
  * - can be dereferenced as an rvalue
  * - supports equality/inequality comparisons
  */
-template <typename T>
+template <typename It>
 class input_it {
 public:
 	using iterator_category = std::input_iterator_tag;
-	using value_type = T;
-	using difference_type = std::ptrdiff_t;
-	using pointer = T *;
-	using reference = T &;
+	using value_type = typename std::iterator_traits<It>::value_type;
+	using difference_type =
+		typename std::iterator_traits<It>::difference_type;
+	using pointer = typename std::iterator_traits<It>::pointer;
+	using reference = typename std::iterator_traits<It>::reference;
 
 	input_it() = delete;
 
-	explicit input_it(pointer it) : _it(it)
+	explicit input_it(It it) : _it(it)
 	{
 	}
 
@@ -159,7 +161,7 @@ public:
 	}
 
 private:
-	pointer _it;
+	It _it;
 };
 
 /**
@@ -175,20 +177,21 @@ private:
  * - multi-pass: neither dereferencing nor incrementing affects
  *   dereferenceability
  */
-template <typename T>
+template <typename It>
 class forward_it {
 public:
 	using iterator_category = std::forward_iterator_tag;
-	using value_type = T;
-	using difference_type = std::ptrdiff_t;
-	using pointer = T *;
-	using reference = T &;
+	using value_type = typename std::iterator_traits<It>::value_type;
+	using difference_type =
+		typename std::iterator_traits<It>::difference_type;
+	using pointer = typename std::iterator_traits<It>::pointer;
+	using reference = typename std::iterator_traits<It>::reference;
 
 	forward_it() : _it()
 	{
 	}
 
-	explicit forward_it(pointer it) : _it(it)
+	explicit forward_it(It it) : _it(it)
 	{
 	}
 
@@ -234,7 +237,7 @@ public:
 	}
 
 private:
-	pointer _it;
+	It _it;
 };
 
 /**
@@ -251,20 +254,21 @@ private:
  * - multi-pass: neither dereferencing nor incrementing affects
  *   dereferenceability
  */
-template <typename T>
+template <typename It>
 class bidirectional_it {
 public:
 	using iterator_category = std::bidirectional_iterator_tag;
-	using value_type = T;
-	using difference_type = std::ptrdiff_t;
-	using pointer = T *;
-	using reference = T &;
+	using value_type = typename std::iterator_traits<It>::value_type;
+	using difference_type =
+		typename std::iterator_traits<It>::difference_type;
+	using pointer = typename std::iterator_traits<It>::pointer;
+	using reference = typename std::iterator_traits<It>::reference;
 
 	bidirectional_it() : _it()
 	{
 	}
 
-	explicit bidirectional_it(pointer it) : _it(it)
+	explicit bidirectional_it(It it) : _it(it)
 	{
 	}
 
@@ -325,7 +329,7 @@ public:
 	}
 
 private:
-	pointer _it;
+	It _it;
 };
 
 /**
@@ -347,20 +351,21 @@ private:
  * - multi-pass: neither dereferencing nor incrementing affects
  *   dereferenceability
  */
-template <typename T>
+template <typename It>
 class random_access_it {
 public:
 	using iterator_category = std::random_access_iterator_tag;
-	using value_type = T;
-	using difference_type = std::ptrdiff_t;
-	using pointer = T *;
-	using reference = T &;
+	using value_type = typename std::iterator_traits<It>::value_type;
+	using difference_type =
+		typename std::iterator_traits<It>::difference_type;
+	using pointer = typename std::iterator_traits<It>::pointer;
+	using reference = typename std::iterator_traits<It>::reference;
 
 	random_access_it() : _it()
 	{
 	}
 
-	explicit random_access_it(pointer it) : _it(it)
+	explicit random_access_it(It it) : _it(it)
 	{
 	}
 
@@ -493,7 +498,7 @@ public:
 	}
 
 private:
-	pointer _it;
+	It _it;
 };
 
 } /* namespace test_common */

--- a/tests/external/libcxx/vector/vector.cons/construct_iter_iter.pass.cpp
+++ b/tests/external/libcxx/vector/vector.cons/construct_iter_iter.pass.cpp
@@ -78,16 +78,16 @@ basic_test_cases(nvobj::pool<struct root> &pop)
 {
 	int a[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 1, 0};
 	int *an = a + sizeof(a) / sizeof(a[0]);
-	basic_test<vector_type>(pop, test_support::input_it<const int>(a),
-				test_support::input_it<const int>(an));
-	basic_test<vector_type>(pop, test_support::forward_it<const int>(a),
-				test_support::forward_it<const int>(an));
-	basic_test<vector_type>(pop,
-				test_support::bidirectional_it<const int>(a),
-				test_support::bidirectional_it<const int>(an));
-	basic_test<vector_type>(pop,
-				test_support::random_access_it<const int>(a),
-				test_support::random_access_it<const int>(an));
+	basic_test<vector_type>(pop, test_support::input_it<const int *>(a),
+				test_support::input_it<const int *>(an));
+	basic_test<vector_type>(pop, test_support::forward_it<const int *>(a),
+				test_support::forward_it<const int *>(an));
+	basic_test<vector_type>(
+		pop, test_support::bidirectional_it<const int *>(a),
+		test_support::bidirectional_it<const int *>(an));
+	basic_test<vector_type>(
+		pop, test_support::random_access_it<const int *>(a),
+		test_support::random_access_it<const int *>(an));
 }
 
 /**
@@ -110,7 +110,7 @@ emplaceable_concept_tests(nvobj::pool<struct root> &pop)
 	auto r = pop.root();
 	/* TEST_1 */
 	{
-		using It = test_support::forward_it<int>;
+		using It = test_support::forward_it<int *>;
 		/* construct */
 		try {
 			nvobj::transaction::run(pop, [&] {
@@ -157,7 +157,7 @@ emplaceable_concept_tests(nvobj::pool<struct root> &pop)
 	}
 	/* TEST_2 */
 	{
-		using It = test_support::input_it<int>;
+		using It = test_support::input_it<int *>;
 		/* construct */
 		try {
 			nvobj::transaction::run(pop, [&] {

--- a/tests/iterator_traits/iterator_traits.cpp
+++ b/tests/iterator_traits/iterator_traits.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Intel Corporation
+ * Copyright 2018-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,92 +44,98 @@ test_is_type_of_iterator()
 	/* test is_output_iterator */
 	UT_ASSERT(true ==
 		  pmem::detail::is_output_iterator<
-			  test_support::output_it<int>>::value);
+			  test_support::output_it<int *>>::value);
 	UT_ASSERT(false ==
 		  pmem::detail::is_output_iterator<
-			  test_support::input_it<int>>::value);
+			  test_support::input_it<int *>>::value);
 	UT_ASSERT(false ==
 		  pmem::detail::is_output_iterator<
-			  test_support::forward_it<int>>::value);
+			  test_support::forward_it<int *>>::value);
 	UT_ASSERT(false ==
 		  pmem::detail::is_output_iterator<
-			  test_support::bidirectional_it<int>>::value);
+			  test_support::bidirectional_it<int *>>::value);
 	UT_ASSERT(false ==
 		  pmem::detail::is_output_iterator<
-			  test_support::random_access_it<int>>::value);
+			  test_support::random_access_it<int *>>::value);
 	UT_ASSERT(false == pmem::detail::is_output_iterator<int>::value);
 
 	/* test is_input_iterator */
 	UT_ASSERT(false ==
 		  pmem::detail::is_input_iterator<
-			  test_support::output_it<int>>::value);
+			  test_support::output_it<int *>>::value);
 	UT_ASSERT(true ==
 		  pmem::detail::is_input_iterator<
-			  test_support::input_it<int>>::value);
+			  test_support::input_it<int *>>::value);
 	UT_ASSERT(true ==
 		  pmem::detail::is_input_iterator<
-			  test_support::forward_it<int>>::value);
+			  test_support::forward_it<int *>>::value);
 	UT_ASSERT(true ==
 		  pmem::detail::is_input_iterator<
-			  test_support::bidirectional_it<int>>::value);
+			  test_support::bidirectional_it<int *>>::value);
 	UT_ASSERT(true ==
 		  pmem::detail::is_input_iterator<
-			  test_support::random_access_it<int>>::value);
+			  test_support::random_access_it<int *>>::value);
 	UT_ASSERT(false == pmem::detail::is_input_iterator<int>::value);
+	UT_ASSERT(true == pmem::detail::is_input_iterator<int *>::value);
 
 	/* test forward_iterator */
 	UT_ASSERT(false ==
 		  pmem::detail::is_forward_iterator<
-			  test_support::output_it<int>>::value);
+			  test_support::output_it<int *>>::value);
 	UT_ASSERT(false ==
 		  pmem::detail::is_forward_iterator<
-			  test_support::input_it<int>>::value);
+			  test_support::input_it<int *>>::value);
 	UT_ASSERT(true ==
 		  pmem::detail::is_forward_iterator<
-			  test_support::forward_it<int>>::value);
+			  test_support::forward_it<int *>>::value);
 	UT_ASSERT(true ==
 		  pmem::detail::is_forward_iterator<
-			  test_support::bidirectional_it<int>>::value);
+			  test_support::bidirectional_it<int *>>::value);
 	UT_ASSERT(true ==
 		  pmem::detail::is_forward_iterator<
-			  test_support::random_access_it<int>>::value);
+			  test_support::random_access_it<int *>>::value);
 	UT_ASSERT(false == pmem::detail::is_forward_iterator<int>::value);
+	UT_ASSERT(true == pmem::detail::is_forward_iterator<int *>::value);
 
 	/* test bidirectional_iterator */
 	UT_ASSERT(false ==
 		  pmem::detail::is_bidirectional_iterator<
-			  test_support::output_it<int>>::value);
+			  test_support::output_it<int *>>::value);
 	UT_ASSERT(false ==
 		  pmem::detail::is_bidirectional_iterator<
-			  test_support::input_it<int>>::value);
+			  test_support::input_it<int *>>::value);
 	UT_ASSERT(false ==
 		  pmem::detail::is_bidirectional_iterator<
-			  test_support::forward_it<int>>::value);
+			  test_support::forward_it<int *>>::value);
 	UT_ASSERT(true ==
 		  pmem::detail::is_bidirectional_iterator<
-			  test_support::bidirectional_it<int>>::value);
+			  test_support::bidirectional_it<int *>>::value);
 	UT_ASSERT(true ==
 		  pmem::detail::is_bidirectional_iterator<
-			  test_support::random_access_it<int>>::value);
+			  test_support::random_access_it<int *>>::value);
 	UT_ASSERT(false == pmem::detail::is_bidirectional_iterator<int>::value);
+	UT_ASSERT(true ==
+		  pmem::detail::is_bidirectional_iterator<int *>::value);
 
 	/* test random_access_iterator */
 	UT_ASSERT(false ==
 		  pmem::detail::is_random_access_iterator<
-			  test_support::output_it<int>>::value);
+			  test_support::output_it<int *>>::value);
 	UT_ASSERT(false ==
 		  pmem::detail::is_random_access_iterator<
-			  test_support::input_it<int>>::value);
+			  test_support::input_it<int *>>::value);
 	UT_ASSERT(false ==
 		  pmem::detail::is_random_access_iterator<
-			  test_support::forward_it<int>>::value);
+			  test_support::forward_it<int *>>::value);
 	UT_ASSERT(false ==
 		  pmem::detail::is_random_access_iterator<
-			  test_support::bidirectional_it<int>>::value);
+			  test_support::bidirectional_it<int *>>::value);
 	UT_ASSERT(true ==
 		  pmem::detail::is_random_access_iterator<
-			  test_support::random_access_it<int>>::value);
+			  test_support::random_access_it<int *>>::value);
 	UT_ASSERT(false == pmem::detail::is_random_access_iterator<int>::value);
+	UT_ASSERT(true ==
+		  pmem::detail::is_random_access_iterator<int *>::value);
 }
 
 int

--- a/tests/vector_ctor_check_copy/vector_ctor_check_copy.cpp
+++ b/tests/vector_ctor_check_copy/vector_ctor_check_copy.cpp
@@ -43,7 +43,7 @@ const static size_t pool_size = PMEMOBJ_MIN_POOL;
 
 using test_type = emplace_constructible_copy_insertable_move_insertable<int>;
 using vector_type = pmem_exp::vector<test_type>;
-using It = test_support::input_it<test_type>;
+using It = test_support::input_it<test_type *>;
 
 struct root {
 	nvobj::persistent_ptr<vector_type> pptr1;
@@ -76,7 +76,7 @@ main(int argc, char *argv[])
 	try {
 		nvobj::transaction::run(pop, [&] {
 			r->pptr1 = nvobj::make_persistent<vector_type>(
-				It(arr), It(std::end(arr)));
+				It(std::begin(arr)), It(std::end(arr)));
 		});
 
 		UT_ASSERTeq(r->pptr1->const_at(0).value, 1);

--- a/tests/vector_private/vector_private.cpp
+++ b/tests/vector_private/vector_private.cpp
@@ -233,9 +233,9 @@ test_vector_grow(nvobj::pool<struct root> &pop) try {
 	/* third case */
 	std::vector<int> v(TEST_SIZE_1, TEST_VAL_1);
 	v.insert(v.end(), TEST_SIZE_2, TEST_VAL_2);
-	auto first = test::input_it<int>(v.data());
-	auto middle = test::input_it<int>(v.data() + TEST_SIZE_1);
-	auto last = test::input_it<int>(v.data() + v.size());
+	auto first = test::input_it<int *>(v.data());
+	auto middle = test::input_it<int *>(v.data() + TEST_SIZE_1);
+	auto last = test::input_it<int *>(v.data() + v.size());
 	nvobj::transaction::run(pop, [&] {
 		r->v_pptr = nvobj::make_persistent<pmem_exp::vector<int>>();
 		r->v_pptr->_alloc(TEST_CAPACITY);


### PR DESCRIPTION
New version takes iterator type instead data type. This
allows for more flexible usage. For example it is required for
testing pmem::obj::experimental::basic_string where required
iterator type is const char*.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/183)
<!-- Reviewable:end -->
