### PR TITLE
allocator: remove unnecessary #include <libpmemobj.h>

### DIFF
--- a/include/libpmemobj++/allocator.hpp
+++ b/include/libpmemobj++/allocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,7 +43,7 @@
 #include <libpmemobj++/detail/pexceptions.hpp>
 #include <libpmemobj++/persistent_ptr.hpp>
 #include <libpmemobj++/pext.hpp>
-#include <libpmemobj.h>
+#include <libpmemobj/tx_base.h>
 
 namespace pmem
 {


### PR DESCRIPTION
Including libpmemobj.h causes inclusion of all type macros
which are not needed by C++.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/565)
<!-- Reviewable:end -->
