### PR TITLE
Fix types in enumerable_thread_specific_access test

### DIFF
--- a/tests/enumerable_thread_specific_access/enumerable_thread_specific_access.cpp
+++ b/tests/enumerable_thread_specific_access/enumerable_thread_specific_access.cpp
@@ -84,8 +84,8 @@ test(nvobj::pool<struct root> &pop)
 
 		UT_ASSERT(tls->size() <= concurrency);
 
-		int n_zeros = 0;
-		int n_100 = 0;
+		size_t n_zeros = 0;
+		size_t n_100 = 0;
 		for (auto &e : checker) {
 			if (e == 0)
 				n_zeros++;
@@ -95,7 +95,7 @@ test(nvobj::pool<struct root> &pop)
 				UT_ASSERTeq(e, 0);
 		}
 
-		/* At least one thread should have done it's work */
+		/* At least one thread should have done its work */
 		UT_ASSERT(n_100 > 0);
 		UT_ASSERT(n_100 + n_zeros == concurrency);
 	}


### PR DESCRIPTION
It fixes the following compilation error on openSUSE Leap:
```
In file included from /libpmemobj-cpp/tests/enumerable_thread_specific_access/enumerable_thread_specific_access.cpp:33:0:
/libpmemobj-cpp/tests/enumerable_thread_specific_access/enumerable_thread_specific_access.cpp: In function 'void test(pmem::obj::pool<root>&)':
/libpmemobj-cpp/tests/enumerable_thread_specific_access/enumerable_thread_specific_access.cpp:100:19: error: conversion to 'size_t {aka long unsigned int}' from 'int' may change the sign of the result [-Werror=sign-conversion]
   UT_ASSERT(n_100 + n_zeros == concurrency);
             ~~~~~~^~~
/libpmemobj-cpp/tests/common/unittest.hpp:130:11: note: in definition of macro 'UT_ASSERT'
  ((void)((cnd) ||                                                       \
           ^~~
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/614)
<!-- Reviewable:end -->
