### PR TITLE
Add ndctl and daxctl packages to satisfy install-pmdk

### DIFF
--- a/utils/docker/images/Dockerfile.centos-8
+++ b/utils/docker/images/Dockerfile.centos-8
@@ -52,6 +52,7 @@ RUN dnf update -y \
 	bash-completion \
 	clang \
 	cmake \
+	daxctl-devel \
 	doxygen \
 	gcc \
 	gdb \
@@ -66,6 +67,7 @@ RUN dnf update -y \
 	make \
 	man \
 	ncurses-devel \
+	ndctl-devel \
 	open-sans-fonts \
 	passwd \
 	perl-Text-Diff \

--- a/utils/docker/images/Dockerfile.opensuse-leap-latest
+++ b/utils/docker/images/Dockerfile.opensuse-leap-latest
@@ -60,6 +60,7 @@ RUN zypper install -y \
 	keyutils-devel \
 	libjson-c-devel \
 	libkmod-devel \
+	libndctl-devel \
 	libtool \
 	libudev-devel \
 	libunwind-devel \

--- a/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
+++ b/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
@@ -60,6 +60,7 @@ RUN zypper install -y \
 	keyutils-devel \
 	libjson-c-devel \
 	libkmod-devel \
+	libndctl-devel \
 	libtool \
 	libudev-devel \
 	libunwind-devel \


### PR DESCRIPTION
install-pmdk.sh script requires ndctl and daxctl packages
to be installed when installing PMDK from packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/571)
<!-- Reviewable:end -->
