### PR TITLE
Implementation of insert_or_assign in concurrent_hash_map

### DIFF
--- a/include/libpmemobj++/container/concurrent_hash_map.hpp
+++ b/include/libpmemobj++/container/concurrent_hash_map.hpp
@@ -348,9 +348,8 @@ struct hash_map_node {
 	}
 
 	template <typename... Args>
-	hash_map_node(node_ptr_t &&_next, Args &&... args)
-	    : next(std::forward<node_ptr_t>(_next)),
-	      item(std::forward<Args>(args)...)
+	hash_map_node(const node_ptr_t &_next, Args &&... args)
+	    : next(_next), item(std::forward<Args>(args)...)
 	{
 	}
 
@@ -2526,6 +2525,97 @@ public:
 		concurrent_hash_map_internal::check_outside_tx();
 
 		insert(il.begin(), il.end());
+	}
+
+	/**
+	 * Inserts item if there is no such key present already, assigns
+	 * provided value otherwise.
+	 * @return return true if the insertion took place and false if the
+	 * assignment took place.
+	 * @throw pmem::transaction_alloc_error on allocation failure.
+	 * @throw pmem::transaction_scope_error if called inside transaction
+	 */
+	template <typename M>
+	bool
+	insert_or_assign(const key_type &key, M &&obj)
+	{
+		concurrent_hash_map_internal::check_outside_tx();
+
+		accessor acc;
+		auto result = internal_insert(key, &acc, true, key,
+					      std::forward<M>(obj));
+
+		if (!result) {
+			pool_base pop = get_pool_base();
+			pmem::obj::transaction::manual tx(pop);
+			acc->second = std::forward<M>(obj);
+			pmem::obj::transaction::commit();
+		}
+
+		return result;
+	}
+
+	/**
+	 * Inserts item if there is no such key present already, assigns
+	 * provided value otherwise.
+	 * @return return true if the insertion took place and false if the
+	 * assignment took place.
+	 * @throw pmem::transaction_alloc_error on allocation failure.
+	 * @throw pmem::transaction_scope_error if called inside transaction
+	 */
+	template <typename M>
+	bool
+	insert_or_assign(key_type &&key, M &&obj)
+	{
+		concurrent_hash_map_internal::check_outside_tx();
+
+		accessor acc;
+		auto result = internal_insert(key, &acc, true, std::move(key),
+					      std::forward<M>(obj));
+
+		if (!result) {
+			pool_base pop = get_pool_base();
+			pmem::obj::transaction::manual tx(pop);
+			acc->second = std::forward<M>(obj);
+			pmem::obj::transaction::commit();
+		}
+
+		return result;
+	}
+
+	/**
+	 * Inserts item if there is no such key-comparable type present already,
+	 * assigns provided value otherwise.
+	 * @return return true if the insertion took place and false if the
+	 * assignment took place.
+	 * @throw pmem::transaction_alloc_error on allocation failure.
+	 * @throw pmem::transaction_scope_error if called inside transaction
+	 */
+	template <
+		typename K, typename M,
+		typename = typename std::enable_if<
+			concurrent_hash_map_internal::has_transparent_key_equal<
+				hasher>::value &&
+				std::is_constructible<key_type, K>::value,
+			K>::type>
+	bool
+	insert_or_assign(K &&key, M &&obj)
+	{
+		concurrent_hash_map_internal::check_outside_tx();
+
+		accessor acc;
+		auto result =
+			internal_insert(key, &acc, true, std::forward<K>(key),
+					std::forward<M>(obj));
+
+		if (!result) {
+			pool_base pop = get_pool_base();
+			pmem::obj::transaction::manual tx(pop);
+			acc->second = std::forward<M>(obj);
+			pmem::obj::transaction::commit();
+		}
+
+		return result;
 	}
 
 	/**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -375,6 +375,9 @@ if(TEST_CONCURRENT_HASHMAP)
 	build_test(concurrent_hash_map_insert_erase concurrent_hash_map_insert_erase/concurrent_hash_map_insert_erase.cpp)
 	add_test_generic(NAME concurrent_hash_map_insert_erase CASE 0 TRACERS none memcheck pmemcheck)
 
+	build_test(concurrent_hash_map_insert_or_assign concurrent_hash_map_insert_or_assign/concurrent_hash_map_insert_or_assign.cpp)
+	add_test_generic(NAME concurrent_hash_map_insert_or_assign TRACERS none memcheck pmemcheck helgrind drd)
+
 	build_test(concurrent_hash_map_rehash concurrent_hash_map_rehash/concurrent_hash_map_rehash.cpp)
 	add_test_generic(NAME concurrent_hash_map_rehash CASE 0 TRACERS none memcheck pmemcheck)
 

--- a/tests/concurrent_hash_map/concurrent_hash_map_string_test.hpp
+++ b/tests/concurrent_hash_map/concurrent_hash_map_string_test.hpp
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2018-2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * concurrent_hash_map_string_test.hpp -- pmem::obj::concurrent_hash_map test
+ */
+
+#include "concurrent_hash_map_traits.hpp"
+#include "unittest.hpp"
+
+#include <libpmemobj++/container/concurrent_hash_map.hpp>
+#include <libpmemobj++/container/string.hpp>
+#include <libpmemobj++/container/vector.hpp>
+#include <libpmemobj++/p.hpp>
+#include <libpmemobj++/persistent_ptr.hpp>
+#include <libpmemobj++/pool.hpp>
+
+#include <string>
+
+#if LIBPMEMOBJ_CPP_USE_TBB_RW_MUTEX
+#include "tbb/spin_rw_mutex.h"
+#endif
+
+#define LAYOUT "concurrent_hash_map"
+
+namespace nvobj = pmem::obj;
+
+class key_equal {
+public:
+	template <typename M, typename U>
+	bool
+	operator()(const M &lhs, const U &rhs) const
+	{
+		return lhs == rhs;
+	}
+};
+
+class string_hasher {
+	/* hash multiplier used by fibonacci hashing */
+	static const size_t hash_multiplier = 11400714819323198485ULL;
+
+public:
+	using transparent_key_equal = key_equal;
+
+	size_t
+	operator()(const nvobj::string &str) const
+	{
+		return hash(str.c_str(), str.size());
+	}
+
+	size_t
+	operator()(const std::string &str) const
+	{
+		return hash(str.c_str(), str.size());
+	}
+
+private:
+	size_t
+	hash(const char *str, size_t size) const
+	{
+		size_t h = 0;
+		for (size_t i = 0; i < size; ++i) {
+			h = static_cast<size_t>(str[i]) ^ (h * hash_multiplier);
+		}
+		return h;
+	}
+};
+
+#if LIBPMEMOBJ_CPP_USE_TBB_RW_MUTEX
+typedef nvobj::concurrent_hash_map<nvobj::string, nvobj::p<int>, string_hasher,
+				   std::equal_to<nvobj::string>,
+				   nvobj::experimental::v<tbb::spin_rw_mutex>,
+				   tbb::spin_rw_mutex::scoped_lock>
+	persistent_map_type;
+#else
+typedef nvobj::concurrent_hash_map<nvobj::string, nvobj::p<int>, string_hasher>
+	persistent_map_type;
+#endif
+typedef nvobj::vector<nvobj::string> tls_type;
+
+struct root {
+	nvobj::persistent_ptr<persistent_map_type> cons;
+	nvobj::persistent_ptr<tls_type> tls;
+};
+
+/*
+ * insert_or_assign_lvalue -- test insert_or_assign with lvalue key
+ * pmem::obj::concurrent_hash_map<nvobj::string, nvobj::string >
+ */
+void
+insert_or_assign_lvalue(nvobj::pool<root> &pop, size_t concurrency = 8,
+			size_t thread_items = 50)
+{
+	PRINT_TEST_PARAMS;
+	ConcurrentHashMapTestPrimitives<root, persistent_map_type> test(
+		pop, pop.root()->cons, thread_items * concurrency);
+
+	nvobj::persistent_ptr<tls_type> &tls = pop.root()->tls;
+	using accessor = persistent_map_type::accessor;
+	using const_acc = persistent_map_type::const_accessor;
+
+	tls->resize(concurrency);
+	parallel_exec(concurrency, [&](size_t thread_id) {
+		int begin = thread_id * thread_items;
+		int end = begin + int(thread_items);
+		auto &pstr = tls->at(thread_id);
+
+		for (int i = begin; i < end; i++) {
+			pstr = std::to_string(i);
+			const persistent_map_type::key_type &val = pstr;
+			bool result = test.insert_or_assign(val, i);
+			UT_ASSERT(result);
+		}
+		for (int i = begin; i < end; i++) {
+			test.check_item<accessor>(std::to_string(i), i);
+		}
+		for (int i = begin; i < end; i++) {
+			/* assign existing keys new values */
+			pstr = std::to_string(i);
+			const persistent_map_type::key_type &val = pstr;
+			bool result = test.insert_or_assign(val, i + 1);
+			UT_ASSERT(!result);
+		}
+		for (int i = begin; i < end; i++) {
+			test.check_item<const_acc>(std::to_string(i), i + 1);
+		}
+	});
+	test.check_consistency();
+	test.clear();
+	tls->clear();
+}
+
+/*
+ * insert_or_assign_rvalue -- test insert_or_assign with rvalue key
+ * pmem::obj::concurrent_hash_map<nvobj::string, nvobj::string >
+ */
+void
+insert_or_assign_rvalue(nvobj::pool<root> &pop, size_t concurrency = 8,
+			size_t thread_items = 50)
+{
+	PRINT_TEST_PARAMS;
+	ConcurrentHashMapTestPrimitives<root, persistent_map_type> test(
+		pop, pop.root()->cons, thread_items * concurrency);
+
+	nvobj::persistent_ptr<tls_type> &tls = pop.root()->tls;
+	using accessor = persistent_map_type::accessor;
+	using const_acc = persistent_map_type::const_accessor;
+
+	tls->resize(concurrency);
+	parallel_exec(concurrency, [&](size_t thread_id) {
+		int begin = thread_id * thread_items;
+		int end = begin + int(thread_items);
+		auto &pstr = tls->at(thread_id);
+
+		for (int i = begin; i < end; i++) {
+			pstr = std::to_string(i);
+			bool result = test.insert_or_assign(std::move(pstr), i);
+			UT_ASSERT(result);
+		}
+		for (int i = begin; i < end; i++) {
+			test.check_item<accessor>(std::to_string(i), i);
+		}
+		for (int i = begin; i < end; i++) {
+			/* assign existing keys new values */
+			pstr = std::to_string(i);
+			bool result =
+				test.insert_or_assign(std::move(pstr), i + 1);
+			UT_ASSERT(!result);
+		}
+		for (int i = begin; i < end; i++) {
+			test.check_item<const_acc>(std::to_string(i), i + 1);
+		}
+	});
+	test.check_consistency();
+	test.clear();
+	tls->clear();
+}
+
+/*
+ * insert_or_assign_heterogeneous -- test insert_or_assign with key-comparable
+ * pmem::obj::concurrent_hash_map<nvobj::string, nvobj::string >
+ */
+void
+insert_or_assign_heterogeneous(nvobj::pool<root> &pop, size_t concurrency = 8,
+			       size_t thread_items = 50)
+{
+	PRINT_TEST_PARAMS;
+	ConcurrentHashMapTestPrimitives<root, persistent_map_type> test(
+		pop, pop.root()->cons, thread_items * concurrency);
+
+	using accessor = persistent_map_type::accessor;
+	using const_acc = persistent_map_type::const_accessor;
+
+	parallel_exec(concurrency, [&](size_t thread_id) {
+		int begin = thread_id * thread_items;
+		int end = begin + int(thread_items);
+
+		for (int i = begin; i < end; i++) {
+			bool result =
+				test.insert_or_assign(std::to_string(i), i);
+			UT_ASSERT(result);
+		}
+		for (int i = begin; i < end; i++) {
+			test.check_item<accessor>(std::to_string(i), i);
+		}
+		for (int i = begin; i < end; i++) {
+			/* assign existing keys new values */
+			bool result =
+				test.insert_or_assign(std::to_string(i), i + 1);
+			UT_ASSERT(!result);
+		}
+		for (int i = begin; i < end; i++) {
+			test.check_item<const_acc>(std::to_string(i), i + 1);
+		}
+	});
+	test.check_consistency();
+	test.clear();
+}

