### PR TITLE
Containers: handle exceptions in destructors

### DIFF
--- a/include/libpmemobj++/container/basic_string.hpp
+++ b/include/libpmemobj++/container/basic_string.hpp
@@ -149,6 +149,7 @@ public:
 	void reserve(size_type new_cap = 0);
 	void shrink_to_fit();
 	void clear();
+	void free_data();
 
 	/* Modifiers */
 	basic_string &erase(size_type index = 0, size_type count = npos);
@@ -673,14 +674,15 @@ basic_string<CharT, Traits>::basic_string(std::initializer_list<CharT> ilist)
 
 /**
  * Destructor.
- *
- * XXX: implement free_data()
  */
 template <typename CharT, typename Traits>
 basic_string<CharT, Traits>::~basic_string()
 {
-	if (!is_sso_used())
-		detail::destroy<non_sso_type>(non_sso_data());
+	try {
+		free_data();
+	} catch (...) {
+		std::terminate();
+	}
 }
 
 /**
@@ -3718,6 +3720,37 @@ void
 basic_string<CharT, Traits>::clear()
 {
 	erase(begin(), end());
+}
+
+/**
+ * Clears the content of a string and frees all allocated persistent memory for
+ * data transactionally.
+ *
+ * @post size() == 0
+ * @post capacity() == 0
+ * @post data() == nullptr
+ *
+ * @throw pmem::transaction_error when snapshotting failed.
+ * @throw pmem::transaction_free_error when freeing of underlying structure
+ * failed.
+ */
+template <typename CharT, typename Traits>
+void
+basic_string<CharT, Traits>::free_data()
+{
+	auto pop = get_pool();
+
+	transaction::run(pop, [&] {
+		if (is_sso_used()) {
+			add_sso_to_tx(0, get_sso_size() + 1);
+			clear();
+			/* sso.data destructor does not have to be called */
+		} else {
+			non_sso_data().free_data();
+			detail::destroy<non_sso_type>(non_sso_data());
+			enable_sso();
+		}
+	});
 }
 
 /**

--- a/include/libpmemobj++/container/concurrent_hash_map.hpp
+++ b/include/libpmemobj++/container/concurrent_hash_map.hpp
@@ -2272,7 +2272,7 @@ public:
 	 */
 	void clear();
 
-	/*
+	/**
 	 * Should be called before concurrent_hash_map destructor is called.
 	 * Otherwise, program can terminate if an exception occurs while freeing
 	 * memory inside dtor.
@@ -2296,11 +2296,20 @@ public:
 	}
 
 	/**
-	 * Clear table and destroy it.
+	 * free_data should be called before concurrent_hash_map
+	 * destructor is called. Otherwise, program can terminate if
+	 * an exception occurs while freeing memory inside dtor.
+	 *
+	 * Hash map can NOT be used after free_data() was called (unless it
+	 * was called in a transaction and that transaction aborted).
 	 */
 	~concurrent_hash_map()
 	{
-		free_data();
+		try {
+			free_data();
+		} catch (...) {
+			std::terminate();
+		}
 	}
 
 	//------------------------------------------------------------------------

--- a/include/libpmemobj++/container/segment_vector.hpp
+++ b/include/libpmemobj++/container/segment_vector.hpp
@@ -1256,19 +1256,19 @@ segment_vector<T, Policy>::assign(const std::vector<T> &other)
 
 /**
  * Destructor.
- * Note that free_data may throw an transaction_free_error when freeing
+ * Note that free_data may throw a transaction_free_error when freeing
  * underlying segments failed. It is recommended to call free_data
- * manually before object destruction.
- *
- * @throw rethrows destructor exception.
- * @throw pmem::transaction_error when snapshotting failed.
- * @throw pmem::transaction_free_error when freeing underlying segments
- * failed.
+ * manually before object destruction, otherwise application can
+ * be terminated on failure.
  */
 template <typename T, typename Policy>
 segment_vector<T, Policy>::~segment_vector()
 {
-	free_data();
+	try {
+		free_data();
+	} catch (...) {
+		std::terminate();
+	}
 }
 
 /**

--- a/include/libpmemobj++/container/vector.hpp
+++ b/include/libpmemobj++/container/vector.hpp
@@ -822,17 +822,19 @@ vector<T>::assign(const std::vector<T> &other)
 
 /**
  * Destructor.
- * Note that free_data may throw an transaction_free_error when freeing
- * underlying array failed. It is recommended to call free_data manually before
- * object destruction.
- *
- * @throw rethrows destructor exception.
- * @throw transaction_free_error when freeing underlying array failed.
+ * Note that free_data may throw a transaction_free_error
+ * when freeing underlying array failed. It is recommended
+ * to call free_data manually before object destruction,
+ * otherwise application can be terminated on failure.
  */
 template <typename T>
 vector<T>::~vector()
 {
-	free_data();
+	try {
+		free_data();
+	} catch (...) {
+		std::terminate();
+	}
 }
 
 /**

--- a/tests/string_modifiers/string_modifiers.cpp
+++ b/tests/string_modifiers/string_modifiers.cpp
@@ -5,6 +5,7 @@
 
 #include <libpmemobj++/container/string.hpp>
 #include <libpmemobj++/make_persistent.hpp>
+#include <libpmemobj.h>
 
 namespace nvobj = pmem::obj;
 
@@ -401,14 +402,34 @@ check_tx_abort(pmem::obj::pool<struct root> &pop, const char *str,
 		assert_tx_abort(pop, s, [&] { pmem::obj::swap(s, str); });
 		verify_string(s, expected);
 		verify_string(str, expected_str);
+
+		assert_tx_abort(pop, s, [&] {
+			s.free_data();
+			s = "BEEF";
+		});
+		verify_string(s, expected);
+
+		assert_tx_abort(pop, s, [&] {
+			s.free_data();
+			s = "BEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEF"
+			    "BEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEF";
+		});
+		verify_string(s, expected);
 	} catch (std::exception &e) {
 		UT_FATALexc(e);
 	}
 
 	nvobj::transaction::run(pop, [&] {
+		r->s->free_data();
+		r->s1->free_data();
+		r->str->free_data();
+		r->str2->free_data();
 		nvobj::delete_persistent<S>(r->s);
 		nvobj::delete_persistent<S>(r->s1);
+		nvobj::delete_persistent<S>(r->str);
+		nvobj::delete_persistent<S>(r->str2);
 	});
+	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
 }
 
 static void
@@ -441,7 +462,7 @@ test(int argc, char *argv[])
 		       "0123456789012345678901234567890123456789"
 		       "0123456789",
 		       true);
-
+	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
 	pop.close();
 }
 


### PR DESCRIPTION
Handle possible exceptions in destructor to avoid crash.

Since C++11 destructors are noexcept(true) by default.
Description is also incorrect, because we'll get terminate signal instead of catching any exception.
Application will crash with current implementation. Can we discuss this issue?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/701)
<!-- Reviewable:end -->
