### PR TITLE
Call object destructor in v<> destructor

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -164,7 +164,7 @@ endif()
 
 if(PMEMVLT_PRESENT)
 	build_test(v v/v.cpp)
-	add_test_generic(NAME v CASE 0 TRACERS none memcheck)
+	add_test_generic(NAME v CASE 0 TRACERS none memcheck pmemcheck)
 else()
 	message(WARNING "Skipping v test because no pmemvlt support found")
 	skip_test("v" "SKIPPED_BECAUSE_OF_MISSING_PMEMVLT")


### PR DESCRIPTION
Current issue:
If v<> is stored in a persistent object which is destroyed in a tx and
this tx aborts, we have no way to rollback v<> destructor (it is not tracked
in a transaction).

This patch allows to call object destructor by zeroing pmemvlt.runid.
This guarantees that any next reference to v<> will reinitialize the object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/382)
<!-- Reviewable:end -->
