### PR TITLE
Avoid potential side effect in array_modifiers test

### DIFF
--- a/tests/array_modifiers/array_modifiers.cpp
+++ b/tests/array_modifiers/array_modifiers.cpp
@@ -246,7 +246,8 @@ test_snapshotting(pmem::obj::pool<struct root> &pop, bool do_abort)
 
 			std::cout << e.c_str() << " " << i << std::endl;
 
-			UT_ASSERT(e == std::to_string(i++));
+			UT_ASSERT(e == std::to_string(i));
+			++i;
 		}
 	}
 }


### PR DESCRIPTION
Move post-incrementation after assertion to avoid side effect

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/697)
<!-- Reviewable:end -->
