### PR TITLE
Disable false-postivie helgrind tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -464,10 +464,11 @@ if(TEST_CONCURRENT_HASHMAP)
 		add_test_generic(NAME concurrent_hash_map_insert_erase_mock CASE 1 TRACERS helgrind drd
 				SCRIPT concurrent_hash_map/check_is_pmem_defrag.cmake)
 
-		add_test_generic(NAME concurrent_hash_map_rehash_mock CASE 0 TRACERS helgrind
-				SCRIPT concurrent_hash_map/check_is_pmem.cmake)
-		add_test_generic(NAME concurrent_hash_map_rehash_mock CASE 1 TRACERS helgrind
-				SCRIPT concurrent_hash_map/check_is_pmem_defrag.cmake)
+		# disabled due to intermittent failures (most probably false-positive reported by helgrind, ref. issue #469)
+		# add_test_generic(NAME concurrent_hash_map_rehash_mock CASE 0 TRACERS helgrind
+		#		SCRIPT concurrent_hash_map/check_is_pmem.cmake)
+		# add_test_generic(NAME concurrent_hash_map_rehash_mock CASE 1 TRACERS helgrind
+		#		SCRIPT concurrent_hash_map/check_is_pmem_defrag.cmake)
 
 		if (TESTS_LONG)
 			add_test_generic(NAME concurrent_hash_map_insert_lookup_mock CASE 0 TRACERS helgrind drd


### PR DESCRIPTION
Disable the concurrent_hash_map_rehash_mock tests
due to intermittent failures (most probably false-positive
reported by helgrind).

Ref: 53c8568
Ref: #469

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/631)
<!-- Reviewable:end -->
