### PR TITLE
tests: fix transaction test

### DIFF
--- a/tests/transaction/transaction.cpp
+++ b/tests/transaction/transaction.cpp
@@ -1094,12 +1094,14 @@ test_tx_callback_scope(nvobj::pool<root> &pop, std::function<void()> commit)
 	cb_work_called = 0;
 
 	try {
+		counter = 0;
 		{
 			T to(pop);
 
 			tx_with_callbacks(cb_oncommit_called, cb_onabort_called,
 					  cb_finally_called, cb_work_called);
 
+			counter = 1;
 			nvobj::transaction::abort(0);
 
 			UT_ASSERT(0);


### PR DESCRIPTION
We did not set counter to a proper value which caused failure on
older std libs (for example in rhel-7.7)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/628)
<!-- Reviewable:end -->
