### PR TITLE
tests: increase poolsize for enumerable_thread_specific access test

### DIFF
--- a/tests/enumerable_thread_specific_access/enumerable_thread_specific_access.cpp
+++ b/tests/enumerable_thread_specific_access/enumerable_thread_specific_access.cpp
@@ -223,7 +223,7 @@ main(int argc, char *argv[])
 	auto path = argv[1];
 	auto pop = nvobj::pool<root>::create(
 		path, "TLSTest: enumerable_thread_specific_access",
-		PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR);
+		10 * PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR);
 
 	auto r = pop.root();
 


### PR DESCRIPTION
in some runs (depending on thread scheduling) test ended with out-of-memory
error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/620)
<!-- Reviewable:end -->
