### PR TITLE
cmake: fix tbb detection for distros without tbb cmake integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ if(BUILD_TESTS OR BUILD_EXAMPLES)
 
 	math(EXPR LIBPMEMOBJ_VERSION_NUM "${LIBPMEMOBJ_VERSION_PATCH} + ${LIBPMEMOBJ_VERSION_MINOR} * 100 + ${LIBPMEMOBJ_VERSION_MAJOR} * 10000")
 
-	find_package(TBB COMPONENTS tbb)
+	include(tbb)
 endif()
 
 add_executable(check_license EXCLUDE_FROM_ALL utils/check_license/check-license.c)

--- a/cmake/tbb.cmake
+++ b/cmake/tbb.cmake
@@ -1,0 +1,50 @@
+# Copyright 2017-2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+if(PKG_CONFIG_FOUND)
+	pkg_check_modules(TBB tbb)
+endif()
+
+if(NOT TBB_FOUND)
+	# find_package without unsetting this var is not working correctly
+	unset(TBB_FOUND CACHE)
+	find_package(TBB COMPONENTS tbb)
+
+	if(TBB_FOUND)
+		message(STATUS "TBB package found without pkg-config")
+	endif()
+
+	set(TBB_LIBRARIES ${TBB_IMPORTED_TARGETS})
+endif()
+
+if(NOT TBB_FOUND)
+	message(WARNING "TBB not found. Please set TBB_DIR CMake variable if TBB \
+is installed in a non-standard directory, like: -DTBB_DIR=<path_to_tbb_cmake_dir>")
+endif()

--- a/tests/ctest_helpers.cmake
+++ b/tests/ctest_helpers.cmake
@@ -178,7 +178,7 @@ endfunction()
 
 function(build_test_tbb name)
 	build_test(${name} ${ARGN})
-	target_link_libraries(${name} ${TBB_IMPORTED_TARGETS})
+	target_link_libraries(${name} ${TBB_LIBRARIES})
 endfunction()
 
 set(vg_tracers memcheck helgrind drd pmemcheck)


### PR DESCRIPTION
Solution copied from pmemkv.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/355)
<!-- Reviewable:end -->
