### PR TITLE
Remove const_contiguous_iterator.

### DIFF
--- a/include/libpmemobj++/experimental/array.hpp
+++ b/include/libpmemobj++/experimental/array.hpp
@@ -101,7 +101,7 @@ struct array {
 	using reference = value_type &;
 	using const_reference = const value_type &;
 	using iterator = basic_contiguous_iterator<T>;
-	using const_iterator = const_contiguous_iterator<T>;
+	using const_iterator = const_pointer;
 	using size_type = std::size_t;
 	using difference_type = std::ptrdiff_t;
 	using reverse_iterator = std::reverse_iterator<iterator>;

--- a/include/libpmemobj++/experimental/contiguous_iterator.hpp
+++ b/include/libpmemobj++/experimental/contiguous_iterator.hpp
@@ -204,77 +204,6 @@ protected:
 	Pointer ptr;
 };
 
-template <typename T>
-struct const_contiguous_iterator;
-
-/**
- * This struct provides comparison operators between const_contiguous_iterator
- * for specified type (as all iterators can be converted to const_iterator this
- * allows to compare all of them).
- */
-template <typename T>
-struct operator_base {
-	/**
-	 * Non-member equal operator.
-	 */
-	friend bool
-	operator==(const const_contiguous_iterator<T> &lhs,
-		   const const_contiguous_iterator<T> &rhs)
-	{
-		return lhs.get_ptr() == rhs.get_ptr();
-	}
-
-	/**
-	 * Non-member not equal operator.
-	 */
-	friend bool
-	operator!=(const const_contiguous_iterator<T> &lhs,
-		   const const_contiguous_iterator<T> &rhs)
-	{
-		return !(lhs == rhs);
-	}
-
-	/**
-	 * Non-member less than operator.
-	 */
-	friend bool
-	operator<(const const_contiguous_iterator<T> &lhs,
-		  const const_contiguous_iterator<T> &rhs)
-	{
-		return lhs.get_ptr() < rhs.get_ptr();
-	}
-
-	/**
-	 * Non-member greater than operator.
-	 */
-	friend bool
-	operator>(const const_contiguous_iterator<T> &lhs,
-		  const const_contiguous_iterator<T> &rhs)
-	{
-		return lhs.get_ptr() > rhs.get_ptr();
-	}
-
-	/**
-	 * Non-member less or equal operator.
-	 */
-	friend bool
-	operator<=(const const_contiguous_iterator<T> &lhs,
-		   const const_contiguous_iterator<T> &rhs)
-	{
-		return !(lhs > rhs);
-	}
-
-	/**
-	 * Non-member greater or equal operator.
-	 */
-	friend bool
-	operator>=(const const_contiguous_iterator<T> &lhs,
-		   const const_contiguous_iterator<T> &rhs)
-	{
-		return !(lhs < rhs);
-	}
-};
-
 /**
  * Non-const iterator which adds elements to a transaction in a bulk.
  *
@@ -292,8 +221,7 @@ struct operator_base {
  */
 template <typename T>
 struct range_snapshotting_iterator
