### PR TITLE
string: mark sso memory as initialized in initialize()

### DIFF
--- a/include/libpmemobj++/experimental/basic_string.hpp
+++ b/include/libpmemobj++/experimental/basic_string.hpp
@@ -2254,6 +2254,11 @@ basic_string<CharT, Traits>::initialize(Args &&... args)
 {
 	assert(pmemobj_tx_stage() == TX_STAGE_WORK);
 
+	/* Mark sso array as initialized */
+#if LIBPMEMOBJ_CPP_VG_MEMCHECK_ENABLED
+	VALGRIND_MAKE_MEM_DEFINED(&sso.data, sizeof(sso.data));
+#endif
+
 	auto size = get_size(std::forward<Args>(args)...);
 
 	if (is_sso_used()) {
@@ -2457,12 +2462,9 @@ template <typename CharT, typename Traits>
 void
 basic_string<CharT, Traits>::snapshot_sso() const
 {
-/*
- * XXX: this can be optimized - only snapshot length() elements.
- */
-#if LIBPMEMOBJ_CPP_VG_MEMCHECK_ENABLED
-	VALGRIND_MAKE_MEM_DEFINED(&sso.data, sizeof(sso.data));
-#endif
+	/*
+	 * XXX: this can be optimized - only snapshot length() elements.
+	 */
 	sso.data.data();
 };
 

--- a/tests/string_snapshot/string_snapshot.cpp
+++ b/tests/string_snapshot/string_snapshot.cpp
@@ -38,6 +38,8 @@
 #include <libpmemobj++/pool.hpp>
 #include <libpmemobj++/transaction.hpp>
 
+#include <libpmemobj++/detail/common.hpp>
+
 #include <iostream>
 
 namespace pmemobj_exp = pmem::obj::experimental;
@@ -78,6 +80,14 @@ test_string_snapshot(pmem::obj::pool<struct root> &pop)
 				    strlen(short_c_str_ctor));
 			UT_ASSERTeq(r->long_str->size(),
 				    strlen(long_c_str_ctor));
+		});
+	} catch (std::exception &e) {
+		UT_FATALexc(e);
+	}
+
+	try {
+		pmem::obj::transaction::run(pop, [&] {
+			pmem::detail::conditional_add_to_tx(r->short_str.get());
 		});
 	} catch (std::exception &e) {
 		UT_FATALexc(e);


### PR DESCRIPTION
If sso would not be marked as defined, memcheck would report
an error if use would snapshot the string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/402)
<!-- Reviewable:end -->
