### PR TITLE
Throw transaction_scope_error in case vector/string ctor was called o…

### DIFF
--- a/include/libpmemobj++/experimental/basic_string.hpp
+++ b/include/libpmemobj++/experimental/basic_string.hpp
@@ -316,7 +316,7 @@ private:
  * @pre must be called in transaction scope.
  *
  * @throw pmem::pool_error if an object is not in persistent memory.
- * @throw pmem::transaction_error if constructor wasn't called in
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
  * transaction.
  */
 template <typename CharT, typename Traits>
@@ -339,7 +339,7 @@ basic_string<CharT, Traits>::basic_string()
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for
  * underlying storage in transaction failed.
- * @throw pmem::transaction_error if constructor wasn't called in
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
  * transaction.
  */
 template <typename CharT, typename Traits>
@@ -365,7 +365,7 @@ basic_string<CharT, Traits>::basic_string(size_type count, CharT ch)
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for
  * underlying storage in transaction failed.
- * @throw pmem::transaction_error if constructor wasn't called in
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
  * transaction.
  */
 template <typename CharT, typename Traits>
@@ -402,7 +402,7 @@ basic_string<CharT, Traits>::basic_string(const basic_string &other,
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for
  * underlying storage in transaction failed.
- * @throw pmem::transaction_error if constructor wasn't called in
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
  * transaction.
  */
 template <typename CharT, typename Traits>
@@ -436,7 +436,7 @@ basic_string<CharT, Traits>::basic_string(const std::basic_string<CharT> &other,
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for
  * underlying storage in transaction failed.
- * @throw pmem::transaction_error if constructor wasn't called in
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
  * transaction.
  */
 template <typename CharT, typename Traits>
@@ -458,7 +458,7 @@ basic_string<CharT, Traits>::basic_string(const CharT *s, size_type count)
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for
  * underlying storage in transaction failed.
- * @throw pmem::transaction_error if constructor wasn't called in
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
  * transaction.
  */
 template <typename CharT, typename Traits>
@@ -485,7 +485,7 @@ basic_string<CharT, Traits>::basic_string(const CharT *s)
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for
  * underlying storage in transaction failed.
- * @throw pmem::transaction_error if constructor wasn't called in
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
  * transaction.
  */
 template <typename CharT, typename Traits>
@@ -512,7 +512,7 @@ basic_string<CharT, Traits>::basic_string(InputIt first, InputIt last)
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for
  * underlying storage in transaction failed.
- * @throw pmem::transaction_error if constructor wasn't called in
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
  * transaction.
  */
 template <typename CharT, typename Traits>
@@ -536,7 +536,7 @@ basic_string<CharT, Traits>::basic_string(const basic_string &other)
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for
  * underlying storage in transaction failed.
- * @throw pmem::transaction_error if constructor wasn't called in
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
  * transaction.
  */
 template <typename CharT, typename Traits>
@@ -556,7 +556,7 @@ basic_string<CharT, Traits>::basic_string(const std::basic_string<CharT> &other)
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for
  * underlying storage in transaction failed.
- * @throw pmem::transaction_error if constructor wasn't called in
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
  * transaction.
  */
 template <typename CharT, typename Traits>
@@ -582,7 +582,7 @@ basic_string<CharT, Traits>::basic_string(basic_string &&other)
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for
  * underlying storage in transaction failed.
- * @throw pmem::transaction_error if constructor wasn't called in
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
  * transaction.
  */
 template <typename CharT, typename Traits>
@@ -2417,20 +2417,20 @@ basic_string<CharT, Traits>::check_pmem() const
 }
 
 /**
- * @throw pmem::transaction_error if called outside of a transaction.
+ * @throw pmem::transaction_scope_error if called outside of a transaction.
  */
 template <typename CharT, typename Traits>
 void
 basic_string<CharT, Traits>::check_tx_stage_work() const
 {
 	if (pmemobj_tx_stage() != TX_STAGE_WORK)
-		throw pmem::transaction_error(
+		throw pmem::transaction_scope_error(
 			"Call made out of transaction scope.");
 }
 
 /**
  * @throw pmem::pool_error if an object is not in persistent memory.
- * @throw pmem::transaction_error if called outside of a transaction.
+ * @throw pmem::transaction_scope_error if called outside of a transaction.
  */
 template <typename CharT, typename Traits>
 void

--- a/include/libpmemobj++/experimental/vector.hpp
+++ b/include/libpmemobj++/experimental/vector.hpp
@@ -282,7 +282,8 @@ bool operator>=(const std::vector<T> &lhs, const vector<T> &rhs);
  * @pre must be called in transaction scope.
  *
  * @throw pmem::pool_error if an object is not in persistent memory.
- * @throw pmem::transaction_error if constructor wasn't called in transaction.
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
+ * transaction.
  */
 template <typename T>
 vector<T>::vector()
@@ -309,7 +310,8 @@ vector<T>::vector()
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for underlying
  * array in transaction failed.
- * @throw pmem::transaction_error if constructor wasn't called in transaction.
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
+ * transaction.
  * @throw rethrows element constructor exception.
  */
 template <typename T>
@@ -337,7 +339,8 @@ vector<T>::vector(size_type count, const value_type &value)
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for underlying
  * array in transaction failed.
- * @throw pmem::transaction_error if constructor wasn't called in transaction.
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
+ * transaction.
  * @throw rethrows element constructor exception.
  */
 template <typename T>
@@ -370,7 +373,8 @@ vector<T>::vector(size_type count)
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for underlying
  * array in transaction failed.
- * @throw pmem::transaction_error if constructor wasn't called in transaction.
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
+ * transaction.
  * @throw rethrows element constructor exception.
  */
 template <typename T>
@@ -402,7 +406,8 @@ vector<T>::vector(InputIt first, InputIt last)
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for underlying
  * array in transaction failed.
- * @throw pmem::transaction_error if constructor wasn't called in transaction.
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
+ * transaction.
  * @throw rethrows element constructor exception.
  */
 template <typename T>
@@ -433,7 +438,8 @@ vector<T>::vector(const vector &other)
  * @post other.size() == 0
  *
  * @throw pmem::pool_error if an object is not in persistent memory.
- * @throw pmem::transaction_error if constructor wasn't called in transaction.
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
+ * transaction.
  */
 template <typename T>
 vector<T>::vector(vector &&other)
@@ -461,7 +467,8 @@ vector<T>::vector(vector &&other)
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for underlying
  * array in transaction failed.
- * @throw pmem::transaction_error if constructor wasn't called in transaction.
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
+ * transaction.
  * @throw rethrows element constructor exception.
  */
 template <typename T>
@@ -484,7 +491,8 @@ vector<T>::vector(std::initializer_list<T> init)
  * @throw pmem::pool_error if an object is not in persistent memory.
  * @throw pmem::transaction_alloc_error when allocating memory for underlying
  * array in transaction failed.
- * @throw pmem::transaction_error if constructor wasn't called in transaction.
+ * @throw pmem::transaction_scope_error if constructor wasn't called in
+ * transaction.
  * @throw rethrows element constructor exception.
  */
 template <typename T>
@@ -2083,15 +2091,15 @@ vector<T>::check_pmem()
  * Private helper function. Checks if current transaction stage is equal to
  * TX_STAGE_WORK and throws an exception otherwise.
  *
- * @throw pmem::transaction_error if current transaction stage is not equal to
- * TX_STAGE_WORK.
+ * @throw pmem::transaction_scope_error if current transaction stage is not
+ * equal to TX_STAGE_WORK.
  */
 template <typename T>
 void
 vector<T>::check_tx_stage_work()
 {
 	if (pmemobj_tx_stage() != TX_STAGE_WORK)
-		throw pmem::transaction_error(
+		throw pmem::transaction_scope_error(
 			"Function called out of transaction scope.");
 }
 

--- a/tests/string_exceptions/string_exceptions.cpp
+++ b/tests/string_exceptions/string_exceptions.cpp
@@ -77,7 +77,7 @@ assert_pool_exception(std::function<void(void)> f)
 }
 
 /*
- * this function verifies that f() throws transaction_error exception.
+ * this function verifies that f() throws transaction_scope_error exception.
  */
 void
 assert_tx_exception(std::function<void(void)> f)
@@ -86,7 +86,7 @@ assert_tx_exception(std::function<void(void)> f)
 	try {
 		f();
 		UT_ASSERT(0);
-	} catch (pmem::transaction_error &) {
+	} catch (pmem::transaction_scope_error &) {
 		exception_thrown = true;
 	} catch (std::exception &e) {
 		UT_FATALexc(e);

--- a/tests/vector_ctor_exceptions_notx/vector_ctor_exceptions_notx.cpp
+++ b/tests/vector_ctor_exceptions_notx/vector_ctor_exceptions_notx.cpp
@@ -44,7 +44,7 @@ using vector_type = pmem_exp::vector<int>;
  * Test pmem::obj::experimental::vector default constructor.
  *
  * Call default constructor out of transaction scope.
- * Expect pmem:transaction_error exception is thrown.
+ * Expect pmem:transaction_scope_error exception is thrown.
  */
 void
 test_default_ctor(nvobj::pool<struct root> &pop)
@@ -60,7 +60,7 @@ test_default_ctor(nvobj::pool<struct root> &pop)
 				UT_ASSERT(0);
 		});
 		pmem::detail::create<vector_type>(&*pptr_v);
-	} catch (pmem::transaction_error &) {
+	} catch (pmem::transaction_scope_error &) {
 		exception_thrown = true;
 	} catch (std::exception &e) {
 		UT_FATALexc(e);
@@ -72,7 +72,7 @@ test_default_ctor(nvobj::pool<struct root> &pop)
  * Test pmem::obj::experimental::vector range constructor.
  *
  * Call range constructor out of transaction scope.
- * Expect pmem:transaction_error exception is thrown.
+ * Expect pmem:transaction_scope_error exception is thrown.
  */
 void
 test_iter_iter_ctor(nvobj::pool<struct root> &pop)
@@ -92,7 +92,7 @@ test_iter_iter_ctor(nvobj::pool<struct root> &pop)
 		pmem::detail::create<vector_type, vector_type::iterator,
 				     vector_type::iterator>(
 			&*pptr_v, std::begin(a), std::end(a));
-	} catch (pmem::transaction_error &) {
+	} catch (pmem::transaction_scope_error &) {
 		exception_thrown = true;
 	} catch (std::exception &e) {
 		UT_FATALexc(e);
@@ -105,7 +105,7 @@ test_iter_iter_ctor(nvobj::pool<struct root> &pop)
  * default values.
  *
  * Call fill constructor out of transaction scope.
- * Expect pmem:transaction_error exception is thrown.
+ * Expect pmem:transaction_scope_error exception is thrown.
  */
 void
 test_size_ctor(nvobj::pool<struct root> &pop)
@@ -122,7 +122,7 @@ test_size_ctor(nvobj::pool<struct root> &pop)
 		});
 		pmem::detail::create<vector_type, vector_type::size_type>(
 			&*pptr_v, 100);
