### PR TITLE
fix missing include header file

### DIFF
--- a/include/libpmemobj++/experimental/slice.hpp
+++ b/include/libpmemobj++/experimental/slice.hpp
@@ -39,6 +39,7 @@
 #define LIBPMEMOBJ_CPP_SLICE_HPP
 
 #include <iterator>
+#include <stdexcept>
 #include <type_traits>
 
 namespace pmem


### PR DESCRIPTION
stdexcept is needed in slice.hpp for std::out_of_range support

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/343)
<!-- Reviewable:end -->
