### PR TITLE
Change RPM/DEB to rpm/deb in README.md and cmake warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cmake .. -DCPACK_GENERATOR="$GEN" -DCMAKE_INSTALL_PREFIX=/usr
 make package
 ```
 
-$GEN is type of package generator and can be RPM or DEB
+$GEN is type of package generator and can be `rpm` or `deb`
 
 CMAKE_INSTALL_PREFIX must be set to a destination were packages will be installed
 

--- a/cmake/packages.cmake
+++ b/cmake/packages.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -37,7 +37,7 @@ string(TOUPPER "${CPACK_GENERATOR}" CPACK_GENERATOR)
 
 if(NOT ("${CPACK_GENERATOR}" STREQUAL "DEB" OR
 	"${CPACK_GENERATOR}" STREQUAL "RPM"))
-	message(FATAL_ERROR "Wrong CPACK_GENERATOR value, valid generators are: DEB, RPM")
+	message(FATAL_ERROR "Wrong CPACK_GENERATOR value, valid generators are: deb, rpm")
 endif()
 
 set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")


### PR DESCRIPTION
To be consistent with other pmem repositories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/189)
<!-- Reviewable:end -->
