### PR TITLE
Make persistent_ptr_base non-template and move to main namespace

### DIFF
--- a/examples/doc_snippets/persistent.cpp
+++ b/examples/doc_snippets/persistent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019, Intel Corporation
+ * Copyright 2016-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -131,3 +131,112 @@ persistent_ptr_example()
 	proot.comp->some_variable = 12;
 }
 //! [persistent_ptr_example]
+
+//! [persistent_ptr_casting_example]
+#include <iostream>
+#include <libpmemobj++/make_persistent.hpp>
+#include <libpmemobj++/persistent_ptr.hpp>
+#include <libpmemobj++/persistent_ptr_base.hpp>
+#include <libpmemobj++/pool.hpp>
+#include <libpmemobj++/transaction.hpp>
+
+using namespace pmem::obj;
+
+struct root {
+	persistent_ptr<int> pfoo;
+};
+
+void
+persistent_ptr_conversion_example(pool<root> &pop)
+{
+	/* Casting persistent_ptr to persistent_ptr_base */
+	transaction::run(pop, [&] {
+		/* Good: any persistent_ptr<T> can be stored in a base ptr */
+		persistent_ptr_base i_ptr_base = make_persistent<int>(10);
+
+		/*
+		 * Wrong: even though raw pointer can be used to create new
+		 * persistent_ptr it's not advised to use it this way, since
+		 * there's no information about underlying/template type
+		 */
+		persistent_ptr<double> dptr = i_ptr_base.raw();
+		std::cout << *dptr; // contains trash data
+
+		/*
+		 * Acceptable: it's not advised, but it will work properly.
+		 * Although, you have to be sure the underlying type is correct
+		 */
+		persistent_ptr<int> iptr_nonbase = i_ptr_base.raw();
+		std::cout << *iptr_nonbase; // contains proper data
+
+		/*
+		 * Wrong: illegal call for derived constructor.
+		 * no viable conversion from 'persistent_ptr_base' to
+		 * 'persistent_ptr<int>' */
+		// iptr_nonbase = i_ptr_base;
+
+		/*
+		 * Wrong: conversion from base class to persistent_ptr<T> is not
+		 * possible: no matching conversion from 'persistent_ptr_base'
+		 * to 'persistent_ptr<int>'
+		 */
+		// iptr_nonbase = static_cast<persistent_ptr<int>>(i_ptr_base);
+
+		/* Good: you can use base and ptr classes with volatile pointer
+		 */
+		persistent_ptr<int> i_ptr = make_persistent<int>(10);
+		persistent_ptr_base *i_ptr_ref = &i_ptr;
+		std::cout << i_ptr_ref->raw().off; // contains PMEMoid's data
+	});
+
+	struct A {
+		uint64_t a;
+	};
+	struct B {
+		uint64_t b;
+	};
+	struct C : public A, public B {
+		uint64_t c;
+	};
+
+	/* Convertible types, using struct A, B and C */
+	transaction::run(pop, [] {
+		/* Good: conversion from type C to B, using copy constructor */
+		auto cptr = make_persistent<C>();
+		persistent_ptr<B> bptr = cptr;
+		std::cout << (bptr->b ==
+			      cptr->b); // thanks to conversion and
+					// recalculating offsets it's correct
+
+		/*
+		 * Good: conversion from type C to B, using converting
+		 * assignment operator
+		 */
+		persistent_ptr<B> bptr2;
+		bptr2 = cptr;
+		std::cout << (bptr2->b == cptr->b); // true
+
+		/* Good: direct conversion using static_cast */
+		persistent_ptr<B> bptr3 = static_cast<persistent_ptr<B>>(cptr);
+		std::cout << (bptr3->b == cptr->b); // true
+
+		/*
+		 * Wrong: conversion to base class and then to different ptr.
+		 * class no matching conversion from 'persistent_ptr_base' to
+		 * 'persistent_ptr<B>'
+		 */
+		// auto cptr2 = (persistent_ptr_base)cptr;
+		// persistent_ptr<B> bptr4 =
+		//		static_cast<persistent_ptr<B>>(cptr2);
+
+		/*
+		 * Wrong: conversion to 'void *' and then to different ptr
+		 * class. ambiguous conversion from 'void *' to
+		 * 'persistent_ptr<B>'
+		 */
+		// auto cptr3 = (void *)&cptr;
+		// persistent_ptr<B> bptr5 =
+		//		static_cast<persistent_ptr<B>>(cptr3);
+	});
+}
+//! [persistent_ptr_casting_example]

