### PR TITLE
Ignore the patch part of a program's version

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2019, Intel Corporation
+# Copyright 2018-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -158,12 +158,12 @@ function(add_check_whitespace name)
 	add_dependencies(check-whitespace check-whitespace-${name})
 endfunction()
 
-# Sets ${ret} to version of program specified by ${name} in major.minor.patch format
+# Sets ${ret} to version of program specified by ${name} in major.minor format
 function(get_program_version name ret)
 	execute_process(COMMAND ${name} --version
 		OUTPUT_VARIABLE cmd_ret
 		ERROR_QUIET)
-	STRING(REGEX MATCH "([0-9]+.)([0-9]+.)([0-9]+)" VERSION ${cmd_ret})
+	STRING(REGEX MATCH "([0-9]+.)([0-9]+)" VERSION ${cmd_ret})
 	SET(${ret} ${VERSION} PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
The patch part of a program's version almost never matters.

This change is needed to accept clang-format v9.0.1 when v9.0 is required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/579)
<!-- Reviewable:end -->
