### PR TITLE
Fix warnings C4800: 'int': forcing value to bool

### DIFF
--- a/include/libpmemobj++/allocation_flag.hpp
+++ b/include/libpmemobj++/allocation_flag.hpp
@@ -98,7 +98,7 @@ struct allocation_flag {
 	bool
 	is_set(const allocation_flag &rhs)
 	{
-		return value & rhs.value;
+		return (value & rhs.value) != 0;
 	}
 
 	allocation_flag
@@ -152,7 +152,7 @@ struct allocation_flag_atomic {
 	bool
 	is_set(const allocation_flag_atomic &rhs)
 	{
-		return value & rhs.value;
+		return (value & rhs.value) != 0;
 	}
 
 	allocation_flag_atomic

--- a/include/libpmemobj++/experimental/basic_string.hpp
+++ b/include/libpmemobj++/experimental/basic_string.hpp
@@ -2152,7 +2152,7 @@ template <typename CharT, typename Traits>
 bool
 basic_string<CharT, Traits>::is_sso_used() const
 {
-	return sso._size & _sso_mask;
+	return (sso._size & _sso_mask) != 0;
 }
 
 template <typename CharT, typename Traits>

--- a/tests/array_slice/array_slice.cpp
+++ b/tests/array_slice/array_slice.cpp
@@ -588,7 +588,7 @@ main(int argc, char *argv[])
 		return 1;
 	}
 
-	Is_pmemcheck_enabled = std::stoi(argv[2]);
+	Is_pmemcheck_enabled = (std::stoi(argv[2])) != 0;
 
 	auto path = argv[1];
 	auto pop = pmem::obj::pool<root>::create(


### PR DESCRIPTION
It fixes 503 warnings #C4800.

Ref: #409

---
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/405)
<!-- Reviewable:end -->
