### PR TITLE
[1.6] cmake: require c++11 for cow check

### DIFF
--- a/tests/pmemobj_check_cow/CMakeLists.txt
+++ b/tests/pmemobj_check_cow/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,6 +31,9 @@
 
 cmake_minimum_required(VERSION 3.3)
 project(pmemobj_check_cow CXX)
+
+set(CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 11)
 
 include_directories(${LIBPMEMOBJ_INCLUDE_DIRS})
 include_directories(${LIBPMEMOBJ++_INCLUDE_DIRS})


### PR DESCRIPTION
C++ version was incorrectly computed by cmake to c++98 which resulted in compilation error on ubuntu 16.04

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/280)
<!-- Reviewable:end -->
