### PR TITLE
Change install-pmdk.sh script

### DIFF
--- a/utils/docker/images/install-pmdk.sh
+++ b/utils/docker/images/install-pmdk.sh
@@ -36,6 +36,8 @@
 
 set -e
 
+PACKAGE_MANAGER=$1
+
 # stable-1.7: Merge pull request #4057 from ldorau/Add-BuildRequires-fdupes-to-spec-for-opensuse, 25.10.2019
 PMDK_VERSION="bfec2ca71b20ac4b56e1d7be9f51aa875d7c5efc"
 
@@ -45,12 +47,15 @@ git checkout $PMDK_VERSION
 
 sudo make -j$(nproc) install prefix=/opt/pmdk
 
-sudo mkdir /opt/pmdk-pkg
-NDCTL_ENABLE=n make -j$(nproc) BUILD_PACKAGE_CHECK=n "$1"
+# Do not create nor test any packages if PACKAGE_MANAGER is not set.
+[ "$PACKAGE_MANAGER" == "" ] && exit 0
 
-if [ "$1" = "dpkg" ]; then
+sudo mkdir /opt/pmdk-pkg
+NDCTL_ENABLE=n make -j$(nproc) BUILD_PACKAGE_CHECK=n "$PACKAGE_MANAGER"
+
+if [ "$PACKAGE_MANAGER" = "dpkg" ]; then
 	sudo mv dpkg/*.deb /opt/pmdk-pkg/
-elif [ "$1" = "rpm" ]; then
+elif [ "$PACKAGE_MANAGER" = "rpm" ]; then
 	sudo mv rpm/x86_64/*.rpm /opt/pmdk-pkg/
 fi
 


### PR DESCRIPTION
Add an option to not build any packages
if a package manager is not specified.
It is useful for linux distributions
with packages different than RPM and DEB
(for example Arch Linux).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/511)
<!-- Reviewable:end -->
