### PR TITLE
Fix rehashing in bucket_accessor::acquire

### DIFF
--- a/include/libpmemobj++/container/concurrent_hash_map.hpp
+++ b/include/libpmemobj++/container/concurrent_hash_map.hpp
@@ -1661,6 +1661,12 @@ protected:
 				}
 			} else {
 				bucket_lock_type::acquire(my_b->mutex, writer);
+				if (my_b->is_rehashed(
+					    std::memory_order_relaxed) ==
+				    false) {
+					/* recursive rehashing */
+					base->rehash_bucket<false>(my_b, h);
+				}
 			}
 
 			assert(my_b->is_rehashed(std::memory_order_relaxed));


### PR DESCRIPTION
An additional check is needed in order to be sure
that the hash map is rehashed and the assert will not fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/552)
<!-- Reviewable:end -->