--- a/include/libpmemobj++/detail/persistent_ptr_base.hpp
+++ b/include/libpmemobj++/detail/persistent_ptr_base.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019, Intel Corporation
+ * Copyright 2016-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -57,33 +57,24 @@ namespace detail
 {
 
 /**
- * Persistent_ptr base class
+ * Persistent_ptr base (non-template) class
  *
  * Implements some of the functionality of the persistent_ptr class. It defines
- * all applicable conversions from and to a persistent_ptr_base. This class is
- * an implementation detail and is not to be instantiated. It cannot be declared
- * as virtual due to the problem with rebuilding the vtable.
+ * all applicable conversions from and to a persistent_ptr_base.
+ *
+ * It can be used e.g. as a parameter, where persistent_ptr of any template
+ * type is required. It is similar to persistent_ptr<void> (it can point
+ * to whatever type), but it can be used when you want to have pointer to some
+ * unspecified persistent_ptr (with persistent_ptr<void> it can't be done,
+ * because: persistent_ptr<T>* does not convert to persistent_ptr<void>*).
  */
-template <typename T>
 class persistent_ptr_base {
-	typedef persistent_ptr_base<T> this_type;
-
-	template <typename U>
-	friend class persistent_ptr_base;
-
 public:
-	/**
-	 * Type of an actual object with all qualifier removed,
-	 * used for easy underlying type access
-	 */
-	typedef typename pmem::detail::sp_element<T>::type element_type;
-
 	/**
 	 * Default constructor, zeroes the PMEMoid.
 	 */
-	persistent_ptr_base() : oid(OID_NULL)
+	persistent_ptr_base() noexcept : oid(OID_NULL)
 	{
-		verify_type();
 	}
 
 	/*
@@ -101,80 +92,6 @@ public:
 	 */
 	persistent_ptr_base(PMEMoid oid) noexcept : oid(oid)
 	{
-		verify_type();
-	}
-
-	/**
-	 * Volatile pointer constructor.
-	 *
-	 * If ptr does not point to an address from a valid pool, the persistent
-	 * pointer will evaluate to nullptr.
-	 *
-	 * @param ptr volatile pointer, pointing to persistent memory.
-	 */
-	persistent_ptr_base(element_type *ptr) : oid(pmemobj_oid(ptr))
-	{
-		verify_type();
-	}
-
-	/**
-	 * Copy constructor from a different persistent_ptr<>.
-	 *
-	 * Available only for convertible types.
-	 */
-	template <typename U,
-		  typename = typename std::enable_if<
-			  !std::is_same<T, U>::value &&
-			  std::is_same<typename std::remove_cv<T>::type,
-				       U>::value>::type>
-	persistent_ptr_base(persistent_ptr_base<U> const &r) noexcept
-	    : oid(r.oid)
-	{
-		this->oid.off +=
-			static_cast<std::uint64_t>(calculate_offset<U>());
-		verify_type();
-	}
-
-	/**
-	 * Copy constructor from a different persistent_ptr<>.
-	 *
-	 * Available only for convertible, non-void types.
-	 */
-	template <
-		typename U, typename Dummy = void,
-		typename = typename std::enable_if<
-			!std::is_same<
-				typename std::remove_cv<T>::type,
-				typename std::remove_cv<U>::type>::value &&
-				!std::is_void<U>::value,
-			decltype(static_cast<T *>(std::declval<U *>()))>::type>
-	persistent_ptr_base(persistent_ptr_base<U> const &r) noexcept
-	    : oid(r.oid)
-	{
-		this->oid.off +=
-			static_cast<std::uint64_t>(calculate_offset<U>());
-		verify_type();
-	}
-
-	/**
-	 * Conversion operator to a different persistent_ptr<>.
-	 *
-	 * Available only for convertible, non-void types.
-	 */
-	template <
-		typename Y,
-		typename = typename std::enable_if<
-			!std::is_same<
-				typename std::remove_cv<T>::type,
-				typename std::remove_cv<Y>::type>::value &&
-				!std::is_void<Y>::value,
-			decltype(static_cast<T *>(std::declval<Y *>()))>::type>
-	operator persistent_ptr_base<Y>() noexcept
-	{
-		/*
-		 * The offset conversion should not be required here.
-		 */
-		return persistent_ptr_base<Y>(this->oid);
 	}
 
 	/*
@@ -184,20 +101,18 @@ public:
 	 */
 	persistent_ptr_base(persistent_ptr_base const &r) noexcept : oid(r.oid)
 	{
-		verify_type();
 	}
 
 	/**
-	 * Defaulted move constructor.
+	 * Move constructor.
 	 */
 	persistent_ptr_base(persistent_ptr_base &&r) noexcept
 	    : oid(std::move(r.oid))
 	{
-		verify_type();
 	}
 
 	/**
-	 * Defaulted move assignment operator.
+	 * Move assignment operator.
 	 */
 	persistent_ptr_base &
 	operator=(persistent_ptr_base &&r)
@@ -221,7 +136,8 @@ public:
 	persistent_ptr_base &
 	operator=(persistent_ptr_base const &r)
 	{
-		this_type(r).swap(*this);
+		detail::conditional_add_to_tx(this);
+		this->oid = r.oid;
 
 		return *this;
 	}
@@ -241,28 +157,6 @@ public:
 	}
 
 	/**
-	 * Converting assignment operator from a different
-	 * persistent_ptr<>.
-	 *
-	 * Available only for convertible types.
-	 * Just like regular assignment, also automatically registers
-	 * itself in a transaction.
-	 *
-	 * @throw pmem::transaction_error when adding the object to the
-	 *	transaction failed.
-	 */
-	template <typename Y,
-		  typename = typename std::enable_if<
-			  std::is_convertible<Y *, T *>::value>::type>
-	persistent_ptr_base &
-	operator=(persistent_ptr_base<Y> const &r)
-	{
-		this_type(r).swap(*this);
-
-		return *this;
-	}
-
-	/**
 	 * Swaps two persistent_ptr objects of the same type.
 	 *
 	 * @param[in,out] other the other persistent_ptr to swap.
@@ -273,24 +167,6 @@ public:
 		detail::conditional_add_to_tx(this);
 		detail::conditional_add_to_tx(&other);
 		std::swap(this->oid, other.oid);
-	}
-
-	/**
-	 * Get a direct pointer.
-	 *
-	 * Performs a calculations on the underlying C-style pointer.
-	 *
-	 * @return a direct pointer to the object.
-	 */
-	element_type *
-	get() const noexcept
-	{
-		if (this->oid.pool_uuid_lo ==
-		    std::numeric_limits<decltype(oid.pool_uuid_lo)>::max())
-			return reinterpret_cast<element_type *>(oid.off);
-		else
-			return static_cast<element_type *>(
-				pmemobj_direct(this->oid));
 	}
 
 	/**
@@ -319,66 +195,9 @@ public:
 		return &(this->oid);
 	}
 
-	/*
-	 * Bool conversion operator.
-	 */
-	explicit operator bool() const noexcept
-	{
-		return get() != nullptr;
-	}
-
 protected:
 	/* The underlying PMEMoid of the held object. */
 	PMEMoid oid;
-
-	void
-	verify_type()
-	{
-		static_assert(!std::is_polymorphic<element_type>::value,
-			      "Polymorphic types are not supported");
-	}
-
-	/**
-	 * Private constructor enabling persistent_ptrs to volatile objects.
-	 *
-	 * This is internal implementation only needed for the
-	 * pointer_traits<persistent_ptr>::pointer_to to be able to create
-	 * valid pointers. This is used in libstdc++'s std::vector::insert().
-	 */
-	persistent_ptr_base(element_type *vptr, int) : persistent_ptr_base(vptr)
-	{
-		if (OID_IS_NULL(oid)) {
-			oid.pool_uuid_lo = std::numeric_limits<decltype(
-				oid.pool_uuid_lo)>::max();
-			oid.off = reinterpret_cast<decltype(oid.off)>(vptr);
-		}
-	}
-
-	/**
-	 * Calculate in-object offset for structures with inheritance.
-	 *
-	 * In case of the given inheritance:
-	 *
-	 *	  A   B
-	 *	   \ /
-	 *	    C
-	 *
-	 * A pointer to B *ptr = &C should be offset by sizeof(A). This function
-	 * calculates that offset.
-	 *
-	 * @return offset between to compatible pointer types to the same object
-	 */
-	template <typename U>
-	inline ptrdiff_t
-	calculate_offset() const
-	{
-		static const ptrdiff_t ptr_offset_magic = 0xDEADBEEF;
-
-		U *tmp{reinterpret_cast<U *>(ptr_offset_magic)};
-		T *diff = static_cast<T *>(tmp);
-		return reinterpret_cast<ptrdiff_t>(diff) -
-			reinterpret_cast<ptrdiff_t>(tmp);
-	}
 };
 
 } /* namespace detail */

