### PR TITLE
Do not add symlinks to clang-9 in the Docker.debian-testing image

### DIFF
--- a/utils/docker/images/Dockerfile.debian-testing
+++ b/utils/docker/images/Dockerfile.debian-testing
@@ -86,10 +86,6 @@ RUN ./install-valgrind.sh
 COPY install-pmdk.sh install-pmdk.sh
 RUN ./install-pmdk.sh dpkg
 
-# Add links to clang-9
-RUN ln -s /usr/lib/llvm-9/bin/clang /usr/bin/clang
-RUN ln -s /usr/lib/llvm-9/bin/clang++ /usr/bin/clang++
-
 # Add user
 ENV USER user
 ENV USERPASS pass


### PR DESCRIPTION
https://github.com/pmem/libpmemobj-cpp/pull/473#issuecomment-542313407

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/498)
<!-- Reviewable:end -->
