### PR TITLE
concurrent_hash_map: remove wrong assert in get_node method

### DIFF
--- a/include/libpmemobj++/experimental/concurrent_hash_map.hpp
+++ b/include/libpmemobj++/experimental/concurrent_hash_map.hpp
@@ -2386,11 +2386,6 @@ protected:
 	get_node(const K &key, const hashcode_t h, hashcode_t &m,
 		 bucket_accessor *b)
 	{
-#ifndef NDEBUG
-		if (b && b->get())
-			internal::assert_not_locked(b->get()->mutex);
-#endif
-
 #if LIBPMEMOBJ_CPP_VG_HELGRIND_ENABLED
 		ANNOTATE_HAPPENS_AFTER(&my_mask);
 #endif


### PR DESCRIPTION
Condition in the assert is not guaranteed to be true - it was
added by mistake in: 7d7eebac749329f1f2823ca6971f95d243997dda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/437)
<!-- Reviewable:end -->
