### PR TITLE
Fix removing pkg-config rpm package

### DIFF
--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -267,7 +267,8 @@ function tests_package() {
 	if [ $PACKAGE_MANAGER = "deb" ]; then
 		sudo_password dpkg -r --force-all pkg-config
 	elif [ $PACKAGE_MANAGER = "rpm" ]; then
-		sudo_password rpm -e --nodeps pkgconf
+		# most rpm based OSes use the 'pkgconf' name, only openSUSE uses 'pkg-config'
+		sudo_password rpm -e --nodeps pkgconf || sudo_password rpm -e --nodeps pkg-config
 	fi
 
 	# Verify installed package using find_package


### PR DESCRIPTION
Most rpm based OSes use the 'pkgconf' name,
only openSUSE uses 'pkg-config'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/503)
<!-- Reviewable:end -->
