### PR TITLE
Change header_features constant to a function in concurrent_hash_map.

### DIFF
--- a/include/libpmemobj++/container/concurrent_hash_map.hpp
+++ b/include/libpmemobj++/container/concurrent_hash_map.hpp
@@ -890,9 +890,6 @@ public:
 		uint32_t incompat;
 	};
 
-	/** Features supported by this header */
-	static constexpr features header_features = {0, 0};
-
 	/* --------------------------------------------------------- */
 
 	/** ID of persistent memory pool where hash map resides. */
@@ -900,7 +897,7 @@ public:
 
 	/** Specifies features of a hashmap, used to check compatibility between
 	 * header and the data */
-	features layout_features = (features)header_features;
+	features layout_features;
 
 	/** In future, my_mask can be implemented using v<> (8 bytes
 	 * overhead) */
@@ -939,6 +936,13 @@ public:
 
 	/* --------------------------------------------------------- */
 
+	/** Features supported by this header */
+	static constexpr features
+	header_features()
+	{
+		return {0, 0};
+	}
+
 	const std::atomic<hashcode_type> &
 	mask() const noexcept
 	{
@@ -970,6 +974,7 @@ public:
 		VALGRIND_HG_DISABLE_CHECKING(&my_size, sizeof(my_size));
 		VALGRIND_HG_DISABLE_CHECKING(&my_mask, sizeof(my_mask));
 #endif
+		layout_features = header_features();
 
 		my_size.get_rw() = 0;
 		PMEMoid oid = pmemobj_oid(this);
@@ -1857,7 +1862,7 @@ protected:
 	void
 	check_features()
 	{
-		if (layout_features.incompat != header_features.incompat)
+		if (layout_features.incompat != header_features().incompat)
 			throw pmem::layout_error(
 				"Incompat flags mismatch, for more details go to: https://pmem.io/pmdk/cpp_obj/ \n");
 	}


### PR DESCRIPTION
header_features was only declared (not defined) in concurrent_hash_map header.
This means that (until C++17) it can be used only in places where address of
this constant is not needed. In operator != we access one member of header_fatures
which requrires it to be declared. This only fails for some compilers like clang-9
because rest of the evaluate this expression at compile time (this is a compiler
decision whether to do this at compile time or runtime).

Fix this issue by creating function header_features().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/475)
<!-- Reviewable:end -->
