### PR TITLE
contigous_iterator: make operator[] take signed integral instead

### DIFF
--- a/include/libpmemobj++/experimental/contiguous_iterator.hpp
+++ b/include/libpmemobj++/experimental/contiguous_iterator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019, Intel Corporation
+ * Copyright 2018-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -178,7 +178,7 @@ struct contiguous_iterator {
 	/**
 	 * Element access operator.
 	 */
-	Reference operator[](std::size_t n)
+	Reference operator[](std::ptrdiff_t n)
 	{
 		return ptr[n];
 	}
@@ -326,7 +326,7 @@ struct range_snapshotting_iterator
 	 *
 	 * Adds element to a transaction.
 	 */
-	reference operator[](std::size_t n)
+	reference operator[](std::ptrdiff_t n)
 	{
 		detail::conditional_add_to_tx(&this->ptr[n]);
 		return base_type::operator[](n);
@@ -465,7 +465,7 @@ struct basic_contiguous_iterator
 	 *
 	 * Adds range containing specified element to a transaction.
 	 */
-	reference operator[](std::size_t n)
+	reference operator[](std::ptrdiff_t n)
 	{
 		detail::conditional_add_to_tx(&this->ptr[n]);
 		return base_type::operator[](n);

--- a/include/libpmemobj++/experimental/slice.hpp
+++ b/include/libpmemobj++/experimental/slice.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Intel Corporation
+ * Copyright 2018-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -136,7 +136,8 @@ public:
 		if (idx >= size())
 			throw std::out_of_range("pmem::obj::slice");
 
-		return it_begin[idx];
+		return it_begin[static_cast<typename std::iterator_traits<
+			Iterator>::difference_type>(idx)];
 	}
 
 	/**
@@ -145,7 +146,8 @@ public:
 	 */
 	reference operator[](size_type idx)
 	{
-		return it_begin[idx];
+		return it_begin[static_cast<typename std::iterator_traits<
+			Iterator>::difference_type>(idx)];
 	}
 
 	size_type

--- a/tests/array_iterator/array_iterator.cpp
+++ b/tests/array_iterator/array_iterator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Intel Corporation
+ * Copyright 2018-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -66,7 +66,7 @@ struct Test1 {
 
 		swap(it, it2);
 
-		it2[c.size() - 1] = 10;
+		it2[static_cast<std::ptrdiff_t>(c.size() - 1)] = 10;
 		it[20] = 20;
 
 		UT_ASSERT(c[c.size() - 1] == 10);


### PR DESCRIPTION
of unsigned.

The reason is that Windows cannot decide for a call like this:

`it[0] = 10`

whether to use:
* `operator[](unsigned)` -- one conversion from signed to unsigned
* `operator T*()` and then build in `operator[](signed)` -- one conversion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/711)
<!-- Reviewable:end -->
