### PR TITLE
Fix a typo in one comment

### DIFF
--- a/include/libpmemobj++/persistent_ptr.hpp
+++ b/include/libpmemobj++/persistent_ptr.hpp
@@ -65,7 +65,7 @@ class persistent_ptr;
  * persistent_ptr void specialization.
  *
  * It's truncated specialization to disallow some of the
- * (unnecessary) functionallities.
+ * (unnecessary) functionalities.
  */
 template <>
 class persistent_ptr<void> : public persistent_ptr_base {


### PR DESCRIPTION
Replace 'functionallities' with 'functionalities'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/653)
<!-- Reviewable:end -->
