### PR TITLE
Fix argument parsing in examples/map_cli.

### DIFF
--- a/examples/map_cli/map_cli.cpp
+++ b/examples/map_cli/map_cli.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -179,7 +179,7 @@ exec_op(pool_base pop, T &map, queue_op op, char *argv[], int &argn)
 			insert(pop, map, argv, argn);
 			break;
 		case MAP_GET: {
-			auto val = map->get(atoll(argv[argn]));
+			auto val = map->get(atoll(argv[argn++]));
 			if (val)
 				std::cout << *val << std::endl;
 			else
@@ -190,7 +190,7 @@ exec_op(pool_base pop, T &map, queue_op op, char *argv[], int &argn)
 			remove(pop, map, argv, argn);
 			break;
 		case MAP_REMOVE_FREE:
-			map->remove_free(atoll(argv[4]));
+			map->remove_free(atoll(argv[argn++]));
 			break;
 		case MAP_CLEAR:
 			map->clear();
@@ -210,7 +210,7 @@ main(int argc, char *argv[])
 	if (argc < 4) {
 		std::cerr << "usage: " << argv[0]
 			  << " file-name <persistent|volatile> "
-			     "[insert|insert_new "
+			     "[insert <key value>|insert_new "
 			     "<key value>|get <key>|remove <key> | remove_free "
 			     "<key>]"
 			  << std::endl;


### PR DESCRIPTION
argn was not incremented in case of get(). This resulted
in "invalid queue operation" message on every get.

Ref: #186

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/191)
<!-- Reviewable:end -->
