### PR TITLE
fix clang compilation error

### DIFF
--- a/tests/array_modifiers/array_modifiers.cpp
+++ b/tests/array_modifiers/array_modifiers.cpp
@@ -138,7 +138,10 @@ test_modifiers(pmem::obj::pool<struct root> &pop)
 	}
 
 	try {
-		stack_array = stack_array;
+		/* Workaround for -Wself-assign-overloaded compile error */
+		auto &ref = stack_array;
+
+		stack_array = ref;
 		UT_ASSERT(0);
 	} catch (pmem::pool_error &) {
 	} catch (std::exception &e) {

--- a/tests/external/libcxx/basic_string/string.cons/copy_assignment.pass.cpp
+++ b/tests/external/libcxx/basic_string/string.cons/copy_assignment.pass.cpp
@@ -50,9 +50,10 @@ test_self_assignment(nvobj::pool<struct root> &pop, const S &s1)
 	nvobj::transaction::run(pop,
 				[&] { r->s1 = nvobj::make_persistent<S>(s1); });
 
+	/* Workaround for -Wself-assign-overloaded compile error */
 	auto &s = *r->s1;
 
-	s = s;
+	s = *r->s1;
 	UT_ASSERT(s == s1);
 	UT_ASSERT(s.capacity() >= s1.size());
 


### PR DESCRIPTION
clang 7.0.0 triggers -Wself-assign-overloaded in case of self assignment
whilst we handle this in our implementation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/261)
<!-- Reviewable:end -->
