### PR TITLE
backport: Disable some libcxx tests for old g++ compilers.

### DIFF
--- a/tests/ctest_helpers.cmake
+++ b/tests/ctest_helpers.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -87,6 +87,15 @@ else()
 	set(NO_CLANG_TEMPLATE_BUG TRUE)
 	set(NO_CHRONO_BUG TRUE)
 endif()
+
+set(CMAKE_REQUIRED_FLAGS "--std=c++${CMAKE_CXX_STANDARD} -c")
+CHECK_CXX_SOURCE_COMPILES(
+	"#include <cstddef>
+	int main() {
+	    std::max_align_t var;
+	    return 0;
+	}"
+	MAX_ALIGN_TYPE_EXISTS)
 
 set(CMAKE_REQUIRED_FLAGS ${SAVED_CMAKE_REQUIRED_FLAGS})
 set(CMAKE_REQUIRED_INCLUDES ${SAVED_CMAKE_REQUIRED_INCLUDES})

--- a/tests/external/CMakeLists.txt
+++ b/tests/external/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -86,8 +86,10 @@ add_test_default(array_indexing none)
 build_test(array_max_size libcxx/array/max_size.pass.cpp)
 add_test_default(array_max_size none)
 
-build_test(array_size_and_alignment libcxx/array/size_and_alignment.pass.cpp)
-add_test_default(array_size_and_alignment none)
+if (MAX_ALIGN_TYPE_EXISTS)
+	build_test(array_size_and_alignment libcxx/array/size_and_alignment.pass.cpp)
+	add_test_default(array_size_and_alignment none)
+endif()
 
 build_test(array_types libcxx/array/types.pass.cpp)
 add_test_default(array_types none)
@@ -107,11 +109,15 @@ add_test_default(array_cons_implicit_copy none)
 build_test(array_initializer_list libcxx/array/array.cons/initializer_list.pass.cpp)
 add_test_default(array_initializer_list none)
 
-build_test(array_data_const libcxx/array/array.data/data_const.pass.cpp)
-add_test_default(array_data_const none)
+if (MAX_ALIGN_TYPE_EXISTS)
+	build_test(array_data_const libcxx/array/array.data/data_const.pass.cpp)
+	add_test_default(array_data_const none)
+endif()
 
-build_test(array_data libcxx/array/array.data/data.pass.cpp)
-add_test_default(array_data none)
+if (MAX_ALIGN_TYPE_EXISTS)
+	build_test(array_data libcxx/array/array.data/data.pass.cpp)
+	add_test_default(array_data none)
+endif()
 
 add_test_expect_failure(array_fill libcxx/array/array.fill/fill.fail.cpp)
 


### PR DESCRIPTION
They cannot be compiled due to lack of full C++11 support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/222)
<!-- Reviewable:end -->
