### PR TITLE
fix: adjust UT_ASSERT to gcc 7.5.0 from openSUSE Leap

### DIFF
--- a/tests/concurrent_hash_map_tx/concurrent_hash_map_tx.cpp
+++ b/tests/concurrent_hash_map_tx/concurrent_hash_map_tx.cpp
@@ -356,7 +356,7 @@ test_tx_singlethread(nvobj::pool<root> &pop)
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTeq(map->size(), static_cast<size_t>(number_of_inserts));
+	UT_ASSERT(static_cast<int>(map->size()) == number_of_inserts);
 
 	pmem::obj::transaction::run(pop, [&] {
 		pmem::obj::delete_persistent<persistent_map_type>(map);


### PR DESCRIPTION
It fixes the following compilation error:
```
In file included from /libpmemobj-cpp/tests/concurrent_hash_map_tx/concurrent_hash_map_tx.cpp:38:0:
/libpmemobj-cpp/tests/concurrent_hash_map_tx/concurrent_hash_map_tx.cpp: In function 'void test_tx_singlethread(pmem::obj::pool<root>&)':
/libpmemobj-cpp/tests/concurrent_hash_map_tx/concurrent_hash_map_tx.cpp:359:27: error: conversion to 'pmem::obj::concurrent_hash_map<pmem::obj::p<int>, pmem::obj::p<int> >::size_type {aka long unsigned int}' from 'int' may change the sign of the result [-Werror=sign-conversion]
  UT_ASSERTeq(map->size(), static_cast<size_t>(number_of_inserts));
/libpmemobj-cpp/tests/common/unittest.hpp:151:21: note: in definition of macro 'UT_ASSERTeq'
  ((void)(((lhs) == (rhs)) ||                                            \
                     ^~~
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/645)
<!-- Reviewable:end -->
