### PR TITLE
concurrent_hash_map: change implementation of runtime_initialize(bool)

### DIFF
--- a/include/libpmemobj++/container/concurrent_hash_map.hpp
+++ b/include/libpmemobj++/container/concurrent_hash_map.hpp
@@ -2197,9 +2197,22 @@ public:
 
 	[[deprecated(
 		"runtime_initialize(bool) is now deprecated, use runtime_initialize(void)")]] void
-	runtime_initialize(bool)
+	runtime_initialize(bool graceful_shutdown)
 	{
-		runtime_initialize();
+		check_incompat_features();
+
+		calculate_mask();
+
+		if (!graceful_shutdown) {
+			auto actual_size =
+				std::distance(this->begin(), this->end());
+			assert(actual_size >= 0);
+			this->my_size = static_cast<size_type>(actual_size);
+		} else {
+			assert(this->size() ==
+			       size_type(std::distance(this->begin(),
+						       this->end())));
+		}
 	}
 
 	/**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -402,6 +402,14 @@ if(TEST_CONCURRENT_HASHMAP)
 	add_test_generic(NAME concurrent_hash_map_insert_reopen CASE 0 TRACERS none memcheck pmemcheck
 			SCRIPT concurrent_hash_map/check_is_pmem.cmake)
 
+	build_test_ext(NAME concurrent_hash_map_insert_reopen_deprecated SRC_FILES concurrent_hash_map_insert_reopen/concurrent_hash_map_insert_reopen.cpp
+			BUILD_OPTIONS -DUSE_DEPRECATED_RUNTIME_INITIALIZE)
+	check_cxx_compiler_flag(-Wdeprecated-declarations deprecated_declarations)
+	if (deprecated_declarations)
+		target_compile_options(concurrent_hash_map_insert_reopen_deprecated PUBLIC -Wno-deprecated-declarations)
+	endif()
+	add_test_generic(NAME concurrent_hash_map_insert_reopen_deprecated TRACERS none)
+
 	if(TESTS_CONCURRENT_HASH_MAP_DRD_HELGRIND)
 		add_test_generic(NAME concurrent_hash_map_insert_lookup CASE 0 TRACERS helgrind
 				SCRIPT concurrent_hash_map/check_is_pmem.cmake)

--- a/tests/concurrent_hash_map_insert_reopen/concurrent_hash_map_insert_reopen.cpp
+++ b/tests/concurrent_hash_map_insert_reopen/concurrent_hash_map_insert_reopen.cpp
@@ -38,6 +38,14 @@
 #include "../concurrent_hash_map/concurrent_hash_map_test.hpp"
 #include "unittest.hpp"
 
+/* When this is defined we test deprecated runtime_initialize() method which
+ * is needed for compatibility. We test new runtime_initialize() otherwise. */
+#ifdef USE_DEPRECATED_RUNTIME_INITIALIZE
+#define RUNTIME_INITIALIZE runtime_initialize(true)
+#else
+#define RUNTIME_INITIALIZE runtime_initialize()
+#endif
+
 /*
  * insert_reopen_test -- (internal) test insert operations and verify
  * consistency after reopen
@@ -87,7 +95,7 @@ insert_reopen_test(nvobj::pool<root> &pop, std::string path,
 
 		UT_ASSERT(map != nullptr);
 
-		map->runtime_initialize();
+		map->RUNTIME_INITIALIZE;
 
 		test.check_items_count();
 


### PR DESCRIPTION
This patch changes implementation to be the same as before
708bd019725aeb90ba0f167df7ec93861cfd6027 (implementation of
runtime_initialize(void) is left unchanged).

The change is needed for backward compatibility with pmemkv-1.0. There, we
called runtime_initialize(true) in a transaction after tx commit (we assumed
there is nothing transactional in runtime_initialize). Introducing a tx
inside new runtime_initialize() reusults in crash on 1.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/622)
<!-- Reviewable:end -->
