### PR TITLE
fix doxygen invalid \ref command

### DIFF
--- a/include/libpmemobj++/experimental/vector.hpp
+++ b/include/libpmemobj++/experimental/vector.hpp
@@ -1677,7 +1677,7 @@ vector<T>::insert(const_iterator pos, std::initializer_list<value_type> ilist)
  * iterator is also invalidated. Note that standard allows args to be a self
  * reference and internal emplace implementation handles this case by creating
  * temporary element_type object. This object is being stored either on stack or
- * on pmem, see @ref temp_value for details.
+ * on pmem, see pmem::detail::temp_value for details.
  *
  * @param[in] pos iterator before which the new element will be constructed.
  * @param[in] args arguments to forward to the constructor of the element.


### PR DESCRIPTION
All words in the documentation that correspond to a documented class and contain at least one non-lower case character will automatically be replaced by a link to the page containing the documentation of the class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/260)
<!-- Reviewable:end -->
