### PR TITLE
Run find_gdb() in tests/CMakeLists.txt

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ if(COVERAGE)
 endif()
 
 find_packages()
+find_gdb()
 
 add_library(test_backtrace STATIC test_backtrace.c)
 if(LIBUNWIND_FOUND)


### PR DESCRIPTION
It fixes regression introduced by bc3438a.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/632)
<!-- Reviewable:end -->
