### PR TITLE
Update PMDK to newest devel-1.8 to get rid of man dependency

### DIFF
--- a/utils/docker/images/Dockerfile.centos-8
+++ b/utils/docker/images/Dockerfile.centos-8
@@ -65,7 +65,6 @@ RUN dnf update -y \
 	libunwind-devel \
 	libuuid-devel \
 	make \
-	man \
 	ncurses-devel \
 	ndctl-devel \
 	open-sans-fonts \

--- a/utils/docker/images/Dockerfile.fedora-31
+++ b/utils/docker/images/Dockerfile.fedora-31
@@ -60,7 +60,6 @@ RUN dnf update -y \
 	libunwind-devel \
 	libuuid-devel \
 	make \
-	man \
 	ncurses-devel \
 	ndctl-devel \
 	open-sans-fonts \

--- a/utils/docker/images/Dockerfile.fedora-rawhide
+++ b/utils/docker/images/Dockerfile.fedora-rawhide
@@ -62,7 +62,6 @@ RUN dnf update -y \
 	libunwind-devel \
 	libuuid-devel \
 	make \
-	man \
 	ncurses-devel \
 	ndctl-devel \
 	open-sans-fonts \

--- a/utils/docker/images/Dockerfile.opensuse-leap-latest
+++ b/utils/docker/images/Dockerfile.opensuse-leap-latest
@@ -66,7 +66,6 @@ RUN zypper install -y \
 	libunwind-devel \
 	libuuid-devel \
 	make \
-	man \
 	ncurses-devel \
 	pandoc \
 	perl-Text-Diff \

--- a/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
+++ b/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
@@ -66,7 +66,6 @@ RUN zypper install -y \
 	libunwind-devel \
 	libuuid-devel \
 	make \
-	man \
 	ncurses-devel \
 	pandoc \
 	perl-Text-Diff \

--- a/utils/docker/images/install-pmdk.sh
+++ b/utils/docker/images/install-pmdk.sh
@@ -38,8 +38,8 @@ set -e
 
 PACKAGE_MANAGER=$1
 
-# devel-1.8: doc: fix indentation; 17.01.2020
-PMDK_VERSION="45e5a673eecd9a6302b8af6c4901b60f9a239b04"
+# devel-1.8: Merge pull request #4497 from marcinslusarz/build, 23.01.2020
+PMDK_VERSION="1947982d15ebb3d107e781cdc1484ef4ce81cc41"
 
 git clone https://github.com/pmem/pmdk
 cd pmdk


### PR DESCRIPTION
The PR pmem/pmdk#4494 is needed to get rid of the 'man' package dependency
and the PR #610 should not be needed then.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/619)
<!-- Reviewable:end -->