--- a/tests/concurrent_hash_map_insert_or_assign/concurrent_hash_map_insert_or_assign.cpp
+++ b/tests/concurrent_hash_map_insert_or_assign/concurrent_hash_map_insert_or_assign.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * concurrent_hash_map_insert_or_assign.cpp -- pmem::obj::concurrent_hash_map
+ * test
+ */
+
+#include "../concurrent_hash_map/concurrent_hash_map_string_test.hpp"
+#include "unittest.hpp"
+
+int
+main(int argc, char *argv[])
+{
+	START();
+
+	if (argc < 2) {
+		UT_FATAL("usage: %s file-name", argv[0]);
+	}
+
+	const char *path = argv[1];
+
+	nvobj::pool<root> pop;
+
+	try {
+		pop = nvobj::pool<root>::create(
+			path, LAYOUT, PMEMOBJ_MIN_POOL * 20, S_IWUSR | S_IRUSR);
+		pmem::obj::transaction::run(pop, [&] {
+			pop.root()->cons =
+				nvobj::make_persistent<persistent_map_type>();
+			pop.root()->tls = nvobj::make_persistent<tls_type>();
+		});
+	} catch (pmem::pool_error &pe) {
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
+	}
+
+	/* Test that scoped_lock traits is working correctly */
+#if LIBPMEMOBJ_CPP_USE_TBB_RW_MUTEX
+	UT_ASSERT(pmem::obj::concurrent_hash_map_internal::scoped_lock_traits<
+			  tbb::spin_rw_mutex::scoped_lock>::
+			  initial_rw_state(true) == false);
+#else
+	UT_ASSERT(pmem::obj::concurrent_hash_map_internal::scoped_lock_traits<
+			  pmem::obj::concurrent_hash_map_internal::
+				  shared_mutex_scoped_lock<
+					  pmem::obj::shared_mutex>>::
+			  initial_rw_state(true) == true);
+#endif
+
+	size_t concurrency = 8;
+	if (On_drd)
+		concurrency = 2;
+	std::cout << "Running tests for " << concurrency << " threads"
+		  << std::endl;
+
+	insert_or_assign_lvalue(pop, concurrency);
+	insert_or_assign_rvalue(pop, concurrency);
+	insert_or_assign_heterogeneous(pop, concurrency);
+
+	pmem::obj::transaction::run(pop, [&] {
+		nvobj::delete_persistent<persistent_map_type>(pop.root()->cons);
+		nvobj::delete_persistent<tls_type>(pop.root()->tls);
+	});
+
+	pop.close();
+	return 0;
+}

