### PR TITLE
travis: run valgrind tests only in one configuration.

### DIFF
--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -57,7 +57,11 @@ function test_command() {
 		bash <(curl -s https://codecov.io/bash) -c -F $1 -x "$gcovexe" > /dev/null
 		cleanup
 	else
-		ctest --output-on-failure --timeout 540
+		if [[ "$3" == "with_valgrind" ]]; then
+			ctest --output-on-failure --timeout 540
+		else
+			ctest -E "_memcheck|_drd|_helgrind|_pmemcheck" --output-on-failure --timeout 540
+		fi
 	fi
 }
 
@@ -151,7 +155,7 @@ cmake .. -DDEVELOPER_MODE=1 \
 			-DTESTS_USE_FORCED_PMEM=1
 
 make -j2
-test_command tests_gcc_debug
+test_command tests_gcc_debug gcc with_valgrind
 
 cd ..
 rm -r build
@@ -174,7 +178,7 @@ cmake .. -DCMAKE_BUILD_TYPE=Release \
 			-DTESTS_USE_FORCED_PMEM=1
 
 make -j2
-test_command tests_gcc_release_cpp17
+test_command tests_gcc_release_cpp17 gcc
 
 cd ..
 rm -r build
@@ -199,7 +203,7 @@ cmake .. -DCMAKE_BUILD_TYPE=Release \
 			-DTESTS_USE_FORCED_PMEM=1
 
 make -j2
-test_command tests_gcc_release_cpp17_no_pmemcheck
+test_command tests_gcc_release_cpp17_no_pmemcheck gcc
 
 cd ..
 rm -r build


### PR DESCRIPTION
This reduces time on travis to ~25m.