### PR TITLE
remove TTB info from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,6 @@ $GEN is type of package generator and can be RPM or DEB
 
 CMAKE_INSTALL_PREFIX must be set to a destination were packages will be installed
 
-#### To use Intel(R) Threading Building Blocks library ####
-
-By default concurrent_hash_map uses pmem::obj::shared_mutex internally. But read-write mutex from Intel(R) Threading Building Blocks library can be used instead to achieve better performance. To enable it in your application set the following compilation flag:
-- -DLIBPMEMOBJ_CPP_USE_TBB_RW_MUTEX=1
-
-If you want to build tests for concurrent_hash_map with read-write mutex from Intel(R) Threading Building Blocks library, run cmake with ```-DTBB_DIR=<Path to Intel TBB>/cmake``` option.
-
-Intel(R) Threading Building Blocks library can be downloaded from the official [release page](https://github.com/01org/tbb/releases).
-
 #### To use with Valgrind ####
 
 In order to build your application with libpmemobj-cpp and


### PR DESCRIPTION
it is outdated and redundant

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/450)
<!-- Reviewable:end -->
