### PR TITLE
Exception handling for volatile state test

### DIFF
--- a/tests/volatile_state/volatile_state.cpp
+++ b/tests/volatile_state/volatile_state.cpp
@@ -61,7 +61,11 @@ struct pmem_obj {
 
 	~pmem_obj()
 	{
-		v_state::destroy(pmemobj_oid(this));
+		try {
+			v_state::destroy(pmemobj_oid(this));
+		} catch (const pmem::transaction_scope_error &e) {
+			UT_ASSERT(false);
+		}
 	}
 };
 


### PR DESCRIPTION
Add try-catch clause for PMEM related exception.

This PR fixes 1 Coverity issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/693)
<!-- Reviewable:end -->
