### PR TITLE
Typo fix proxy address in Docker README

### DIFF
--- a/utils/docker/images/README.md
+++ b/utils/docker/images/README.md
@@ -11,7 +11,7 @@ In case of any problem, patches and github issues are welcome.
 # How to build docker image
 
 ```sh
-docker build --build-arg https_proxy=https://proxy.com:port --build-arg http_proxy=http://proxy.com:port -t libpmemobj-cpp:debian-unstable -f ./Dockerfile.debian-unstable .
+docker build --build-arg https_proxy=http://proxy.com:port --build-arg http_proxy=http://proxy.com:port -t libpmemobj-cpp:debian-unstable -f ./Dockerfile.debian-unstable .
 ```
 
 # How to use docker image


### PR DESCRIPTION
Problem:
Cloning Valgrind repository produces: gnutls_handshake() failed: The TLS connection was non-properly terminated.
https_proxy=https:// causes problems while you connect through proxy.

Changed to be consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/673)
<!-- Reviewable:end -->
