### PR TITLE
tests: change sizeof(&tls->local()) to sizeof(tls->local())

### DIFF
--- a/tests/enumerable_thread_specific_access/enumerable_thread_specific_access.cpp
+++ b/tests/enumerable_thread_specific_access/enumerable_thread_specific_access.cpp
@@ -73,7 +73,7 @@ test(nvobj::pool<struct root> &pop)
 
 	std::thread t([&] {
 		tls->local() = 99;
-		pop.persist(&tls->local(), sizeof(&tls->local()));
+		pop.persist(&tls->local(), sizeof(tls->local()));
 
 		UT_ASSERT(tls->size() <= concurrency + 1);
 		UT_ASSERT(tls->local() == 99);
@@ -95,7 +95,7 @@ test_with_spin(nvobj::pool<struct root> &pop, size_t concurrency)
 
 	parallel_exec_with_sync(concurrency, [&](size_t thread_index) {
 		tls->local()++;
-		pop.persist(&tls->local(), sizeof(&tls->local()));
+		pop.persist(&tls->local(), sizeof(tls->local()));
 	});
 
 	/*
@@ -125,12 +125,12 @@ test_multiple_tls(nvobj::pool<struct root> &pop)
 
 	parallel_exec_with_sync(concurrency, [&](size_t thread_index) {
 		tls1->local() = thread_index;
-		pop.persist(&tls1->local(), sizeof(&tls1->local()));
+		pop.persist(&tls1->local(), sizeof(tls1->local()));
 	});
 
 	parallel_exec_with_sync(concurrency, [&](size_t thread_index) {
 		tls2->local() = thread_index;
-		pop.persist(&tls2->local(), sizeof(&tls2->local()));
+		pop.persist(&tls2->local(), sizeof(tls2->local()));
 	});
 
 	UT_ASSERT(tls1->size() == concurrency);
@@ -162,10 +162,10 @@ test_multiple_tls(nvobj::pool<struct root> &pop)
 
 	parallel_exec_with_sync(concurrency, [&](size_t thread_index) {
 		tls1->local() = thread_index;
-		pop.persist(&tls1->local(), sizeof(&tls1->local()));
+		pop.persist(&tls1->local(), sizeof(tls1->local()));
 
 		tls2->local() = thread_index;
-		pop.persist(&tls2->local(), sizeof(&tls2->local()));
+		pop.persist(&tls2->local(), sizeof(tls2->local()));
 	});
 
 	UT_ASSERT(tls1->size() == concurrency);

--- a/tests/enumerable_thread_specific_initialize/enumerable_thread_specific_initialize.cpp
+++ b/tests/enumerable_thread_specific_initialize/enumerable_thread_specific_initialize.cpp
@@ -102,7 +102,7 @@ check_with_tx_abort_and_delete(nvobj::pool<struct root> &pop,
 
 	parallel_exec_with_sync(concurrency, [&](size_t thread_index) {
 		tls->local()++;
-		pop.persist(&tls->local(), sizeof(&tls->local()));
+		pop.persist(&tls->local(), sizeof(tls->local()));
 	});
 
 	for (auto &e : *tls) {

--- a/tests/enumerable_thread_specific_iterators/enumerable_thread_specific_iterators.cpp
+++ b/tests/enumerable_thread_specific_iterators/enumerable_thread_specific_iterators.cpp
@@ -26,7 +26,7 @@ test(nvobj::pool<struct root> &pop)
 
 	parallel_exec(concurrency, [&](size_t thread_index) {
 		tls->local() = 99;
-		pop.persist(&tls->local(), sizeof(&tls->local()));
+		pop.persist(&tls->local(), sizeof(tls->local()));
 	});
 
 	UT_ASSERT(tls->size() <= concurrency);

--- a/tests/enumerable_thread_specific_size/enumerable_thread_specific_size.cpp
+++ b/tests/enumerable_thread_specific_size/enumerable_thread_specific_size.cpp
@@ -30,7 +30,7 @@ test(nvobj::pool<struct root> &pop, size_t batch_size)
 	for (size_t i = 0; i < num_batches; i++)
 		parallel_exec(batch_size, [&](size_t thread_index) {
 			tls->local();
-			pop.persist(&tls->local(), sizeof(&tls->local()));
+			pop.persist(&tls->local(), sizeof(tls->local()));
 		});
 
 	/* There was at most batch_size threads at any given time. */
@@ -52,7 +52,7 @@ test_with_spin(nvobj::pool<struct root> &pop, size_t batch_size)
 
 	parallel_exec_with_sync(batch_size, [&](size_t thread_index) {
 		tls->local() = thread_index;
-		pop.persist(&tls->local(), sizeof(&tls->local()));
+		pop.persist(&tls->local(), sizeof(tls->local()));
 	});
 
 	/*
@@ -78,7 +78,7 @@ test_clear_abort(nvobj::pool<struct root> &pop, size_t batch_size)
 
 	parallel_exec_with_sync(batch_size, [&](size_t thread_index) {
 		tls->local() = 2;
-		pop.persist(&tls->local(), sizeof(&tls->local()));
+		pop.persist(&tls->local(), sizeof(tls->local()));
 	});
 
 	/*


### PR DESCRIPTION
The idea is to persist tls->local() variable, not the pointer to
it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/710)
<!-- Reviewable:end -->
