### PR TITLE
[1.7] Fix void_t declaration.

### DIFF
--- a/include/libpmemobj++/detail/template_helpers.hpp
+++ b/include/libpmemobj++/detail/template_helpers.hpp
@@ -46,11 +46,15 @@ namespace pmem
 namespace detail
 {
 
-template <typename...>
-using void_t = void;
+template <typename... Ts>
+struct make_void {
+	typedef void type;
+};
+template <typename... Ts>
+using void_t = typename make_void<Ts...>::type;
 
-// Generic SFINAE helper for expression checks, based on the idea demonstrated
-// in ISO C++ paper n4502
+/* Generic SFINAE helper for expression checks, based on the idea demonstrated
+ * in ISO C++ paper n4502 */
 template <typename T, typename, template <typename> class... Checks>
 struct supports_impl {
 	using type = std::false_type;


### PR DESCRIPTION
Until CWG 1558 (a C++14 defect), unused parameters in alias templates were
not guaranteed to ensure SFINAE and could be ignored, this implementation
of void_t solves this issue. See: https://en.cppreference.com/w/cpp/types/void_t

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/359)
<!-- Reviewable:end -->
