### PR TITLE
Install pmdk-debuginfo package

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -18,6 +18,7 @@ env:
     - TYPE=memcheck_drd OS=ubuntu OS_VER=19.04
     - TYPE=coverity OS=ubuntu OS_VER=19.04
     - TYPE=package OS=ubuntu OS_VER=19.04
+    - TYPE=package OS=fedora OS_VER=30
 
 before_install:
   - echo $TRAVIS_COMMIT_RANGE

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -231,7 +231,7 @@ function tests_package() {
 		sudo_password dpkg -i /opt/pmdk-pkg/libpmem_*.deb /opt/pmdk-pkg/libpmem-dev_*.deb
 		sudo_password dpkg -i /opt/pmdk-pkg/libpmemobj_*.deb /opt/pmdk-pkg/libpmemobj-dev_*.deb
 	elif [ $PACKAGE_MANAGER = "rpm" ]; then
-		sudo_password rpm -i /opt/pmdk-pkg/libpmem-*.rpm
+		sudo_password rpm -i /opt/pmdk-pkg/libpmem-*.rpm /opt/pmdk-pkg/pmdk-debuginfo-*.rpm
 		sudo_password rpm -i /opt/pmdk-pkg/libpmemobj-*.rpm
 	fi
 


### PR DESCRIPTION
It fixes the following error on Fedora-rawhide and CentOS-8:
 error: Failed dependencies:
	pmdk-debuginfo(x86-64) = 1.7-1.fc32 is needed by libpmem-debug-debuginfo-1.7-1.fc32.x86_64
	pmdk-debuginfo(x86-64) = 1.7-1.fc32 is needed by libpmem-debuginfo-1.7-1.fc32.x86_64

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/484)
<!-- Reviewable:end -->
