### PR TITLE
test: fix one type in volatile_state test

### DIFF
--- a/tests/volatile_state/volatile_state.cpp
+++ b/tests/volatile_state/volatile_state.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Intel Corporation
+ * Copyright 2019-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -67,7 +67,7 @@ struct v_data1 {
 	int *val;
 };
 
-static std::atomic<int> v2_initialized;
+static std::atomic<size_t> v2_initialized;
 
 struct v_data2 {
 	v_data2() : val(new int(VALUE))


### PR DESCRIPTION
It fixes the following compilation error:

In file included from /libpmemobj-cpp/tests/volatile_state/\
volatile_state.cpp:33:0:
/libpmemobj-cpp/tests/volatile_state/volatile_state.cpp:\
In function 'void test_vector_of_elements(pmem::obj::pool<root>&)':
/libpmemobj-cpp/tests/volatile_state/volatile_state.cpp:348:30:\
error: conversion to 'size_t {aka long unsigned int}' \
from 'std::__atomic_base<int>::__int_type {aka int}' \
may change the sign of the result [-Werror=sign-conversion]
  UT_ASSERT(v2_initialized == NUM_ELEMENTS);
                              ^

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/584)
<!-- Reviewable:end -->
