### PR TITLE
Decrease Visual Studio warning level to W3

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ add_check_whitespace(tests-common ${CMAKE_CURRENT_SOURCE_DIR}/common/*.*pp ${CMA
 add_check_whitespace(tests-cmake ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt)
 
 if(MSVC_VERSION)
-	add_flag(-W4)
+	add_flag(-W3)
 	add_flag(-bigobj) # fix C1128 raised for some test binaries
 else()
 	add_flag(-Wall)


### PR DESCRIPTION
... to reduce the Appveyor build time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/403)
<!-- Reviewable:end -->
