### PR TITLE
Appveyor: switch to Visual Studio 2017

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 1.4.{build}
-os: Visual Studio 2015
+os: Visual Studio 2017
 platform: x64
 
 environment:


### PR DESCRIPTION
This change is required because of the following issue:
https://help.appveyor.com/discussions/problems/24684-problem-with-vcpkg-wrong-version-on-appveyor
appveyor/ci#3052
which cannot be fixed directly now.

---
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/397)
<!-- Reviewable:end -->
