### PR TITLE
appveyor: set PMEM_IS_PMEM_FORCE in tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ before_build:
 - cmake . -Bbuild -G "%GENERATOR%"
         -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
         -DCMAKE_INSTALL_PREFIX=c:/install/libpmemobj-cpp
+        -DTESTS_USE_FORCED_PMEM=ON
 
 build_script:
 - msbuild build/ALL_BUILD.vcxproj /property:Configuration=%CONFIGURATION%
@@ -38,4 +39,5 @@ test_script:
 - cmake . -G "%GENERATOR%"
         -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
         -DCMAKE_PREFIX_PATH=c:/install/libpmemobj-cpp
+        -DTESTS_USE_FORCED_PMEM=ON
 - msbuild ALL_BUILD.vcxproj


### PR DESCRIPTION
PMEM_IS_PMEM_FORCE is not set in tests
and Appveyor build is timed out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/401)
<!-- Reviewable:end -->
