### PR TITLE
To support user customized type num

### DIFF
--- a/include/libpmemobj++/detail/common.hpp
+++ b/include/libpmemobj++/detail/common.hpp
@@ -154,11 +154,30 @@ conditional_add_to_tx(const T *that, std::size_t count = 1)
 /*
  * Return type number for given type.
  */
-template <typename T>
-uint64_t
-type_num()
-{
+template <typename T, typename U = int>
+struct type_num_cls {
+  uint64_t operator()(){
 	return typeid(T).hash_code();
+  }
+};
+
+/*
+ * Return type number for given type.
+ */
+template <typename T>
+struct type_num_cls <T, decltype((void)T::type_num(), 0)> {
+  uint64_t operator()(){
+	return T::type_num();
+  }
+};
+
+/*
+ * Return type number for given type.
+ */
+template <typename T>
+uint64_t type_num() {
+  static type_num_cls<T> type_num_fn;
+  return type_num_fn();
 }
 
 /**


### PR DESCRIPTION
In current libpmemobj++ design, type num of a new persistent object is
always typeid(T).hash_code().

In some cases, the library user wants to define his/her own type_num for
a specific class.

Here we check if T has one static function with signature uint64_t
type_num(), we will use its result as the type num.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/334)
<!-- Reviewable:end -->
