### PR TITLE
stable1.5: fix persistent ptr

### DIFF
--- a/include/libpmemobj++/make_persistent_array.hpp
+++ b/include/libpmemobj++/make_persistent_array.hpp
@@ -111,7 +111,7 @@ make_persistent(std::size_t N)
 	 * case when transaction is aborted after make_persistent completes and
 	 * we have no way to call destructors.
 	 */
-	for (std::size_t i = 0; i < N; ++i)
+	for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(N); ++i)
 		detail::create<I>(data + i);
 
 	return ptr;
@@ -163,7 +163,7 @@ make_persistent()
 	 * case when transaction is aborted after make_persistent completes and
 	 * we have no way to call destructors.
 	 */
-	for (std::size_t i = 0; i < N; ++i)
+	for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(N); ++i)
 		detail::create<I>(data + i);
 
 	return ptr;
@@ -204,8 +204,9 @@ delete_persistent(typename detail::pp_if_array<T>::type ptr, std::size_t N)
 	 */
 	auto data = ptr.get();
 
-	for (std::size_t i = 0; i < N; ++i)
-		detail::destroy<I>(data[N - 1 - i]);
+	for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(N); ++i)
+		detail::destroy<I>(
+			data[static_cast<std::ptrdiff_t>(N) - 1 - i]);
 
 	if (pmemobj_tx_free(*ptr.raw_ptr()) != 0)
 		throw transaction_free_error("failed to delete "
@@ -247,8 +248,9 @@ delete_persistent(typename detail::pp_if_size_array<T>::type ptr)
 	 */
 	auto data = ptr.get();
 
-	for (std::size_t i = 0; i < N; ++i)
-		detail::destroy<I>(data[N - 1 - i]);
+	for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(N); ++i)
+		detail::destroy<I>(
+			data[static_cast<std::ptrdiff_t>(N) - 1 - i]);
 
 	if (pmemobj_tx_free(*ptr.raw_ptr()) != 0)
 		throw transaction_free_error("failed to delete "

--- a/include/libpmemobj++/persistent_ptr.hpp
+++ b/include/libpmemobj++/persistent_ptr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018, Intel Corporation
+ * Copyright 2015-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -177,17 +177,13 @@ public:
 	}
 
 	/**
-	 * Array access operator. This function template participates in
-	 * overload resolution only if 'I' satisfies requirements of
-	 * is_integral.
+	 * Array access operator.
 	 *
 	 * Contains run-time bounds checking for static arrays.
 	 */
-	template <typename I,
-		  typename std::enable_if<std::is_integral<I>::value,
-					  int>::type = 0>
-	typename pmem::detail::sp_array_access<T>::type operator[](I i) const
-		noexcept
+	template <typename = typename std::enable_if<!std::is_void<T>::value>>
+	typename pmem::detail::sp_array_access<T>::type
+	operator[](std::ptrdiff_t i) const noexcept
 	{
 		assert(i >= 0 &&
 		       (i < pmem::detail::sp_extent<T>::value ||

--- a/tests/make_persistent_array/make_persistent_array.cpp
+++ b/tests/make_persistent_array/make_persistent_array.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,6 +39,7 @@
 #include <libpmemobj++/make_persistent_array.hpp>
 #include <libpmemobj++/p.hpp>
 #include <libpmemobj++/persistent_ptr.hpp>
+#include <libpmemobj++/pext.hpp>
 #include <libpmemobj++/pool.hpp>
 #include <libpmemobj++/transaction.hpp>
 
@@ -115,7 +116,7 @@ test_make_one_d(nvobj::pool_base &pop)
 	try {
 		nvobj::transaction::run(pop, [&] {
 			auto pfoo = nvobj::make_persistent<foo[]>(5);
-			for (int i = 0; i < 5; ++i)
+			for (nvobj::p<int> i = 0; i < 5; ++i)
 				pfoo[i].check_foo();
 
 			nvobj::delete_persistent<foo[]>(pfoo, 5);

--- a/tests/ptr/ptr.cpp
+++ b/tests/ptr/ptr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018, Intel Corporation
+ * Copyright 2015-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -245,29 +245,6 @@ test_ptr_transactional(nvobj::pool<root> &pop)
 void
 test_ptr_array(nvobj::pool<root> &pop)
 {
-	nvobj::persistent_ptr<int[]> parr_test_index;
-
-	try {
-		nvobj::make_persistent_atomic<int[]>(pop, parr_test_index,
-						     TEST_ARR_SIZE);
-	} catch (...) {
-		UT_ASSERT(0);
-	}
-
-	/* check if index operator works with both signed and unsigned types */
-	for (std::ptrdiff_t i = 0; i < TEST_ARR_SIZE; ++i)
-		(void)parr_test_index[i];
-	for (std::size_t i = 0; i < TEST_ARR_SIZE; ++i)
-		(void)parr_test_index[i];
-	for (unsigned i = 0; i < TEST_ARR_SIZE; ++i)
-		(void)parr_test_index[i];
-	for (int i = 0; i < TEST_ARR_SIZE; ++i)
-		(void)parr_test_index[i];
-	for (long long i = 0; i < TEST_ARR_SIZE; ++i)
-		(void)parr_test_index[i];
-	for (unsigned long long i = 0; i < TEST_ARR_SIZE; ++i)
-		(void)parr_test_index[i];
-
 	nvobj::persistent_ptr<nvobj::p<int>[]> parr_vsize;
 
 	try {


### PR DESCRIPTION
Fix operator[] for persistent_ptr for array types.

Enabling operator[] only for integral types, disables operator[] for p<> class argument with integral template parameter which is not a desired behavior. It is not worth to implement custom type_trait is_convertible_to_integral (which must explicitly list all possible integral types; it is not possible to use std::is_integral there), because old approach better imitates STL behavior for array's operator[].

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/217)
<!-- Reviewable:end -->
