### PR TITLE
Update comment for pool::persist(persistent_ptr&)

### DIFF
--- a/include/libpmemobj++/pool.hpp
+++ b/include/libpmemobj++/pool.hpp
@@ -303,7 +303,8 @@ public:
 	}
 
 	/**
-	 * Performs persist operation on a given persistent object.
+	 * Performs persist operation on a given persistent pointer.
+	 * Persist is not performed on the object referenced by this pointer.
 	 *
 	 * @param[in] ptr Persistent pointer to object
 	 */


### PR DESCRIPTION
Former description could have been misinterpreted. Persist
operation does not persist pointee but only a pointer - this
change makes that clear.

Ref: https://github.com/pmem/libpmemobj-cpp/issues/524

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/525)
<!-- Reviewable:end -->