-    : public contiguous_iterator<range_snapshotting_iterator<T>, T &, T *>,
-      public operator_base<T> {
+    : public contiguous_iterator<range_snapshotting_iterator<T>, T &, T *> {
 	using iterator_category = std::random_access_iterator_tag;
 	using value_type = T;
 	using difference_type = std::ptrdiff_t;
@@ -319,6 +247,14 @@ struct range_snapshotting_iterator
 
 		if (snapshot_size > 0)
 			snapshot_range(ptr);
+	}
+
+	/**
+	 * Conversion operator to const T*.
+	 */
+	operator const T *()
+	{
+		return this->ptr;
 	}
 
 	/**
@@ -422,8 +358,7 @@ private:
  */
 template <typename T>
 struct basic_contiguous_iterator
-    : public contiguous_iterator<basic_contiguous_iterator<T>, T &, T *>,
-      public operator_base<T> {
+    : public contiguous_iterator<basic_contiguous_iterator<T>, T &, T *> {
 	using iterator_category = std::random_access_iterator_tag;
 	using value_type = T;
 	using difference_type = std::ptrdiff_t;
@@ -438,6 +373,14 @@ struct basic_contiguous_iterator
 	 */
 	basic_contiguous_iterator(pointer ptr = nullptr) : base_type(ptr)
 	{
+	}
+
+	/**
+	 * Conversion operator to const T*.
+	 */
+	operator const T *()
+	{
+		return this->ptr;
 	}
 
 	/**
@@ -476,55 +419,6 @@ struct basic_contiguous_iterator
 	 */
 	friend void
 	swap(basic_contiguous_iterator &lhs, basic_contiguous_iterator &rhs)
-	{
-		std::swap(lhs.ptr, rhs.ptr);
-	}
-};
-
-/**
- * Const iterator.
- */
-template <typename T>
-struct const_contiguous_iterator
-    : public contiguous_iterator<const_contiguous_iterator<T>, const T &,
-				 const T *>,
-      public operator_base<T> {
-	using iterator_category = std::random_access_iterator_tag;
-	using value_type = T;
-	using difference_type = std::ptrdiff_t;
-	using reference = const T &;
-	using pointer = const T *;
-	using base_type = contiguous_iterator<const_contiguous_iterator<T>,
-					      reference, pointer>;
-
-	/**
-	 * Constructor taking pointer as argument.
-	 */
-	const_contiguous_iterator(pointer ptr = nullptr) : base_type(ptr)
-	{
-	}
-
-	/**
-	 * Conversion operator from non-const iterator.
-	 */
-	const_contiguous_iterator(const basic_contiguous_iterator<T> &other)
-	    : base_type(other.get_ptr())
-	{
-	}
-
-	/**
-	 * Conversion operator from non-const iterator.
-	 */
-	const_contiguous_iterator(const range_snapshotting_iterator<T> &other)
-	    : base_type(other.get_ptr())
-	{
-	}
-
-	/**
-	 * Non-member swap function.
-	 */
-	friend void
-	swap(const_contiguous_iterator &lhs, const_contiguous_iterator &rhs)
 	{
 		std::swap(lhs.ptr, rhs.ptr);
 	}

--- a/include/libpmemobj++/experimental/vector.hpp
+++ b/include/libpmemobj++/experimental/vector.hpp
@@ -78,7 +78,7 @@ public:
 	using pointer = value_type *;
 	using const_pointer = const value_type *;
 	using iterator = basic_contiguous_iterator<T>;
-	using const_iterator = const_contiguous_iterator<T>;
+	using const_iterator = const_pointer;
 	using reverse_iterator = std::reverse_iterator<iterator>;
 	using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 

--- a/tests/array_iterator/array_iterator.cpp
+++ b/tests/array_iterator/array_iterator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Intel Corporation
+ * Copyright 2018-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -103,6 +103,7 @@ struct Test3 {
 		auto sub_slice = c.range(1, c.size() - 2);
 		auto cslice = c.crange(0, c.size());
 
+		UT_ASSERT(c.begin() == c.cbegin());
 		UT_ASSERT(c.begin() == slice.begin());
 		UT_ASSERT(c.begin() == sub_slice.begin() - 1);
 		UT_ASSERT(c.begin() == cslice.begin());
@@ -116,6 +117,7 @@ struct Test3 {
 		UT_ASSERT(slice.begin() == cslice.begin());
 		UT_ASSERT(cslice.begin() == slice.begin());
 
+		UT_ASSERT(c.end() == c.cend());
 		UT_ASSERT(c.end() == slice.end());
 		UT_ASSERT(c.end() == sub_slice.end() + 1);
 		UT_ASSERT(c.end() == cslice.end());
@@ -129,6 +131,7 @@ struct Test3 {
 		UT_ASSERT(slice.end() == cslice.end());
 		UT_ASSERT(cslice.end() == slice.end());
 
+		UT_ASSERT(c.end() > c.begin());
 		UT_ASSERT(c.end() > slice.begin());
 		UT_ASSERT(c.end() > sub_slice.begin() + 1);
 		UT_ASSERT(c.end() > cslice.begin());

--- a/tests/external/libcxx/array/types.pass.cpp
+++ b/tests/external/libcxx/array/types.pass.cpp
@@ -77,9 +77,7 @@ main()
 				pmem_exp::basic_contiguous_iterator<T>>::value),
 			"");
 		static_assert(
-			(std::is_same<
-				C::const_iterator,
-				pmem_exp::const_contiguous_iterator<T>>::value),
+			(std::is_same<C::const_iterator, const T *>::value),
 			"");
 		test_iterators<C>();
 		static_assert((std::is_same<C::pointer, T *>::value), "");
@@ -130,9 +128,7 @@ main()
 				pmem_exp::basic_contiguous_iterator<T>>::value),
 			"");
 		static_assert(
-			(std::is_same<
-				C::const_iterator,
-				pmem_exp::const_contiguous_iterator<T>>::value),
+			(std::is_same<C::const_iterator, const T *>::value),
 			"");
 		test_iterators<C>();
 		static_assert((std::is_same<C::pointer, T *>::value), "");

--- a/tests/external/libcxx/vector/types.pass.cpp
+++ b/tests/external/libcxx/vector/types.pass.cpp
@@ -61,6 +61,9 @@ test()
 				   std::reverse_iterator<
 					   typename C::const_iterator>>::value,
 		      "");
+	static_assert(
+		(std::is_same<typename C::const_iterator, const T *>::value),
+		"");
 }
 
 int


### PR DESCRIPTION
This iterator can be replaced by simple const pointer. To support
comparison operators between basic_contiguous_iterator,
range_snapshotting_iterator and pointers, conversion operator to const_pointer
was added. This change is a potential performance improvement (we don't
have another abstraction layer - const_contigous_iterator. This also
allows to reduce amount of code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/203)
<!-- Reviewable:end -->
