### PR TITLE
Update doxygen files

### DIFF
--- a/doc/libpmemobj++.Doxyfile.in
+++ b/doc/libpmemobj++.Doxyfile.in
@@ -23,7 +23,7 @@ PROJECT_NAME = "PMDK C++ bindings"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER = "1.2.0"
+PROJECT_NUMBER = @VERSION@
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/libpmemobj++/README.md
+++ b/include/libpmemobj++/README.md
@@ -35,7 +35,7 @@ not stored in persistent memory, therefore their value will _not_ always be
 consistent across subsequent executions or compilations of user applications.
 
 If you find any issues or have suggestion about these bindings please file an
-issue in https://github.com/pmem/issues. There are also blog articles in
+issue in https://github.com/pmem/libpmemobj-cpp/issues. There are also blog articles in
 http://pmem.io/blog/ which you might find helpful.
 
 Have fun!
@@ -45,7 +45,7 @@ The PMDK team
 The C++ bindings require a C++11 compliant compiler, therefore the minimal
 versions of GCC and Clang are 4.8.1 and 3.3 respectively. However the
 pmem::obj::transaction::automatic class requires C++17, so
-you need a more recent version for this to be available(GCC 6.1/Clang 3.7).
+you need a more recent version for this to be available (GCC 6.1/Clang 3.7).
 It is recommended to use these or newer versions of GCC or Clang.
 
 ### Standard notice ###


### PR DESCRIPTION
- URL for issues in doxygen's README was wrong,
- doxygen docs version was hard-coded.

I guess, to be fixed also for 1.5 and 1.6


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/439)
<!-- Reviewable:end -->
