### PR TITLE
Increase timeout for valgrind tests on travis

### DIFF
--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -156,7 +156,7 @@ function tests_gcc_debug_no_valgrind() {
 function tests_gcc_debug_valgrind() {
 	printf "\n$(tput setaf 1)$(tput setab 7)BUILD ${FUNCNAME[0]} START$(tput sgr 0)\n"
 	build_gcc_debug
-	ctest -E "_none" --timeout 540
+	ctest -E "_none" --timeout 700
 	ctest -R "_pmreorder" --timeout 540
 	cd ..
 	rm -r build


### PR DESCRIPTION
So that concurrent_hash_map_drd tests will not fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/455)
<!-- Reviewable:end -->
