### PR TITLE
Backport hash map erase fix to stable 1.8

### DIFF
--- a/include/libpmemobj++/container/concurrent_hash_map.hpp
+++ b/include/libpmemobj++/container/concurrent_hash_map.hpp
@@ -1510,6 +1510,9 @@ operator!=(const hash_map_iterator<Container, M> &i,
  * find(), insert(), erase() (and all overloads) are guaranteed to be
  * thread-safe.
  *
+ * When a thread holds accessor to an element with a certain key, it is not
+ * allowed to call find, insert nor erase with that key.
+ *
  * MutexType defines type of read write lock used in concurrent_hash_map.
  * ScopedLockType defines a mutex wrapper that provides RAII-style mechanism
  * for owning a mutex. It should implement following methods and constructors:
@@ -1527,6 +1530,11 @@ operator!=(const hash_map_iterator<Container, M> &i,
  * Implementing all optional methods and supplying is_writer variable can
  * improve performance if MutexType supports efficient upgrading and
  * downgrading operations.
+ *
+ * Testing note:
+ * In some case, helgrind and drd might report lock ordering errors for
+ * concurrent_hash_map. This might happen when calling find, insert or erase
+ * while already holding an accessor to some element.
  *
  * The typical usage example would be:
  * @snippet doc_snippets/concurrent_hash_map.cpp concurrent_hash_map_example

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -367,6 +367,11 @@ if(PMEMVLT_PRESENT AND ENABLE_CONCURRENT_HASHMAP)
 	build_test(concurrent_hash_map_rehash concurrent_hash_map_rehash/concurrent_hash_map_rehash.cpp)
 	add_test_generic(NAME concurrent_hash_map_rehash CASE 0 TRACERS none memcheck pmemcheck)
 
+	# This test can NOT be run under helgrind as it will report wrong lock ordering. Helgrind is right about
+	# possible deadlock situation but that could only happen in case of wrong API usage.
+	build_test(concurrent_hash_map_deadlock concurrent_hash_map_deadlock/concurrent_hash_map_deadlock.cpp)
+	add_test_generic(NAME concurrent_hash_map_deadlock CASE 0 TRACERS none drd memcheck pmemcheck)
+
 	if(TESTS_CONCURRENT_HASH_MAP_DRD_HELGRIND)
 		add_test_generic(NAME concurrent_hash_map_insert_lookup CASE 0 TRACERS helgrind)
 

--- a/tests/concurrent_hash_map_deadlock/concurrent_hash_map_deadlock.cpp
+++ b/tests/concurrent_hash_map_deadlock/concurrent_hash_map_deadlock.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * concurrent_hash_map_deadlock.cpp -- pmem::obj::concurrent_hash_map test
+ *
+ */
+
+#include "../concurrent_hash_map/concurrent_hash_map_test.hpp"
+#include "unittest.hpp"
+
+int
+main(int argc, char *argv[])
+{
+	START();
+
+	if (argc < 2) {
+		UT_FATAL("usage: %s file-name", argv[0]);
+	}
+
+	const char *path = argv[1];
+
+	nvobj::pool<root> pop;
+
+	try {
+		pop = nvobj::pool<root>::create(
+			path, LAYOUT, PMEMOBJ_MIN_POOL * 20, S_IWUSR | S_IRUSR);
+		pmem::obj::transaction::run(pop, [&] {
+			pop.root()->cons =
+				nvobj::make_persistent<persistent_map_type>();
+		});
+	} catch (pmem::pool_error &pe) {
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
+	}
+
+	lookup_insert_erase_deadlock_test(pop);
+
+	pop.close();
+	return 0;
+}

--- a/tests/concurrent_hash_map_deadlock/concurrent_hash_map_deadlock_0.cmake
+++ b/tests/concurrent_hash_map_deadlock/concurrent_hash_map_deadlock_0.cmake
@@ -1,0 +1,42 @@
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+include(${SRC_DIR}/../helpers.cmake)
+
+setup()
+
+if ((${TRACER} STREQUAL "drd") OR (${TRACER} STREQUAL "helgrind"))
+    check_is_pmem(${DIR}/testfile)
+endif()
+
+execute(${TEST_EXECUTABLE} ${DIR}/testfile)
+
+finish()


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/613)
<!-- Reviewable:end -->