--- a/include/libpmemobj++/persistent_ptr.hpp
+++ b/include/libpmemobj++/persistent_ptr.hpp
@@ -44,8 +44,8 @@
 #include <ostream>
 
 #include <libpmemobj++/detail/common.hpp>
-#include <libpmemobj++/detail/persistent_ptr_base.hpp>
 #include <libpmemobj++/detail/specialization.hpp>
+#include <libpmemobj++/persistent_ptr_base.hpp>
 #include <libpmemobj++/pool.hpp>
 #include <libpmemobj/base.h>
 
@@ -68,7 +68,7 @@ class persistent_ptr;
  * (unnecessary) functionallities.
  */
 template <>
-class persistent_ptr<void> : public detail::persistent_ptr_base {
+class persistent_ptr<void> : public persistent_ptr_base {
 public:
 	typedef void element_type;
 	typedef persistent_ptr<void> this_type;
@@ -114,7 +114,7 @@ public:
  * (unnecessary) functionallities.
  */
 template <>
-class persistent_ptr<const void> : public detail::persistent_ptr_base {
+class persistent_ptr<const void> : public persistent_ptr_base {
 public:
 	typedef const void element_type;
 	typedef persistent_ptr<const void> this_type;
@@ -206,7 +206,7 @@ public:
  * @snippet doc_snippets/persistent.cpp persistent_ptr_example
  */
 template <typename T>
-class persistent_ptr : public detail::persistent_ptr_base {
+class persistent_ptr : public persistent_ptr_base {
 public:
 	typedef persistent_ptr<T> this_type;
 
@@ -220,7 +220,7 @@ public:
 	typedef typename pmem::detail::sp_element<T>::type element_type;
 
 	persistent_ptr() = default;
-	using detail::persistent_ptr_base::persistent_ptr_base;
+	using persistent_ptr_base::persistent_ptr_base;
 
 	/*
 	 * Constructors
@@ -230,7 +230,7 @@ public:
 	 * Explicit void specialization of the converting constructor.
 	 */
 	explicit persistent_ptr(persistent_ptr<void> const &rhs) noexcept
-	    : detail::persistent_ptr_base(rhs.raw())
+	    : persistent_ptr_base(rhs.raw())
 	{
 	}
 
@@ -238,7 +238,7 @@ public:
 	 * Explicit const void specialization of the converting constructor.
 	 */
 	explicit persistent_ptr(persistent_ptr<const void> const &rhs) noexcept
-	    : detail::persistent_ptr_base(rhs.raw())
+	    : persistent_ptr_base(rhs.raw())
 	{
 	}
 

--- a/include/libpmemobj++/persistent_ptr.hpp
+++ b/include/libpmemobj++/persistent_ptr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019, Intel Corporation
+ * Copyright 2015-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -193,6 +193,10 @@ public:
  * rollback uses memcpy internally. Using memcpy on an object in C++ is allowed
  * by the standard only if the type satisfies TriviallyCopyable requirement.
  *
+ * This type does NOT manage the life-cycle of the object. The typical usage
+ * example would be:
+ * @snippet doc_snippets/persistent.cpp persistent_ptr_example
+ *
  * Casting to persistent_ptr_base can be easily done from any persistent_ptr<T>
  * objects, but when casting between convertible objects be advised to use
  * constructors or operator= specified for such conversion, see:
@@ -201,9 +205,8 @@ public:
  * When casting indirectly with (void *) or using static_cast, and then casting
  * to the second (convertible) type, the offset will not be re-calculated.
  *
- * This type does NOT manage the life-cycle of the object. The typical usage
- * example would be:
- * @snippet doc_snippets/persistent.cpp persistent_ptr_example
+ * Below you can find an example how to and how NOT to cast persistent_ptr's:
+ * @snippet doc_snippets/persistent.cpp persistent_ptr_casting_example
  */
 template <typename T>
 class persistent_ptr : public persistent_ptr_base {

--- a/include/libpmemobj++/persistent_ptr.hpp
+++ b/include/libpmemobj++/persistent_ptr.hpp
@@ -436,27 +436,6 @@ public:
 		return *this;
 	}
 
-	/**
-	 * Conversion operator to a different persistent_ptr<>.
-	 *
-	 * Available only for convertible, non-void types.
-	 */
-	template <
-		typename Y,
-		typename = typename std::enable_if<
-			!std::is_same<
-				typename std::remove_cv<T>::type,
-				typename std::remove_cv<Y>::type>::value &&
-				!std::is_void<Y>::value,
-			decltype(static_cast<T *>(std::declval<Y *>()))>::type>
-	operator persistent_ptr<Y>() noexcept
-	{
-		/*
-		 * The offset conversion should not be required here.
-		 */
-		return persistent_ptr<Y>(this->oid);
-	}
-
 	/*
 	 * Bool conversion operator.
 	 */

--- a/include/libpmemobj++/persistent_ptr.hpp
+++ b/include/libpmemobj++/persistent_ptr.hpp
@@ -61,27 +61,96 @@ class pool;
 template <typename T>
 class persistent_ptr;
 
-/*
+/**
  * persistent_ptr void specialization.
+ *
+ * It's truncated specialization to disallow some of the
+ * (unnecessary) functionallities.
  */
 template <>
-class persistent_ptr<void> : public detail::persistent_ptr_base<void> {
+class persistent_ptr<void> : public detail::persistent_ptr_base {
 public:
+	typedef void element_type;
+	typedef persistent_ptr<void> this_type;
+
 	persistent_ptr() = default;
-	using detail::persistent_ptr_base<void>::persistent_ptr_base;
-	using detail::persistent_ptr_base<void>::operator=;
+	using persistent_ptr_base::persistent_ptr_base;
+	persistent_ptr(void *ptr) : persistent_ptr_base(pmemobj_oid(ptr))
+	{
+	}
+
+	element_type *
+	get() const noexcept
+	{
+		if (this->oid.pool_uuid_lo ==
+		    std::numeric_limits<decltype(oid.pool_uuid_lo)>::max())
+			return reinterpret_cast<element_type *>(oid.off);
+		else
+			return static_cast<element_type *>(
+				pmemobj_direct(this->oid));
+	}
+
+	template <typename Y,
+		  typename = typename std::enable_if<
+			  std::is_convertible<Y *, void *>::value>::type>
+	persistent_ptr<void> &
+	operator=(persistent_ptr<void> const &r)
+	{
+		this_type(r).swap(*this);
+
+		return *this;
+	}
+
+	explicit operator bool() const noexcept
+	{
+		return get() != nullptr;
+	}
 };
 
-/*
+/**
  * persistent_ptr const void specialization.
+ *
+ * It's truncated specialization to disallow some of the
+ * (unnecessary) functionallities.
  */
 template <>
-class persistent_ptr<const void>
-    : public detail::persistent_ptr_base<const void> {
+class persistent_ptr<const void> : public detail::persistent_ptr_base {
 public:
+	typedef const void element_type;
+	typedef persistent_ptr<const void> this_type;
+
 	persistent_ptr() = default;
-	using detail::persistent_ptr_base<const void>::persistent_ptr_base;
-	using detail::persistent_ptr_base<const void>::operator=;
+	using persistent_ptr_base::persistent_ptr_base;
+	persistent_ptr(const void *ptr) : persistent_ptr_base(pmemobj_oid(ptr))
+	{
+	}
+
+	element_type *
+	get() const noexcept
+	{
+		if (this->oid.pool_uuid_lo ==
+		    std::numeric_limits<decltype(oid.pool_uuid_lo)>::max())
+			return reinterpret_cast<element_type *>(oid.off);
+		else
+			return static_cast<element_type *>(
+				pmemobj_direct(this->oid));
+	}
+
+	template <typename Y,
+		  typename = typename std::enable_if<
+			  std::is_convertible<Y *, const void *>::value>::type>
+	persistent_ptr<const void> &
+	operator=(persistent_ptr<const void> const &r)
+	{
+		this_type(r).swap(*this);
+
+		return *this;
+	}
+
+	explicit operator bool() const noexcept
+	{
+		return get() != nullptr;
+	}
 };
 
 /**
@@ -124,21 +193,44 @@ public:
  * rollback uses memcpy internally. Using memcpy on an object in C++ is allowed
  * by the standard only if the type satisfies TriviallyCopyable requirement.
  *
+ * Casting to persistent_ptr_base can be easily done from any persistent_ptr<T>
+ * objects, but when casting between convertible objects be advised to use
+ * constructors or operator= specified for such conversion, see:
+ * * persistent_ptr::persistent_ptr(persistent_ptr<U> const &r) ,
+ * * persistent_ptr<T> & operator=(persistent_ptr<Y> const &r) .
+ * When casting indirectly with (void *) or using static_cast, and then casting
+ * to the second (convertible) type, the offset will not be re-calculated.
+ *
  * This type does NOT manage the life-cycle of the object. The typical usage
  * example would be:
  * @snippet doc_snippets/persistent.cpp persistent_ptr_example
  */
 template <typename T>
-class persistent_ptr : public detail::persistent_ptr_base<T> {
+class persistent_ptr : public detail::persistent_ptr_base {
 public:
+	typedef persistent_ptr<T> this_type;
+
+	template <typename U>
+	friend class persistent_ptr;
+
+	/**
+	 * Type of the actual object with all qualifiers removed,
+	 * used for easy underlying type access.
+	 */
+	typedef typename pmem::detail::sp_element<T>::type element_type;
+
 	persistent_ptr() = default;
-	using detail::persistent_ptr_base<T>::persistent_ptr_base;
+	using detail::persistent_ptr_base::persistent_ptr_base;
+
+	/*
+	 * Constructors
+	 */
 
 	/**
 	 * Explicit void specialization of the converting constructor.
 	 */
 	explicit persistent_ptr(persistent_ptr<void> const &rhs) noexcept
-	    : detail::persistent_ptr_base<T>(rhs.raw())
+	    : detail::persistent_ptr_base(rhs.raw())
 	{
 	}
 
@@ -146,9 +238,66 @@ public:
 	 * Explicit const void specialization of the converting constructor.
 	 */
 	explicit persistent_ptr(persistent_ptr<const void> const &rhs) noexcept
-	    : detail::persistent_ptr_base<T>(rhs.raw())
+	    : detail::persistent_ptr_base(rhs.raw())
 	{
 	}
+
+	/**
+	 * Volatile pointer constructor.
+	 *
+	 * If ptr does not point to an address from a valid pool, the persistent
+	 * pointer will evaluate to nullptr.
+	 *
+	 * @param ptr volatile pointer, pointing to persistent memory.
+	 */
+	persistent_ptr(element_type *ptr)
+	    : persistent_ptr_base(pmemobj_oid(ptr))
+	{
+		verify_type();
+	}
+
+	/**
+	 * Copy constructor from a different persistent_ptr<>.
+	 *
+	 * Available only for convertible types.
+	 */
+	template <typename U,
+		  typename = typename std::enable_if<
+			  !std::is_same<T, U>::value &&
+			  std::is_same<typename std::remove_cv<T>::type,
+				       U>::value>::type>
+	persistent_ptr(persistent_ptr<U> const &r) noexcept
+	    : persistent_ptr_base(r.oid)
+	{
+		this->oid.off +=
+			static_cast<std::uint64_t>(calculate_offset<U>());
+		verify_type();
+	}
+
+	/**
+	 * Copy constructor from a different persistent_ptr<>.
+	 *
+	 * Available only for convertible, non-void types.
+	 */
+	template <
+		typename U, typename Dummy = void,
+		typename = typename std::enable_if<
+			!std::is_same<
+				typename std::remove_cv<T>::type,
+				typename std::remove_cv<U>::type>::value &&
+				!std::is_void<U>::value,
+			decltype(static_cast<T *>(std::declval<U *>()))>::type>
+	persistent_ptr(persistent_ptr<U> const &r) noexcept
+	    : persistent_ptr_base(r.oid)
+	{
+		this->oid.off +=
+			static_cast<std::uint64_t>(calculate_offset<U>());
+		verify_type();
+	}
+
+	/*
+	 * Operators
+	 */
 
 	/**
 	 * Persistent pointer to void conversion operator.
@@ -266,6 +415,61 @@ public:
 	}
 
 	/**
+	 * Converting assignment operator from a different
+	 * persistent_ptr<>.
+	 *
+	 * Available only for convertible types.
+	 * Just like regular assignment, also automatically registers
+	 * itself in a transaction.
+	 *
+	 * @throw pmem::transaction_error when adding the object
+	 * to the transaction failed.
+	 */
+	template <typename Y,
+		  typename = typename std::enable_if<
+			  std::is_convertible<Y *, T *>::value>::type>
+	persistent_ptr<T> &
+	operator=(persistent_ptr<Y> const &r)
+	{
+		this_type(r).swap(*this);
+
+		return *this;
+	}
+
+	/**
+	 * Conversion operator to a different persistent_ptr<>.
+	 *
+	 * Available only for convertible, non-void types.
+	 */
+	template <
+		typename Y,
+		typename = typename std::enable_if<
+			!std::is_same<
+				typename std::remove_cv<T>::type,
+				typename std::remove_cv<Y>::type>::value &&
+				!std::is_void<Y>::value,
+			decltype(static_cast<T *>(std::declval<Y *>()))>::type>
+	operator persistent_ptr<Y>() noexcept
+	{
+		/*
+		 * The offset conversion should not be required here.
+		 */
+		return persistent_ptr<Y>(this->oid);
+	}
+
+	/*
+	 * Bool conversion operator.
+	 */
+	explicit operator bool() const noexcept
+	{
+		return get() != nullptr;
+	}
+
+	/*
+	 * Persist/flush methods
+	 */
+
+	/**
 	 * Persists the content of the underlying object.
 	 *
 	 * @param[in] pop Pmemobj pool
@@ -342,6 +546,24 @@ public:
 	}
 
 	/**
+	 * Get the direct pointer.
+	 *
+	 * Performs a calculations on the underlying C-style pointer.
+	 *
+	 * @return the direct pointer to the object.
+	 */
+	element_type *
+	get() const noexcept
+	{
+		if (this->oid.pool_uuid_lo ==
+		    std::numeric_limits<decltype(oid.pool_uuid_lo)>::max())
+			return reinterpret_cast<element_type *>(oid.off);
+		else
+			return static_cast<element_type *>(
+				pmemobj_direct(this->oid));
+	}
+
+	/**
 	 * Rebind to a different type of pointer.
 	 */
 	template <class U>
@@ -357,7 +579,7 @@ public:
 	 */
 	using bool_type = bool;
 
-	/*
+	/**
 	 * Random access iterator requirements (members)
 	 */
 
@@ -385,6 +607,60 @@ public:
 	 * The pointer type.
 	 */
 	using pointer = persistent_ptr<T>;
+
+protected:
+	/**
+	 * Verify if element_type is not polymorphic
+	 */
+	void
+	verify_type()
+	{
+		static_assert(!std::is_polymorphic<element_type>::value,
+			      "Polymorphic types are not supported");
+	}
+
+	/**
+	 * Private constructor enabling persistent_ptrs to volatile objects.
+	 *
+	 * This is internal implementation needed only for the
+	 * pointer_traits<persistent_ptr>::pointer_to to be able to create
+	 * valid pointers. This is used in libstdc++'s std::vector::insert().
+	 */
+	persistent_ptr(element_type *vptr, int) : persistent_ptr_base(vptr)
+	{
+		if (OID_IS_NULL(oid)) {
+			oid.pool_uuid_lo = std::numeric_limits<decltype(
+				oid.pool_uuid_lo)>::max();
+			oid.off = reinterpret_cast<decltype(oid.off)>(vptr);
+		}
+	}
+
+	/**
+	 * Calculate in-object offset for structures with inheritance.
+	 *
+	 * In case of the given inheritance:
+	 *
+	 *	  A   B
+	 *	   \ /
+	 *	    C
+	 *
+	 * A pointer to B *ptr = &C should be offset by sizeof(A). This function
+	 * calculates that offset.
+	 *
+	 * @return offset between two compatible pointer types to the same
+	 * object
+	 */
+	template <typename U>
+	inline ptrdiff_t
+	calculate_offset() const
+	{
+		static const ptrdiff_t ptr_offset_magic = 0xDEADBEEF;
+
+		U *tmp{reinterpret_cast<U *>(ptr_offset_magic)};
+		T *diff = static_cast<T *>(tmp);
+		return reinterpret_cast<ptrdiff_t>(diff) -
+			reinterpret_cast<ptrdiff_t>(tmp);
+	}
 };
 
 /**

--- a/include/libpmemobj++/persistent_ptr_base.hpp
+++ b/include/libpmemobj++/persistent_ptr_base.hpp
@@ -53,7 +53,7 @@
 namespace pmem
 {
 
-namespace detail
+namespace obj
 {
 
 /**
@@ -200,7 +200,7 @@ protected:
 	PMEMoid oid;
 };
 
-} /* namespace detail */
+} /* namespace obj */
 
 } /* namespace pmem */
 

--- a/tests/ptr/ptr.cpp
+++ b/tests/ptr/ptr.cpp
@@ -343,6 +343,17 @@ test_offset(nvobj::pool<root> &pop)
 			nvobj::persistent_ptr<B> bptr = cptr;
 			UT_ASSERT((bptr.raw().off - cptr.raw().off) ==
 				  sizeof(A));
+
+			nvobj::persistent_ptr<B> bptr2;
+			bptr2 = cptr;
+			UT_ASSERT((bptr2.raw().off - cptr.raw().off) ==
+				  sizeof(A));
+
+			nvobj::persistent_ptr<B> bptr3 =
+				static_cast<nvobj::persistent_ptr<B>>(cptr);
+			UT_ASSERT((bptr3.raw().off - cptr.raw().off) ==
+				  sizeof(A));
+
 			nvobj::delete_persistent<C>(cptr);
 		});
 	} catch (...) {

--- a/tests/ptr/ptr.cpp
+++ b/tests/ptr/ptr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019, Intel Corporation
+ * Copyright 2015-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,11 +37,13 @@
 
 #include "unittest.hpp"
 
+#include <libpmemobj++/container/vector.hpp>
 #include <libpmemobj++/make_persistent.hpp>
 #include <libpmemobj++/make_persistent_array_atomic.hpp>
 #include <libpmemobj++/make_persistent_atomic.hpp>
 #include <libpmemobj++/p.hpp>
 #include <libpmemobj++/persistent_ptr.hpp>
+#include <libpmemobj++/persistent_ptr_base.hpp>
 #include <libpmemobj++/pool.hpp>
 #include <libpmemobj++/transaction.hpp>
 
@@ -116,12 +118,15 @@ struct nested {
 	nvobj::persistent_ptr<foo> inner;
 };
 
+using V = pmem::obj::vector<nvobj::persistent_ptr_base *>;
+
 struct root {
 	nvobj::persistent_ptr<foo> pfoo;
 	nvobj::persistent_ptr<nvobj::p<int>[TEST_ARR_SIZE]> parr;
+	nvobj::persistent_ptr<V> v;
 
 	/* This variable is unused, but it's here to check if the persistent_ptr
-	 * does not violate it's own restrictions.
+	 * does not violate its own restrictions.
 	 */
 	nvobj::persistent_ptr<nested> outer;
 };
@@ -344,6 +349,37 @@ test_offset(nvobj::pool<root> &pop)
 		UT_ASSERT(0);
 	}
 }
+
+void
+test_base_ptr_casting(nvobj::pool<root> &pop)
+{
+	auto r = pop.root();
+
+	try {
+		nvobj::transaction::run(pop, [&] {
+			r->v = nvobj::make_persistent<V>();
+			auto vecptr = nvobj::make_persistent<V>();
+			auto intptr = nvobj::make_persistent<int>(TEST_INT);
+			nvobj::persistent_ptr<int> int_explicit_ptr_null =
+				nullptr;
+
+			r->v->push_back(&vecptr);
+			r->v->push_back(&intptr);
+			r->v->push_back(&int_explicit_ptr_null);
+
+			UT_ASSERT(!OID_IS_NULL(r->v->at(0)->raw()));
+			UT_ASSERTeq(*(int *)pmemobj_direct(r->v->at(1)->raw()),
+				    TEST_INT);
+			UT_ASSERT(OID_IS_NULL(r->v->at(2)->raw()));
+
+			nvobj::delete_persistent<V>(vecptr);
+			nvobj::delete_persistent<int>(intptr);
+			nvobj::delete_persistent<V>(r->v);
+		});
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+}
 }
 
 int
@@ -370,6 +406,7 @@ main(int argc, char *argv[])
 	test_ptr_transactional(pop);
 	test_ptr_array(pop);
 	test_offset(pop);
+	test_base_ptr_casting(pop);
 
 	pop.close();
 


### PR DESCRIPTION
persistent_ptr_base is changed to enable usage e.g. as a generic
parameter for a function requiring any persistent_ptr.
Non-template version of the base class is perfect for that.
Rationale for this change is a defragmentation feature, which will operate on
various persistent_ptr's.

For wide usage it's also moved out of detail to the main namespace (pmem::obj).

Some tests were extended and some minor fixes were introduced alongside.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/559)
<!-- Reviewable:end -->
