### PR TITLE
test: enable -bigobj option for MSVC compiler

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_check_whitespace(tests-cmake ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt)
 
 if(MSVC_VERSION)
 	add_flag(-W4)
+	add_flag(-bigobj) # fix C1128 raised for some test binaries
 else()
 	add_flag(-Wall)
 endif()


### PR DESCRIPTION
Fixes C1128 compiler error raised for some test binaries
due to exceeded limit of addressable sections

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/249)
<!-- Reviewable:end -->
