### PR TITLE
Move finding valgrind to top level CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,64 +284,9 @@ write_basic_package_version_file(libpmemobj++-config-version.cmake
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libpmemobj++-config.cmake ${CMAKE_CURRENT_BINARY_DIR}/libpmemobj++-config-version.cmake
 	DESTINATION ${CMAKE_INSTALL_LIBDIR}/libpmemobj++/cmake)
 
-if(NOT MSVC_VERSION)
-	set(SAVED_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
-
-	# Check for issues with older gcc compilers which do not expand variadic template
-	# variables in lambda expressions.
-	set(CMAKE_REQUIRED_FLAGS "--std=c++11 -Wno-error -c")
-	CHECK_CXX_SOURCE_COMPILES(
-		"void print() {}
-		template<typename...Args, typename T>
-		void print(const T&, const Args &...arg) {
-			auto f = [&]{ print(arg...);};
-		}
-		int main() {
-			print(1, 2, 3);
-			return 0;
-		}"
-		NO_GCC_VARIADIC_TEMPLATE_BUG)
-
-	# Check for issues with older gcc compilers if "inline" aggregate initialization
-	# works for array class members https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65815
-	CHECK_CXX_SOURCE_COMPILES(
-		"struct array {
-			int data[2];
-		};
-		struct X {
-			array a = { 1, 2 };
-		};
-		int main() {
-			return 0;
-		}"
-		NO_GCC_AGGREGATE_INITIALIZATION_BUG)
-
-	# Check for issues related to agregate initialization in new expression.
-	# Following code will fail for LLVM compiler https://bugs.llvm.org/show_bug.cgi?id=39988
-	set(CMAKE_REQUIRED_FLAGS "--std=c++11 -Wno-error")
-	CHECK_CXX_SOURCE_COMPILES(
-		"template<typename T>
-		struct A {
-			 A() {};
-			~A() {};
-		};
-		struct B {
-			A<int> a;
-			A<int> b;
-		};
-		int main() {
-			new B{};
-			return 0;
-		}"
-		NO_CLANG_BRACE_INITIALIZATION_NEWEXPR_BUG)
-	set(CMAKE_REQUIRED_FLAGS ${SAVED_CMAKE_REQUIRED_FLAGS})
-else()
-	set(NO_GCC_VARIADIC_TEMPLATE_BUG TRUE)
-	set(NO_GCC_AGGREGATE_INITIALIZATION_BUG TRUE)
-	set(NO_CLANG_BRACE_INITIALIZATION_NEWEXPR_BUG TRUE)
-endif()
-
 include_directories(include)
