### PR TITLE
concurrent_hash_map fixes

### DIFF
--- a/include/libpmemobj++/container/concurrent_hash_map.hpp
+++ b/include/libpmemobj++/container/concurrent_hash_map.hpp
@@ -1036,7 +1036,7 @@ public:
 #if LIBPMEMOBJ_CPP_VG_HELGRIND_ENABLED
 		VALGRIND_HG_DISABLE_CHECKING(&my_mask, sizeof(my_mask));
 #endif
-		layout_features = header_features();
+		layout_features = {0, 0};
 
 		PMEMoid oid = pmemobj_oid(this);
 
@@ -1057,9 +1057,9 @@ public:
 
 		on_init_size = 0;
 
-		value_size = sizeof(std::pair<const Key, T>);
+		value_size = 0;
 
-		this->tls_ptr = make_persistent<tls_t>();
+		this->tls_ptr = nullptr;
 	}
 
 	/*
@@ -2192,6 +2192,7 @@ public:
 			auto pop = get_pool_base();
 			transaction::run(pop, [&] {
 				this->tls_ptr = make_persistent<tls_t>();
+				this->value_size = sizeof(value_type);
 
 				layout_features.compat |=
 					FEATURE_CONSISTENT_SIZE;

--- a/include/libpmemobj++/container/concurrent_hash_map.hpp
+++ b/include/libpmemobj++/container/concurrent_hash_map.hpp
@@ -2186,12 +2186,13 @@ public:
 				std::distance(this->begin(), this->end());
 			assert(actual_size >= 0);
 
-			this->on_init_size = static_cast<size_t>(actual_size);
 			this->my_size = static_cast<size_t>(actual_size);
 
 			auto pop = get_pool_base();
 			transaction::run(pop, [&] {
 				this->tls_ptr = make_persistent<tls_t>();
+				this->on_init_size =
+					static_cast<size_t>(actual_size);
 				this->value_size = sizeof(value_type);
 
 				layout_features.compat |=

--- a/include/libpmemobj++/container/concurrent_hash_map.hpp
+++ b/include/libpmemobj++/container/concurrent_hash_map.hpp
@@ -41,6 +41,7 @@
 
 #include <libpmemobj++/detail/atomic_backoff.hpp>
 #include <libpmemobj++/detail/common.hpp>
+#include <libpmemobj++/detail/pair.hpp>
 #include <libpmemobj++/detail/template_helpers.hpp>
 
 #include <libpmemobj++/make_persistent.hpp>
@@ -307,7 +308,7 @@ struct hash_map_node {
 	/** Scoped lock type for mutex. */
 	using scoped_t = ScopedLockType;
 
-	using value_type = std::pair<const Key, T>;
+	using value_type = detail::pair<const Key, T>;
 
 	/** Persistent pointer type for next. */
 	using node_ptr_t = detail::persistent_pool_ptr<
