### PR TITLE
fix CMake issue

### DIFF
--- a/cmake/check_compiling_issues.cmake
+++ b/cmake/check_compiling_issues.cmake
@@ -37,7 +37,7 @@ if(NOT MSVC_VERSION)
 	# Even if we are ensuring that we use CMAKE_CXX_STANDARD >= 14, check if
 	# shared_mutex header file is available for the current compiler version
 	# because CXX_STANDARD is being set to 14 for --c++1y parameter
-	if(CXX_STANDARD GREATER_EQUAL 14)
+	if(CXX_STANDARD GREATER 11)
 		set(CMAKE_REQUIRED_FLAGS "--std=c++${CMAKE_CXX_STANDARD} -c")
 		CHECK_CXX_SOURCE_COMPILES(
 			"#include <shared_mutex>


### PR DESCRIPTION
cmake 3.3 (which we're using) doesn't have function GREATER_EQUAL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/698)
<!-- Reviewable:end -->