+
+include(${CMAKE_SOURCE_DIR}/cmake/check_compiler_issues.cmake)
 
 if(BUILD_TESTS)
 	if(TEST_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,25 @@ include_directories(include)
 
 include(${CMAKE_SOURCE_DIR}/cmake/check_compiler_issues.cmake)
 
+if(PKG_CONFIG_FOUND)
+	pkg_check_modules(VALGRIND QUIET valgrind)
+else()
+	find_package(VALGRIND QUIET)
+endif()
+
+if(VALGRIND_FOUND)
+	add_flag(-DLIBPMEMOBJ_CPP_VG_MEMCHECK_ENABLED=1)
+	add_flag(-DLIBPMEMOBJ_CPP_VG_DRD_ENABLED=1)
+	add_flag(-DLIBPMEMOBJ_CPP_VG_HELGRIND_ENABLED=1)
+
+	include_directories(${VALGRIND_INCLUDE_DIRS})
+	find_pmemcheck()
+
+	if(VALGRIND_PMEMCHECK_FOUND)
+		add_flag(-DLIBPMEMOBJ_CPP_VG_PMEMCHECK_ENABLED=1)
+	endif()
+endif()
+
 if(BUILD_TESTS)
 	if(TEST_DIR)
 		enable_testing()

--- a/cmake/check_compiler_issues.cmake
+++ b/cmake/check_compiler_issues.cmake
@@ -1,0 +1,131 @@
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+if(NOT MSVC_VERSION)
+	set(SAVED_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+	set(SAVED_CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES})
+
+	# Check for issues with older gcc compilers which do not expand variadic template
+	# variables in lambda expressions.
+	set(CMAKE_REQUIRED_FLAGS "--std=c++11 -Wno-error -c")
+	CHECK_CXX_SOURCE_COMPILES(
+		"void print() {}
+		template<typename...Args, typename T>
+		void print(const T&, const Args &...arg) {
+			auto f = [&]{ print(arg...);};
+		}
+		int main() {
+			print(1, 2, 3);
+			return 0;
+		}"
+		NO_GCC_VARIADIC_TEMPLATE_BUG)
+
+	# Check for issues with older gcc compilers if "inline" aggregate initialization
+	# works for array class members https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65815
+	CHECK_CXX_SOURCE_COMPILES(
+		"struct array {
+			int data[2];
+		};
+		struct X {
+			array a = { 1, 2 };
+		};
+		int main() {
+			return 0;
+		}"
+		NO_GCC_AGGREGATE_INITIALIZATION_BUG)
+
+	# Check for issues related to agregate initialization in new expression.
+	# Following code will fail for LLVM compiler https://bugs.llvm.org/show_bug.cgi?id=39988
+	set(CMAKE_REQUIRED_FLAGS "--std=c++11 -Wno-error")
+	CHECK_CXX_SOURCE_COMPILES(
+		"template<typename T>
+		struct A {
+			 A() {};
+			~A() {};
+		};
+		struct B {
+			A<int> a;
+			A<int> b;
+		};
+		int main() {
+			new B{};
+			return 0;
+		}"
+		NO_CLANG_BRACE_INITIALIZATION_NEWEXPR_BUG)
+
+	# Check for issues with older clang compilers which assert on delete persistent<[][]>.
+	set(CMAKE_REQUIRED_INCLUDES ${CMAKE_SOURCE_DIR}/include ${LIBPMEMOBJ_INCLUDE_DIRS})
+	set(CMAKE_REQUIRED_FLAGS "--std=c++11 -Wno-error -c")
+	CHECK_CXX_SOURCE_COMPILES(
+		"#include <libpmemobj++/make_persistent_array.hpp>
+		using namespace pmem::obj;
+		int main() {
+			delete_persistent<int[][3]>(make_persistent<int[][3]>(2), 2);
+			return 0;
+		}"
+		NO_CLANG_TEMPLATE_BUG)
+
+	# This is a workaround for older incompatible versions of libstdc++ and clang.
+	# Please see https://llvm.org/bugs/show_bug.cgi?id=15517 for more info.
+	set(CMAKE_REQUIRED_FLAGS "--std=c++11 -Wno-error -include future")
+	CHECK_CXX_SOURCE_COMPILES(
+		"int main() { return 0; }"
+		NO_CHRONO_BUG)
+else()
+	set(NO_GCC_VARIADIC_TEMPLATE_BUG TRUE)
+	set(NO_GCC_AGGREGATE_INITIALIZATION_BUG TRUE)
+	set(NO_CLANG_BRACE_INITIALIZATION_NEWEXPR_BUG TRUE)
+	set(NO_CLANG_TEMPLATE_BUG TRUE)
+	set(NO_CHRONO_BUG TRUE)
+endif()
+
+set(CMAKE_REQUIRED_FLAGS "--std=c++${CMAKE_CXX_STANDARD} -c")
+CHECK_CXX_SOURCE_COMPILES(
+	"#include <cstddef>
+	int main() {
+	    std::max_align_t var;
+	    return 0;
+	}"
+	MAX_ALIGN_TYPE_EXISTS)
+
+set(CMAKE_REQUIRED_FLAGS "--std=c++${CMAKE_CXX_STANDARD} -c")
+CHECK_CXX_SOURCE_COMPILES(
+	"#include <type_traits>
+	int main() {
+	#if !__cpp_lib_is_aggregate
+		static_assert(false, \"\");
+	#endif
+	}"
+	AGGREGATE_INITIALIZATION_AVAILABLE
+)
+
+set(CMAKE_REQUIRED_INCLUDES ${SAVED_CMAKE_REQUIRED_INCLUDES})
+set(CMAKE_REQUIRED_FLAGS ${SAVED_CMAKE_REQUIRED_FLAGS})

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -151,4 +151,28 @@ function(get_program_version name ret)
 		ERROR_QUIET)
 	STRING(REGEX MATCH "([0-9]+.)([0-9]+.)([0-9]+)" VERSION ${cmd_ret})
 	SET(${ret} ${VERSION} PARENT_SCOPE)