@@ -322,20 +323,10 @@ struct hash_map_node {
 	/** Item stored in node */
 	value_type item;
 
-	hash_map_node() : next(OID_NULL)
-	{
-	}
-
-	hash_map_node(const node_ptr_t &_next) : next(_next)
-	{
-	}
-
-	hash_map_node(node_ptr_t &&_next) : next(std::move(_next))
-	{
-	}
-
 	hash_map_node(const node_ptr_t &_next, const Key &key)
-	    : next(_next), item(key, T())
+	    : next(_next),
+	      item(std::piecewise_construct, std::forward_as_tuple(key),
+		   std::forward_as_tuple())
 	{
 	}
 

--- a/include/libpmemobj++/detail/pair.hpp
+++ b/include/libpmemobj++/detail/pair.hpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef LIBPMEMOBJ_PAIR_HPP
+#define LIBPMEMOBJ_PAIR_HPP
+
+#include <utility>
+
+#include <libpmemobj++/detail/integer_sequence.hpp>
+
+namespace pmem
+{
+
+namespace detail
+{
+
+template <typename F, typename S>
+struct pair {
+	constexpr pair() : first(), second()
+	{
+	}
+
+	template <typename... Args1, typename... Args2>
+	constexpr pair(std::piecewise_construct_t pc,
+		       std::tuple<Args1...> first_args,
+		       std::tuple<Args2...> second_args)
+	    : pair(pc, first_args, second_args,
+		   typename make_index_sequence<Args1...>::type{},
+		   typename make_index_sequence<Args2...>::type{})
+	{
+	}
+
+	constexpr pair(const F &k, const S &v) : first(k), second(v)
+	{
+	}
+
+	template <typename K, typename V>
+	constexpr pair(K &&k, V &&v)
+	    : first(std::forward<K>(k)), second(std::forward<V>(v))
+	{
+	}
+
+	template <typename K, typename V>
+	constexpr pair(const std::pair<K, V> &p)
+	    : first(p.first), second(p.second)
+	{
+	}
+
+	template <typename K, typename V>
+	constexpr pair(std::pair<K, V> &&p)
+	    : first(std::forward<K>(p.first)), second(std::forward<V>(p.second))
+	{
+	}
+
+	F first;
+	S second;
+
+private:
+	template <typename... Args1, typename... Args2, size_t... I1,
+		  size_t... I2>
+	constexpr pair(std::piecewise_construct_t,
+		       std::tuple<Args1...> &first_args,
+		       std::tuple<Args2...> &second_args, index_sequence<I1...>,
+		       index_sequence<I2...>)
+	    : first(std::forward<Args1>(std::get<I1>(first_args))...),
+	      second(std::forward<Args2>(std::get<I2>(second_args))...)
+	{
+	}
+};
+
+} /* namespace detail */
+
+} /* namespace pmem */
+
+#endif /* LIBPMEMOBJ_PAIR_HPP */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,6 +152,9 @@ build_test(ptr ptr/ptr.cpp)
 add_test_generic(NAME ptr CASE 0 TRACERS none pmemcheck
 		SCRIPT cmake/common_0.cmake)
 
+build_test(pair pair/pair.cpp)
+add_test_generic(NAME pair TRACERS none memcheck)
+
 build_test(ptr_arith ptr_arith/ptr_arith.cpp)
 add_test_generic(NAME ptr_arith TRACERS memcheck pmemcheck)
 # XXX Bug: incompatibility between asan and custom library

--- a/tests/concurrent_hash_map_layout/concurrent_hash_map_layout.hpp
+++ b/tests/concurrent_hash_map_layout/concurrent_hash_map_layout.hpp
@@ -53,9 +53,9 @@ static constexpr std::size_t CACHELINE_SIZE = 64;
 /*
  * Test is implemented in inherited class to get access to protected variables.
  */
-template <typename MapType, std::size_t value_size>
+template <typename MapType, std::size_t ValueSize>
 struct hashmap_test : public MapType {
-	static constexpr std::size_t NODE_SIZE = 72 + value_size;
+	static constexpr std::size_t NODE_SIZE = 72 + ValueSize;
 
 	using persistent_map_type = MapType;
 	using hash_map_base = typename MapType::hash_map_base;
@@ -69,6 +69,7 @@ struct hashmap_test : public MapType {
 		ASSERT_ALIGNED_FIELD(T, t, layout_features);
 		ASSERT_ALIGNED_FIELD(T, t, my_mask_reserved);
 		ASSERT_ALIGNED_FIELD(T, t, my_mask);
+		ASSERT_ALIGNED_FIELD(T, t, value_size);
 		ASSERT_ALIGNED_FIELD(T, t, padding1);
 		ASSERT_OFFSET_CHECKPOINT(T, CACHELINE_SIZE);
 		ASSERT_ALIGNED_FIELD(T, t, my_table);

--- a/tests/concurrent_hash_map_singlethread/concurrent_hash_map_singlethread.cpp
+++ b/tests/concurrent_hash_map_singlethread/concurrent_hash_map_singlethread.cpp
@@ -177,13 +177,18 @@ typedef persistent_map_move_type::value_type value_move_type;
 typedef nvobj::concurrent_hash_map<nvobj::string, nvobj::p<int>, string_hasher>
 	persistent_map_hetero_type;
 
+typedef nvobj::concurrent_hash_map<nvobj::string, nvobj::string, string_hasher>
+	persistent_map_str_type;
+
 struct root {
 	nvobj::persistent_ptr<persistent_map_type> map1;
 	nvobj::persistent_ptr<persistent_map_type> map2;
 
 	nvobj::persistent_ptr<persistent_map_move_type> map_move;
-
 	nvobj::persistent_ptr<persistent_map_hetero_type> map_hetero;
+	nvobj::persistent_ptr<persistent_map_str_type> map_str;
+
+	nvobj::persistent_ptr<nvobj::string> tmp;
 };
 
 void
@@ -511,46 +516,82 @@ void
 hetero_test(nvobj::pool<root> &pop)
 {
 	auto &map = pop.root()->map_hetero;
+	auto &map_str = pop.root()->map_str;
 
 	tx_alloc_wrapper<persistent_map_hetero_type>(pop, map);
+	tx_alloc_wrapper<persistent_map_str_type>(pop, map_str);
+
+	pmem::obj::transaction::run(pop, [&] {
+		pop.root()->tmp =
+			pmem::obj::make_persistent<pmem::obj::string>("123");
+	});
 
 	map->runtime_initialize();
+	map_str->runtime_initialize();
 
 	for (long i = 0; i < 100; ++i) {
 		map->insert_or_assign(std::to_string(i), i);
+
+		map_str->insert_or_assign(std::to_string(i), std::to_string(i));
 	}
 
 	for (int i = 0; i < 100; ++i) {
 		UT_ASSERTeq(map->count(std::to_string(i)), 1);
+		UT_ASSERTeq(map_str->count(std::to_string(i)), 1);
 	}
 
 	for (int i = 0; i < 100; ++i) {
-		persistent_map_hetero_type::accessor accessor;
+		persistent_map_hetero_type::accessor accessor1;
 		auto val = std::to_string(i);
-		UT_ASSERT(map->find(accessor, val));
-		UT_ASSERT(val == accessor->first);
-		UT_ASSERT(i == accessor->second);
+		UT_ASSERT(map->find(accessor1, val));
+		UT_ASSERT(val == accessor1->first);
+		UT_ASSERT(i == accessor1->second);
+
+		persistent_map_str_type::accessor accessor2;
+		UT_ASSERT(map_str->find(accessor2, val));
+		UT_ASSERT(val == accessor2->first);
+		UT_ASSERT(std::to_string(i) == accessor2->second);
 	}
 
 	for (long i = 0; i < 100; ++i) {
 		map->insert_or_assign(std::to_string(i), i + 1);
+		map_str->insert_or_assign(std::to_string(i),
+					  std::to_string(i + 1));
 	}
 
 	for (int i = 0; i < 100; ++i) {
-		persistent_map_hetero_type::const_accessor accessor;
+		persistent_map_hetero_type::const_accessor accessor1;
 		auto val = std::to_string(i);
-		UT_ASSERT(map->find(accessor, val));
-		UT_ASSERT(val == accessor->first);
-		UT_ASSERT(i + 1 == accessor->second);
+		UT_ASSERT(map->find(accessor1, val));
+		UT_ASSERT(val == accessor1->first);
+		UT_ASSERT(i + 1 == accessor1->second);
+
+		persistent_map_str_type::const_accessor accessor2;
+		UT_ASSERT(map_str->find(accessor2, val));
+		UT_ASSERT(val == accessor2->first);
+		UT_ASSERT(std::to_string(i + 1) == accessor2->second);
 	}
 
 	for (int i = 0; i < 100; ++i) {
 		UT_ASSERT(map->erase(std::to_string(i)));
+		UT_ASSERT(map_str->erase(std::to_string(i)));
 	}
 
 	for (int i = 0; i < 100; ++i) {
 		UT_ASSERTeq(map->count(std::to_string(i)), 0);
+		UT_ASSERTeq(map_str->count(std::to_string(i)), 0);
 	}
+
+	{
+		persistent_map_str_type::const_accessor accessor;
+		map_str->insert(accessor, *(pop.root()->tmp));
+		UT_ASSERT(map_str->count(*(pop.root()->tmp)) == 1);
+	}
+
+	pmem::obj::transaction::run(pop, [&] {
+		pmem::obj::delete_persistent<pmem::obj::string>(
+			pop.root()->tmp);
+	});
 }
 
 /*

--- a/tests/pair/pair.cpp
+++ b/tests/pair/pair.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "unittest.hpp"
+
+#include <array>
+
+#include <libpmemobj++/detail/pair.hpp>
+#include <libpmemobj++/pool.hpp>
+
+static int copy_ctor_called = 0;
+static int move_ctor_called = 0;
+
+struct A {
+	A(int a = 0, int b = 0, int c = 0) : a(a), b(b), c(c)
+	{
+	}
+
+	A(const A &rhs)
+	{
+		copy_ctor_called++;
+
+		a = rhs.a;
+		b = rhs.b;
+		c = rhs.c;
+	}
+
+	A(A &&rhs)
+	{
+		move_ctor_called++;
+
+		a = rhs.a;
+		b = rhs.b;
+		c = rhs.c;
+	}
+
+	int a;
+	int b;
+	int c;
+};
+
+void
+verify_vals(pmem::detail::pair<A, A> &a, std::array<int, 6> expected)
+{
+	UT_ASSERTeq(a.first.a, expected[0]);
+	UT_ASSERTeq(a.first.b, expected[1]);
+	UT_ASSERTeq(a.first.c, expected[2]);
+	UT_ASSERTeq(a.second.a, expected[3]);
+	UT_ASSERTeq(a.second.b, expected[4]);
+	UT_ASSERTeq(a.second.c, expected[5]);
+}
+
+void
+construct_test()
+{
+	{
+		A a1(1, 2, 3), a2(4, 5, 6);
+		copy_ctor_called = 0;
+		move_ctor_called = 0;
+
+		pmem::detail::pair<A, A> p(a1, a2);
+		UT_ASSERTeq(copy_ctor_called, 2);
+		UT_ASSERTeq(move_ctor_called, 0);
+
+		verify_vals(p, {1, 2, 3, 4, 5, 6});
+	}
+
+	{
+		A a1(1, 2, 3), a2(4, 5, 6);
+		copy_ctor_called = 0;
+		move_ctor_called = 0;
+
+		pmem::detail::pair<A, A> p(std::move(a1), std::move(a2));
+		UT_ASSERTeq(copy_ctor_called, 0);
+		UT_ASSERTeq(move_ctor_called, 2);
+
+		verify_vals(p, {1, 2, 3, 4, 5, 6});
+	}
+
+	{
+		A a1(1, 2, 3), a2(4, 5, 6);
+		copy_ctor_called = 0;
+		move_ctor_called = 0;
+
+		pmem::detail::pair<A, A> p(std::piecewise_construct,
+					   std::forward_as_tuple(a1),
+					   std::forward_as_tuple(a2));
+		UT_ASSERTeq(copy_ctor_called, 2);
+		UT_ASSERTeq(move_ctor_called, 0);
+
+		verify_vals(p, {1, 2, 3, 4, 5, 6});
+	}
+
+	{
+		A a1(1, 2, 3), a2(4, 5, 6);
+		copy_ctor_called = 0;
+		move_ctor_called = 0;
+
+		pmem::detail::pair<A, A> p(
+			std::piecewise_construct,
+			std::forward_as_tuple(std::move(a1)),
+			std::forward_as_tuple(std::move(a2)));
+		UT_ASSERTeq(copy_ctor_called, 0);
+		UT_ASSERTeq(move_ctor_called, 2);
+
+		verify_vals(p, {1, 2, 3, 4, 5, 6});
+	}
+
+	{
+		A a1(1, 2, 3), a2(4, 5, 6);
+		copy_ctor_called = 0;
+		move_ctor_called = 0;
+
+		pmem::detail::pair<A, A> p(std::piecewise_construct,
+					   std::forward_as_tuple(1, 2),
+					   std::forward_as_tuple(3));
+		UT_ASSERTeq(copy_ctor_called, 0);
+		UT_ASSERTeq(move_ctor_called, 0);
+
+		verify_vals(p, {1, 2, 0, 3, 0, 0});
+	}
+}
+
+int
+main(int argc, char *argv[])
+{
+	START();
+
+	construct_test();
+
+	return 0;
+}


### PR DESCRIPTION
in runtime_initialize

It will protect user in case of accidentaly changing size of key
or value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/627)
<!-- Reviewable:end -->