-	} catch (pmem::transaction_error &) {
+	} catch (pmem::transaction_scope_error &) {
 		exception_thrown = true;
 	} catch (std::exception &e) {
 		UT_FATALexc(e);
@@ -135,7 +135,7 @@ test_size_ctor(nvobj::pool<struct root> &pop)
  * custom values.
  *
  * Call fill constructor out of transaction scope.
- * Expect pmem:transaction_error exception is thrown.
+ * Expect pmem:transaction_scope_error exception is thrown.
  */
 void
 test_size_value_ctor(nvobj::pool<struct root> &pop)
@@ -152,7 +152,7 @@ test_size_value_ctor(nvobj::pool<struct root> &pop)
 		});
 		pmem::detail::create<vector_type, vector_type::size_type,
 				     vector_type::value_type>(&*pptr_v, 100, 5);
-	} catch (pmem::transaction_error &) {
+	} catch (pmem::transaction_scope_error &) {
 		exception_thrown = true;
 	} catch (std::exception &e) {
 		UT_FATALexc(e);
@@ -164,7 +164,7 @@ test_size_value_ctor(nvobj::pool<struct root> &pop)
  * Test pmem::obj::experimental::vector copy constructor.
  *
  * Call copy constructor out of transaction scope.
- * Expect pmem:transaction_error exception is thrown.
+ * Expect pmem:transaction_scope_error exception is thrown.
  */
 void
 test_copy_ctor(nvobj::pool<struct root> &pop)
@@ -191,7 +191,7 @@ test_copy_ctor(nvobj::pool<struct root> &pop)
 				UT_ASSERT(0);
 		});
 		pmem::detail::create<vector_type>(&*pptr_v, *pptr);