+endfunction()
+
+function(find_pmemcheck)
+	set(ENV{PATH} ${VALGRIND_PREFIX}/bin:$ENV{PATH})
+	execute_process(COMMAND valgrind --tool=pmemcheck --help
+			RESULT_VARIABLE VALGRIND_PMEMCHECK_RET
+			OUTPUT_QUIET
+			ERROR_QUIET)
+	if(VALGRIND_PMEMCHECK_RET)
+		set(VALGRIND_PMEMCHECK_FOUND 0 CACHE INTERNAL "")
+	else()
+		set(VALGRIND_PMEMCHECK_FOUND 1 CACHE INTERNAL "")
+	endif()
+
+	if(VALGRIND_PMEMCHECK_FOUND)
+		execute_process(COMMAND valgrind --tool=pmemcheck true
+				ERROR_VARIABLE PMEMCHECK_OUT
+				OUTPUT_QUIET)
+
+		string(REGEX MATCH ".*pmemcheck-([0-9.]*),.*" PMEMCHECK_OUT "${PMEMCHECK_OUT}")
+		set(PMEMCHECK_VERSION ${CMAKE_MATCH_1} CACHE INTERNAL "")
+	else()
+		message(WARNING "Valgrind pmemcheck NOT found.")
+	endif()
 endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,16 +88,6 @@ endfunction()
 
 find_packages()
 
-if(VALGRIND_FOUND)
-	add_flag(-DLIBPMEMOBJ_CPP_VG_MEMCHECK_ENABLED=1)
-	add_flag(-DLIBPMEMOBJ_CPP_VG_DRD_ENABLED=1)
-	add_flag(-DLIBPMEMOBJ_CPP_VG_HELGRIND_ENABLED=1)
-
-	if(VALGRIND_PMEMCHECK_FOUND)
-		add_flag(-DLIBPMEMOBJ_CPP_VG_PMEMCHECK_ENABLED=1)
-	endif()
-endif()
-
 if(NO_GCC_VARIADIC_TEMPLATE_BUG)
 	build_example_queue()
 	add_test_generic(NAME ex-queue CASE 0 TRACERS none)

--- a/tests/ctest_helpers.cmake
+++ b/tests/ctest_helpers.cmake
@@ -123,15 +123,6 @@ function(find_packages)
 		find_package(Curses QUIET)
 	endif()
 
-	# Look for valgrind only if proper option is enabled.
-	if (TESTS_USE_VALGRIND)
-		if(PKG_CONFIG_FOUND)
-			pkg_check_modules(VALGRIND QUIET valgrind)
-		else()
-			find_package(VALGRIND QUIET)
-		endif()
-	endif()
-
 	if(PKG_CONFIG_FOUND)
 		pkg_check_modules(LIBUNWIND QUIET libunwind)
 	else()
@@ -143,9 +134,6 @@ function(find_packages)
 
 	if(NOT WIN32)
 		if(VALGRIND_FOUND)
-			include_directories(${VALGRIND_INCLUDE_DIRS})
-			find_pmemcheck()
-
 			if ((NOT(PMEMCHECK_VERSION LESS 1.0)) AND PMEMCHECK_VERSION LESS 2.0)
 				find_program(PMREORDER names pmreorder HINTS ${LIBPMEMOBJ_PREFIX}/bin)
 				check_pmemobj_cow_support("cow.pool")
@@ -245,7 +233,7 @@ function(add_test_common name tracer testcase cmake_script)
 	    set(tracer none)
 	endif()
 
-	if (NOT WIN32 AND (NOT VALGRIND_FOUND) AND ${tracer} IN_LIST vg_tracers)
+	if (NOT WIN32 AND ((NOT VALGRIND_FOUND) OR (NOT TESTS_USE_VALGRIND)) AND ${tracer} IN_LIST vg_tracers)
 		# Only print "SKIPPED_*" message when option is enabled
 		if (TESTS_USE_VALGRIND)
 			skip_test(${name}_${testcase}_${tracer} "SKIPPED_BECAUSE_OF_MISSING_VALGRIND")
@@ -253,7 +241,7 @@ function(add_test_common name tracer testcase cmake_script)
 		return()
 	endif()
 
-	if (NOT WIN32 AND (NOT VALGRIND_PMEMCHECK_FOUND) AND ${tracer} STREQUAL "pmemcheck")
+	if (NOT WIN32 AND ((NOT VALGRIND_PMEMCHECK_FOUND) OR (NOT TESTS_USE_VALGRIND)) AND ${tracer} STREQUAL "pmemcheck")
 		# Only print "SKIPPED_*" message when option is enabled
 		if (TESTS_USE_VALGRIND)
 			skip_test(${name}_${testcase}_${tracer} "SKIPPED_BECAUSE_OF_MISSING_PMEMCHECK")


### PR DESCRIPTION
to allow compiling examples with valgrind support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/274)
<!-- Reviewable:end -->
