### PR TITLE
tests: remove unnecessary #include <libpmemobj.h>

### DIFF
--- a/tests/temp_value/temp_value.cpp
+++ b/tests/temp_value/temp_value.cpp
@@ -39,7 +39,7 @@
 #include <libpmemobj++/detail/temp_value.hpp>
 #include <libpmemobj++/pool.hpp>
 #include <libpmemobj++/transaction.hpp>
-#include <libpmemobj.h>
+#include <libpmemobj/pool_base.h>
 
 namespace nvobj = pmem::obj;
 namespace det = pmem::detail;


### PR DESCRIPTION
Including libpmemobj.h causes inclusion of all type macros
which are not needed by C++.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/566)
<!-- Reviewable:end -->
