### PR TITLE
Fix persistent_pool_ptr swap() method signature

### DIFF
--- a/include/libpmemobj++/detail/persistent_pool_ptr.hpp
+++ b/include/libpmemobj++/detail/persistent_pool_ptr.hpp
@@ -319,7 +319,7 @@ public:
 	 * Swaps two persistent_pool_ptr objects of the same type.
 	 */
 	void
-	swap(persistent_pool_ptr &other) noexcept
+	swap(persistent_pool_ptr &other)
 	{
 		conditional_add_to_tx(this);
 		conditional_add_to_tx(&other);


### PR DESCRIPTION
conditional_add_to_tx can throw an exception which means swap()
should not be noexcept.

Fiexes one coverity issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/448)
<!-- Reviewable:end -->
