### PR TITLE
Remove checking for offsetof error in pmdk

### DIFF
--- a/cmake/check_compiler_issues.cmake
+++ b/cmake/check_compiler_issues.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright 2019, Intel Corporation
+# Copyright 2019-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -125,21 +125,6 @@ CHECK_CXX_SOURCE_COMPILES(
 	#endif
 	}"
 	AGGREGATE_INITIALIZATION_AVAILABLE
-)
-
-set(CMAKE_REQUIRED_FLAGS "--std=c++${CMAKE_CXX_STANDARD} -c")
-CHECK_CXX_SOURCE_COMPILES("
-	#include <libpmemobj/types.h>
-	struct s {
-		int a;
-		int b;
-	};
-	int main() {
-		if (offsetof(struct s, a) >= offsetof(struct s, b))
-			return 1;
-		return 0;
-	}"
-	OFFSETOF_CORRECT
 )
 
 set(CMAKE_REQUIRED_INCLUDES ${SAVED_CMAKE_REQUIRED_INCLUDES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,18 +63,6 @@ add_flag(-DDEBUG DEBUG)
 
 add_flag("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2" RELEASE)
 
-if(NOT OFFSETOF_CORRECT)
-	#
-	# Enable workaround in libpmemobj.h for the issue with the offsetof() macro:
-	#
-	# https://github.com/pmem/pmdk/issues/4303
-	#
-	# https://developercommunity.visualstudio.com/content/problem/96174/\
-	# offsetof-macro-is-broken-for-nested-objects.html
-	#
-	add_flag(-DPMEMOBJ_OFFSETOF_WA)
-endif()
-
 if(USE_ASAN)
        add_sanitizer_flag(address)
 endif()


### PR DESCRIPTION
Now, we do not include any headers which depend on offsetof (types.h)
so this check is not longer necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/595)
<!-- Reviewable:end -->
