### PR TITLE
Fix installing libpmem-*.rpm

### DIFF
--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -231,8 +231,7 @@ function tests_package() {
 		sudo_password dpkg -i /opt/pmdk-pkg/libpmem_*.deb /opt/pmdk-pkg/libpmem-dev_*.deb
 		sudo_password dpkg -i /opt/pmdk-pkg/libpmemobj_*.deb /opt/pmdk-pkg/libpmemobj-dev_*.deb
 	elif [ $PACKAGE_MANAGER = "rpm" ]; then
-		sudo_password rpm -i /opt/pmdk-pkg/libpmem-*.rpm /opt/pmdk-pkg/pmdk-debuginfo-*.rpm
-		sudo_password rpm -i /opt/pmdk-pkg/libpmemobj-*.rpm
+		sudo_password rpm -i /opt/pmdk-pkg/libpmem*.rpm /opt/pmdk-pkg/pmdk-debuginfo-*.rpm
 	fi
 
 	CC=gcc CXX=g++ \


### PR DESCRIPTION
Replace 'libpmem-*.rpm' with 'libpmem*.rpm'.
It fixes following errors on openSUSE:

error: Failed dependencies:
        libpmemobj1 = 1.7-1.suse1500 is needed by libpmemobj-debug-1.7-1.suse1500.x86_64
        libpmemobj1 = 1.7-1.suse1500 is needed by libpmemobj-devel-1.7-1.suse1500.x86_64

error: Failed dependencies:
        libpmem1 = 1.7-1.suse1500 is needed by libpmem-debug-1.7-1.suse1500.x86_64
        libpmem1 = 1.7-1.suse1500 is needed by libpmem-devel-1.7-1.suse1500.x86_64

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/502)
<!-- Reviewable:end -->
