### PR TITLE
Set OS-specific options for building ndctl

### DIFF
--- a/utils/docker/images/Dockerfile.centos-8
+++ b/utils/docker/images/Dockerfile.centos-8
@@ -82,7 +82,7 @@ RUN dnf update -y \
 
 # Install libndctl
 COPY install-libndctl.sh install-libndctl.sh
-RUN ./install-libndctl.sh fedora
+RUN ./install-libndctl.sh centos
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh

--- a/utils/docker/images/Dockerfile.opensuse-leap-latest
+++ b/utils/docker/images/Dockerfile.opensuse-leap-latest
@@ -81,7 +81,7 @@ RUN zypper clean all
 
 # Install libndctl
 COPY install-libndctl.sh install-libndctl.sh
-RUN ./install-libndctl.sh fedora
+RUN ./install-libndctl.sh opensuse
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh

--- a/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
+++ b/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
@@ -83,7 +83,7 @@ RUN zypper clean all
 
 # Install libndctl
 COPY install-libndctl.sh install-libndctl.sh
-RUN ./install-libndctl.sh fedora
+RUN ./install-libndctl.sh opensuse
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh

--- a/utils/docker/images/install-libndctl.sh
+++ b/utils/docker/images/install-libndctl.sh
@@ -76,9 +76,21 @@ rm -rf $RPMDIR
 
 else
 
+echo "==== set OS-specific options ===="
+OS_SPECIFIC=""
+LIBDIR=/usr/lib
+case $(echo $OS | cut -d'-' -f1) in
+	centos|opensuse)
+		LIBDIR=/usr/lib64
+		;;
+	archlinux)
+		OS_SPECIFIC="--disable-dependency-tracking"
+		;;
+esac
+
 echo "==== build ndctl ===="
 ./autogen.sh
-./configure
+./configure --libdir=$LIBDIR $OS_SPECIFIC
 make -j$(nproc)
 
 echo "==== install ndctl ===="

--- a/utils/docker/images/install-libndctl.sh
+++ b/utils/docker/images/install-libndctl.sh
@@ -57,7 +57,7 @@ git archive --format=tar --prefix="ndctl-${VERSION}/" HEAD | gzip > "$RPMDIR/SOU
 
 echo "==== build ndctl ===="
 ./autogen.sh
-./configure
+./configure --disable-docs
 make -j$(nproc)
 
 echo "==== update ndctl.spec ===="
@@ -90,7 +90,7 @@ esac
 
 echo "==== build ndctl ===="
 ./autogen.sh
-./configure --libdir=$LIBDIR $OS_SPECIFIC
+./configure --libdir=$LIBDIR --disable-docs $OS_SPECIFIC
 make -j$(nproc)
 
 echo "==== install ndctl ===="


### PR DESCRIPTION
Arch Linux requires to run the 'configure' script
with the '--disable-dependency-tracking' option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/517)
<!-- Reviewable:end -->
