### PR TITLE
Drop libdir from pkgconfig.

### DIFF
--- a/cmake/libpmemobj++.pc.in
+++ b/cmake/libpmemobj++.pc.in
@@ -1,5 +1,4 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: libpmemobj++


### PR DESCRIPTION
The library is header-only, thus there's no binary lib to link against.

[Upstreaming a patch from Debian/Ubuntu, there since 1.5.]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/353)
<!-- Reviewable:end -->
