### PR TITLE
Update a docker image build-dependency.

### DIFF
--- a/utils/docker/images/Dockerfile.ubuntu-18.04
+++ b/utils/docker/images/Dockerfile.ubuntu-18.04
@@ -57,7 +57,7 @@ RUN apt-get update \
 	gdb \
 	git \
 	graphviz \
-	libunwind8-dev \
+	libunwind-dev \
 	libtext-diff-perl \
 	pkg-config \
 	ruby \


### PR DESCRIPTION
Maintainers want to get rid of the old name, thus it'll disappear soon.  The new one is available since Ubuntu 14.10, thus everywhere we care about.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/192)
<!-- Reviewable:end -->