-	} catch (pmem::transaction_error &) {
+	} catch (pmem::transaction_scope_error &) {
 		exception_thrown = true;
 	} catch (std::exception &e) {
 		UT_FATALexc(e);
@@ -211,7 +211,7 @@ test_copy_ctor(nvobj::pool<struct root> &pop)
  * Test pmem::obj::experimental::vector initializer list constructor.
  *
  * Call initializer list constructor out of transaction scope.
- * Expect pmem:transaction_error exception is thrown.
+ * Expect pmem:transaction_scope_error exception is thrown.
  */
 void
 test_initializer_list_ctor(nvobj::pool<struct root> &pop)
@@ -228,7 +228,7 @@ test_initializer_list_ctor(nvobj::pool<struct root> &pop)
 		});
 		pmem::detail::create<vector_type>(
 			&*pptr_v, std::initializer_list<int>{1, 2, 3, 4});
-	} catch (pmem::transaction_error &) {
+	} catch (pmem::transaction_scope_error &) {
 		exception_thrown = true;
 	} catch (std::exception &e) {
 		UT_FATALexc(e);
@@ -240,7 +240,7 @@ test_initializer_list_ctor(nvobj::pool<struct root> &pop)
  * Test pmem::obj::experimental::vector move constructor.
  *
  * Call move constructor out of transaction scope.
- * Expect pmem:transaction_error exception is thrown.
+ * Expect pmem:transaction_scope_error exception is thrown.
  */
 void
 test_move_ctor(nvobj::pool<struct root> &pop)
@@ -266,7 +266,7 @@ test_move_ctor(nvobj::pool<struct root> &pop)
 				UT_ASSERT(0);
 		});
 		pmem::detail::create<vector_type>(&*pptr_v, std::move(*pptr));
-	} catch (pmem::transaction_error &) {
+	} catch (pmem::transaction_scope_error &) {
 		exception_thrown = true;
 	} catch (std::exception &e) {
 		UT_FATALexc(e);


### PR DESCRIPTION
…utside tx

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/368)
<!-- Reviewable:end -->
