### PR TITLE
fix allocation_flag issues

### DIFF
--- a/include/libpmemobj++/allocation_flag.hpp
+++ b/include/libpmemobj++/allocation_flag.hpp
@@ -58,7 +58,12 @@ namespace obj
  * Flags can be combined with each other using operator|()
  */
 struct allocation_flag {
-	allocation_flag() = delete;
+	/**
+	 * Emplace constructor.
+	 */
+	allocation_flag(uint64_t val) : value(val)
+	{
+	}
 
 	/**
 	 * Allocate the object from the allocation class with id equal to id.
@@ -66,7 +71,7 @@ struct allocation_flag {
 	static allocation_flag
 	class_id(uint64_t id)
 	{
-		return {POBJ_CLASS_ID(id)};
+		return allocation_flag(POBJ_CLASS_ID(id));
 	}
 
 	/**
@@ -75,7 +80,7 @@ struct allocation_flag {
 	static allocation_flag
 	no_flush()
 	{
-		return {POBJ_XALLOC_NO_FLUSH};
+		return allocation_flag(POBJ_XALLOC_NO_FLUSH);
 	}
 
 	/**
@@ -84,7 +89,7 @@ struct allocation_flag {
 	static allocation_flag
 	none()
 	{
-		return {0};
+		return allocation_flag(0);
 	}
 
 	/**
@@ -99,7 +104,7 @@ struct allocation_flag {
 	allocation_flag
 	operator|(const allocation_flag &rhs)
 	{
-		return {value | rhs.value};
+		return allocation_flag(value | rhs.value);
 	}
 
 	uint64_t value;
@@ -116,7 +121,12 @@ struct allocation_flag {
  * Flags can be combined with each other using operator|()
  */
 struct allocation_flag_atomic {
-	allocation_flag_atomic() = delete;
+	/**
+	 * Emplace constructor.
+	 */
+	allocation_flag_atomic(uint64_t val) : value(val)
+	{
+	}
 
 	/**
 	 * Allocate the object from the allocation class with id equal to id.
@@ -124,7 +134,7 @@ struct allocation_flag_atomic {
 	static allocation_flag_atomic
 	class_id(uint64_t id)
 	{
-		return {POBJ_CLASS_ID(id)};
+		return allocation_flag_atomic(POBJ_CLASS_ID(id));
 	}
 
 	/**
@@ -133,7 +143,7 @@ struct allocation_flag_atomic {
 	static allocation_flag_atomic
 	none()
 	{
-		return {0};
+		return allocation_flag_atomic(0);
 	}
 
 	/**
@@ -148,7 +158,7 @@ struct allocation_flag_atomic {
 	allocation_flag_atomic
 	operator|(const allocation_flag_atomic &rhs)
 	{
-		return {value | rhs.value};
+		return allocation_flag_atomic(value | rhs.value);
 	}
 
 	uint64_t value;


### PR DESCRIPTION
aggregate initialization is allowed for structs with no user-declared (explicitly defaulted or deleted constructors are allowed) constructors since C++11, but gcc 4.8.5 doesn't support it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/215)
<!-- Reviewable:end -->
