### PR TITLE
Change logic for finding font in pmpong example.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -129,16 +129,18 @@ if(SFML_FOUND)
 	target_link_libraries(example-pmpong ${LIBPMEMOBJ_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${SFML_LIBRARIES})
 
 	if(NOT WIN32)
-		execute_process(COMMAND uname -s OUTPUT_VARIABLE SYSTEM_TYPE)
-		if(SYSTEM_TYPE STREQUAL "FreeBSD")
-			set(FONTDIR "/usr/local/share/fonts")
-		else()
-			set(FONTDIR "/usr/share/fonts")
+		find_program(FCLIST NAMES fc-list)
+		if(NOT FCLIST)
+			message(WARNING "fc-list not found. Install fontconfig to allow examples-pmpong to automatically find fonts.")
 		endif()
-		file(GLOB_RECURSE fonts ${FONTDIR}/*.ttf)
-		list(GET fonts 0 font)
-		file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/fontConf ${font})
+
+		execute_process(COMMAND bash -c "fc-list --format='%{file}\n' | head -n1 | tr -d '\n'" OUTPUT_VARIABLE FONT_PATH ERROR_QUIET)
+		set(font ${FONT_PATH})
+	else()
+		set(font "C:/Windows/Fonts/Arial.ttf")
 	endif()
+
+	target_compile_options(example-pmpong PUBLIC -DLIBPMEMOBJ_CPP_PMPONG_FONT_PATH="${font}")
 else()
 	message(WARNING "SFML 2.4 or newer not found - pmpong won't be build")
 endif()

--- a/examples/pmpong/CMakeLists.txt
+++ b/examples/pmpong/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -57,3 +57,17 @@ add_executable(pmpong Ball.cpp GameController.cpp GameOverView.cpp
 		PongGameStatus.cpp Pool.cpp)
 target_include_directories(pmpong PUBLIC ${SFML_INCLUDE_DIR} ${LIBPMEMOBJ++_INCLUDE_DIRS} .)
 target_link_libraries(pmpong ${LIBPMEMOBJ++_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${SFML_LIBRARIES})
+
+if(NOT WIN32)
+	find_program(FCLIST NAMES fc-list)
+	if(NOT FCLIST)
+		message(WARNING "fc-list not found. Install fontconfig to allow examples-pmpong to automatically find fonts.")
+	endif()
+
+	execute_process(COMMAND bash -c "fc-list --format='%{file}\n' | head -n1 | tr -d '\n'" OUTPUT_VARIABLE FONT_PATH ERROR_QUIET)
+	set(font ${FONT_PATH})
+else()
+	set(font "C:/Windows/Fonts/Arial.ttf")
+endif()
+
+target_compile_options(pmpong PUBLIC -DLIBPMEMOBJ_CPP_PMPONG_FONT_PATH="${font}")

--- a/examples/pmpong/GameConstants.hpp
+++ b/examples/pmpong/GameConstants.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Intel Corporation
+ * Copyright 2017-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,20 +68,26 @@
 #define LAYOUT_NAME "DEFAULT_LAYOUT_NAME"
 #define DEFAULT_POOLFILE_NAME "DEFAULT_FILENAME"
 
-static inline std::string
-readFontConf()
+static inline sf::Font
+getFont()
 {
-	static std::string path = "";
-	std::ifstream file("fontConf");
-	if (file.is_open()) {
-		getline(file, path);
+	std::string font_path = "";
+#ifdef LIBPMEMOBJ_CPP_PMPONG_FONT_PATH
+	font_path = LIBPMEMOBJ_CPP_PMPONG_FONT_PATH;
+#endif
+
+	auto env = getenv("LIBPMEMOBJ_CPP_PMPONG_FONT_PATH");
+	if (env != nullptr)
+		font_path = env;
+
+	sf::Font font;
+	if (!font.loadFromFile(font_path)) {
+		throw std::runtime_error(
+			"Cannot find fonts. Please set environmental variable LIBPMEMOBJ_CPP_PMPONG_FONT_PATH"
+			" to path to existing font file");
 	}
-	return path;
+
+	return font;
 }
 
-#ifndef _WIN32
-#define FONT_PATH readFontConf()
-#else
-#define FONT_PATH "C:/Windows/Fonts/Arial.ttf"
-#endif
 #endif /* LIBPMEMOBJ_CPP_EXAMPLES_PMPONG_GAMECONSTANTS_HPP */

--- a/examples/pmpong/GameController.cpp
+++ b/examples/pmpong/GameController.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Intel Corporation
+ * Copyright 2017-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -54,10 +54,7 @@ GameController::gameLoop(bool isSimulation)
 		sf::VideoMode(WINDOW_WIDTH, WINDOW_HEIGHT), GAME_NAME);
 	gameWindow->setFramerateLimit(FRAMERATE_LIMIT);
 
-	sf::Font font;
-	if (!font.loadFromFile(FONT_PATH)) {
-		throw std::runtime_error("Cannot load font from file");
-	}
+	sf::Font font = getFont();
 
 	View *menuView = new MenuView(font);
 	View *gameView = new GameView(font);


### PR DESCRIPTION
Currently, if font is found during build then LIBPMEMOBJ_CPP_PMPONG_FONT_PATH is
set accordingly. Otherwise user has to specify path using environment variable.

Ref: #277 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/287)
<!-- Reviewable:end -->
