### PR TITLE
Enumerable_thread_specific constructors fix

### DIFF
--- a/include/libpmemobj++/experimental/enumerable_thread_specific.hpp
+++ b/include/libpmemobj++/experimental/enumerable_thread_specific.hpp
@@ -274,9 +274,9 @@ template <typename T, template <typename...> typename Map, typename Mutex,
 	  typename Storage>
 enumerable_thread_specific<T, Map, Mutex, Storage>::enumerable_thread_specific(
 	enumerable_thread_specific &other)
+    : _storage(other._storage)
 {
 	_map.get(other._map.get());
-	_storage = other._storage;
 }
 
 /**
@@ -291,9 +291,9 @@ template <typename T, template <typename...> typename Map, typename Mutex,
 	  typename Storage>
 enumerable_thread_specific<T, Map, Mutex, Storage>::enumerable_thread_specific(
 	enumerable_thread_specific &&other)
+    : _storage(std::move(other._storage))
 {
 	_map.get(std::move(other._map.get()));
-	_storage = std::move(other._storage);
 }
 
 /**


### PR DESCRIPTION
Copy/Move constructors fixed to use storage's copy/move constructors instead of operator=

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/532)
<!-- Reviewable:end -->
