### PR TITLE
Mark allocation_flag constructor as explicit.

### DIFF
--- a/include/libpmemobj++/allocation_flag.hpp
+++ b/include/libpmemobj++/allocation_flag.hpp
@@ -61,7 +61,7 @@ struct allocation_flag {
 	/**
 	 * Emplace constructor.
 	 */
-	allocation_flag(uint64_t val) : value(val)
+	explicit allocation_flag(uint64_t val) : value(val)
 	{
 	}
 
@@ -124,7 +124,7 @@ struct allocation_flag_atomic {
 	/**
 	 * Emplace constructor.
 	 */
-	allocation_flag_atomic(uint64_t val) : value(val)
+	explicit allocation_flag_atomic(uint64_t val) : value(val)
 	{
 	}
 


### PR DESCRIPTION
Having implicit constructor caused unexpected beahviour with
make_persistent_array. For make_persistent version designed to
work with sized arrays calling make_persistent<int[100]>(90) didn't
failed as expected. Instead, '90' was implicitly converted to
allocation_flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/330)
<!-- Reviewable:end -->
