### PR TITLE
Fix concurrent_hash_map_pmreorder_multiple_buckets test

### DIFF
--- a/tests/concurrent_hash_map_pmreorder_multiple_buckets/concurrent_hash_map_pmreorder_multiple_buckets.cpp
+++ b/tests/concurrent_hash_map_pmreorder_multiple_buckets/concurrent_hash_map_pmreorder_multiple_buckets.cpp
@@ -227,7 +227,7 @@ main(int argc, char *argv[])
 
 			nvobj::make_persistent_atomic<persistent_map_type>(
 				pop, pop.root()->cons);
-			pop.root()->cons->insert(value_type(1, 1));
+			pop.root()->cons->insert(value_type(0, 0));
 		} else if (argv[1][0] == 'i') {
 			pop = nvobj::pool<root>::open(path, LAYOUT);
 


### PR DESCRIPTION
The check_consistency() function verifies if the hash map contains
elements (0, 0), (1, 1), (2, 2)... starting from (0, 0),
so the first inserted element should be (0, 0), not (1, 1).

---
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/384)
<!-- Reviewable:end -->
