### PR TITLE
docker: enable ndctl when building pmdk

### DIFF
--- a/utils/docker/images/install-pmdk.sh
+++ b/utils/docker/images/install-pmdk.sh
@@ -51,7 +51,7 @@ sudo make -j$(nproc) install prefix=/opt/pmdk
 [ "$PACKAGE_MANAGER" == "" ] && exit 0
 
 sudo mkdir /opt/pmdk-pkg
-NDCTL_ENABLE=n make -j$(nproc) BUILD_PACKAGE_CHECK=n "$PACKAGE_MANAGER"
+make -j$(nproc) BUILD_PACKAGE_CHECK=n "$PACKAGE_MANAGER"
 
 if [ "$PACKAGE_MANAGER" = "dpkg" ]; then
 	sudo mv dpkg/*.deb /opt/pmdk-pkg/


### PR DESCRIPTION
Disabling it is not neccesary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/558)
<!-- Reviewable:end -->
