### PR TITLE
segment_vector: fix typo and doxygen comments

### DIFF
--- a/include/libpmemobj++/experimental/segment_vector.hpp
+++ b/include/libpmemobj++/experimental/segment_vector.hpp
@@ -218,7 +218,7 @@ segment_iterator<Container, is_const>::operator++(int)
 }
 
 /**
- * Random acess incrementing.
+ * Random access incrementing.
  *
  * @return incremented segment_iterator.
  */
@@ -230,7 +230,7 @@ segment_iterator<Container, is_const>::operator+(difference_type idx) const
 }
 
 /**
- * Random acess incrementing with assignment.
+ * Random access incrementing with assignment.
  *
  * @return incremented segment_iterator.
  */
@@ -270,7 +270,7 @@ segment_iterator<Container, is_const>::operator--(int)
 }
 
 /**
- * Random acess decrementing.
+ * Random access decrementing.
  *
  * @return decremented segment_iterator.
  */
@@ -282,7 +282,7 @@ segment_iterator<Container, is_const>::operator-(difference_type idx) const
 }
 
 /**
- * Random acess decrementing with assignment.
+ * Random access decrementing with assignment.
  *
  * @return decremented segment_iterator.
  */
@@ -325,7 +325,7 @@ operator-(const segment_iterator<Container, C> &rhs)
 /**
  * Equality operator.
  *
- * @param[in] segment_iterator<Container, C> to compare with.
+ * @param[in] rhs segment_iterator<Container, C> to compare with.
  *
  * @return true if rhs is equal to current iterator, false otherwise.
  */
@@ -341,7 +341,7 @@ operator==(const segment_iterator<Container, C> &rhs)
 /**
  * Not equal operator.
  *
- * @param[in] segment_iterator<Container, C> to compare with.
+ * @param[in] rhs segment_iterator<Container, C> to compare with.
  *
  * @return true if rhs is not equal to current iterator, false
  * otherwise.
@@ -358,7 +358,7 @@ operator!=(const segment_iterator<Container, C> &rhs)
 /**
  * Less operator.
  *
- * @param[in] segment_iterator<Container, C> to compare with.
+ * @param[in] rhs segment_iterator<Container, C> to compare with.
  *
  * @return true if current index less than rhs index, false otherwise.
  *
@@ -380,7 +380,7 @@ operator<(const segment_iterator<Container, C> &rhs)
 /**
  * Greater operator.
  *
- * @param[in] segment_iterator<Container, C> to compare with.
+ * @param[in] rhs segment_iterator<Container, C> to compare with.
  *
  * @return true if current index greater than rhs index, false
  * otherwise.
@@ -403,7 +403,7 @@ operator>(const segment_iterator<Container, C> &rhs)
 /**
  * Less or equal operator.
  *
- * @param[in] segment_iterator<Container, C> to compare with.
+ * @param[in] rhs segment_iterator<Container, C> to compare with.
  *
  * @return true if current index less or equal to rhs index, false
  * otherwise.
@@ -426,7 +426,7 @@ operator<=(const segment_iterator<Container, C> &rhs)
 /**
  * Greater or equal operator.
  *
- * @param[in] segment_iterator<Container, C> to compare with.
+ * @param[in] rhs segment_iterator<Container, C> to compare with.
  *
  * @return true if current index greater or equal to rhs index, false
  * otherwise.
@@ -755,7 +755,7 @@ public:
 	segment_vector &operator=(const std::vector<T> &other);
 
 	/* Assign methods */
-	void assign(size_type count, const T &value);
+	void assign(size_type count, const_reference value);
 	template <typename InputIt,
 		  typename std::enable_if<
 			  detail::is_input_iterator<InputIt>::value,
@@ -2831,10 +2831,10 @@ segment_vector<T, Segment, Policy>::get_pool() const noexcept
 
 /**
  * Private helper function. Takes a “snapshot” of data in range
- * [this[idx_first], this[idx_last])
+ * [this[first], this[last])
  *
- * @param[in] idx_first first index.
- * @param[in] idx_last last index.
+ * @param[in] first first index.
+ * @param[in] last last index.
  *
  * @throw pmem::transaction_error when snapshotting failed.
  */


### PR DESCRIPTION
This fixes warnings generated by doxygen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/466)
<!-- Reviewable:end -->
