### PR TITLE
tests: fix build

### DIFF
--- a/tests/external/libcxx/basic_string/string.modifiers/throwing_iterator.hpp
+++ b/tests/external/libcxx/basic_string/string.modifiers/throwing_iterator.hpp
@@ -19,7 +19,7 @@
 template <typename T>
 struct throwing_it {
   typedef std::bidirectional_iterator_tag iterator_category;
-  typedef ptrdiff_t difference_type;
+  typedef std::ptrdiff_t difference_type;
   typedef const T value_type;
   typedef const T *pointer;
   typedef const T &reference;


### PR DESCRIPTION
```
[ 76%] Building CXX object tests/external/CMakeFiles/string_libcxx_modifiers_append_iterator.dir/libcxx/basic_string/string.modifiers/string_append/iterator.pass.cpp.o
In file included from /home/mslusarz/pmem/libpmemobj-cpp/tests/external/libcxx/basic_string/string.modifiers/string_append/iterator.pass.cpp:15:0:
/home/mslusarz/pmem/libpmemobj-cpp/tests/external/libcxx/basic_string/string.modifiers/string_append/../throwing_iterator.hpp:22:11: error: ‘ptrdiff_t’ does not name a type
   typedef ptrdiff_t difference_type;
           ^~~~~~~~~
In file included from /home/mslusarz/pmem/libpmemobj-cpp/tests/common/unittest.hpp:38:0,
                 from /home/mslusarz/pmem/libpmemobj-cpp/tests/external/libcxx/basic_string/string.modifiers/string_append/iterator.pass.cpp:16:
/home/mslusarz/pmem/libpmemobj-cpp/tests/common/iterators_support.hpp: In instantiation of ‘class test_support::forward_it<throwing_it<char> >’:
/home/mslusarz/pmem/libpmemobj-cpp/tests/external/libcxx/basic_string/string.modifiers/string_append/iterator.pass.cpp:196:50:   required from here
/home/mslusarz/pmem/libpmemobj-cpp/tests/common/iterators_support.hpp:184:66: error: no type named ‘value_type’ in ‘struct std::iterator_traits<throwing_it<char> >’
  using value_type = typename std::iterator_traits<It>::value_type;
                                                                  ^
/home/mslusarz/pmem/libpmemobj-cpp/tests/common/iterators_support.hpp:186:53: error: no type named ‘difference_type’ in ‘struct std::iterator_traits<throwing_it<char> >’
   typename std::iterator_traits<It>::difference_type;
                                                     ^
/home/mslusarz/pmem/libpmemobj-cpp/tests/common/iterators_support.hpp:187:60: error: no type named ‘pointer’ in ‘struct std::iterator_traits<throwing_it<char> >’
  using pointer = typename std::iterator_traits<It>::pointer;
                                                            ^
/home/mslusarz/pmem/libpmemobj-cpp/tests/common/iterators_support.hpp:188:64: error: no type named ‘reference’ in ‘struct std::iterator_traits<throwing_it<char> >’
  using reference = typename std::iterator_traits<It>::reference;
                                                                ^
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/344)
<!-- Reviewable:end -->