--- a/tests/concurrent_hash_map_singlethread/concurrent_hash_map_singlethread.cpp
+++ b/tests/concurrent_hash_map_singlethread/concurrent_hash_map_singlethread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019, Intel Corporation
+ * Copyright 2018-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,6 +47,7 @@
 #include <vector>
 
 #include <libpmemobj++/container/concurrent_hash_map.hpp>
+#include <libpmemobj++/container/string.hpp>
 
 #define LAYOUT "concurrent_hash_map"
 
@@ -95,13 +96,20 @@ public:
 
 	MyLong(int v)
 	{
-		UT_ASSERT(false);
+		UT_ASSERT(pmemobj_pool_by_ptr(this) != nullptr);
 	}
 
 	long
 	get_val() const
 	{
 		return val.get_ro();
+	}
+
+	MyLong &
+	operator=(long other)
+	{
+		val = other;
+		return *this;
 	}
 
 	bool
@@ -120,12 +128,6 @@ private:
 	nvobj::p<long> val;
 };
 
-bool
-operator==(int lhs, const MyLong &rhs)
-{
-	return rhs == lhs;
-}
-
 class TransparentKeyEqual {
 public:
 	template <typename M, typename U>
@@ -136,19 +138,34 @@ public:
 	}
 };
 
-class HeteroHasher {
+class string_hasher {
+	/* hash multiplier used by fibonacci hashing */
+	static const size_t hash_multiplier = 11400714819323198485ULL;
+
 public:
 	using transparent_key_equal = TransparentKeyEqual;
+
 	size_t
-	operator()(const MyLong &myLong) const
+	operator()(const nvobj::string &str) const
 	{
-		return size_t(myLong.get_val());
+		return hash(str.c_str(), str.size());
 	}
 
 	size_t
-	operator()(int i) const
+	operator()(const std::string &str) const
 	{
-		return size_t(i);
+		return hash(str.c_str(), str.size());
+	}
+
+private:
+	size_t
+	hash(const char *str, size_t size) const
+	{
+		size_t h = 0;
+		for (size_t i = 0; i < size; ++i) {
+			h = static_cast<size_t>(str[i]) ^ (h * hash_multiplier);
+		}
+		return h;
 	}
 };
 
@@ -157,7 +174,7 @@ typedef nvobj::concurrent_hash_map<nvobj::p<int>, move_element>
 
 typedef persistent_map_move_type::value_type value_move_type;
 
-typedef nvobj::concurrent_hash_map<MyLong, MyLong, HeteroHasher>
+typedef nvobj::concurrent_hash_map<nvobj::string, nvobj::p<int>, string_hasher>
 	persistent_map_hetero_type;
 
 struct root {
@@ -488,12 +505,11 @@ insert_test(nvobj::pool<root> &pop)
 
 /*
  * hetero_test -- (internal) test heterogeneous count/find/erase methods
- * pmem::obj::concurrent_hash_map<MyLong, MyLong, HeteroHasher >
+ * pmem::obj::concurrent_hash_map<nvobj::string, nvobj::p<int>, string_hasher >
  */
 void
 hetero_test(nvobj::pool<root> &pop)
 {
-	typedef persistent_map_hetero_type::value_type value_type;
 	auto &map = pop.root()->map_hetero;
 
 	tx_alloc_wrapper<persistent_map_hetero_type>(pop, map);
@@ -501,33 +517,39 @@ hetero_test(nvobj::pool<root> &pop)
 	map->runtime_initialize();
 
 	for (long i = 0; i < 100; ++i) {
-		map->insert(value_type(i, i));
+		map->insert_or_assign(std::to_string(i), i);
 	}
 
 	for (int i = 0; i < 100; ++i) {
-		UT_ASSERTeq(map->count(i), 1);
+		UT_ASSERTeq(map->count(std::to_string(i)), 1);
 	}
 
 	for (int i = 0; i < 100; ++i) {
 		persistent_map_hetero_type::accessor accessor;
-		UT_ASSERT(map->find(accessor, i));
-		UT_ASSERT(i == accessor->first);
+		auto val = std::to_string(i);
+		UT_ASSERT(map->find(accessor, val));
+		UT_ASSERT(val == accessor->first);
 		UT_ASSERT(i == accessor->second);
+	}
+
+	for (long i = 0; i < 100; ++i) {
+		map->insert_or_assign(std::to_string(i), i + 1);
 	}
 
 	for (int i = 0; i < 100; ++i) {
 		persistent_map_hetero_type::const_accessor accessor;
-		UT_ASSERT(map->find(accessor, i));
-		UT_ASSERT(i == accessor->first);
-		UT_ASSERT(i == accessor->second);
+		auto val = std::to_string(i);
+		UT_ASSERT(map->find(accessor, val));
+		UT_ASSERT(val == accessor->first);
+		UT_ASSERT(i + 1 == accessor->second);
 	}
 
 	for (int i = 0; i < 100; ++i) {
-		UT_ASSERT(map->erase(i));
+		UT_ASSERT(map->erase(std::to_string(i)));
 	}
 
 	for (int i = 0; i < 100; ++i) {
-		UT_ASSERTeq(map->count(i), 0);
+		UT_ASSERTeq(map->count(std::to_string(i)), 0);
 	}
 }
 


### PR DESCRIPTION
Insert_or_assign from std::unordered_map (since C++17) without hints, additional method with heterogeneous key-type and tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/599)
<!-- Reviewable:end -->
