### PR TITLE
Fix tests_clang_release_cpp11_no_valgrind in run-build.sh

### DIFF
--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -141,7 +141,7 @@ function tests_clang_release_cpp11_no_valgrind() {
 	CC=clang CXX=clang++ \
 	cmake .. -DDEVELOPER_MODE=1 \
 		-DCHECK_CPP_STYLE=${CHECK_CPP_STYLE} \
-		-DCMAKE_BUILD_TYPE=Debug \
+		-DCMAKE_BUILD_TYPE=Release \
 		-DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
 		-DTRACE_TESTS=1 \
 		-DCOVERAGE=$COVERAGE \


### PR DESCRIPTION
Set CMAKE_BUILD_TYPE to Release instead of Debug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/616)
<!-- Reviewable:end -->
