### PR TITLE
basic_string: optimize move ctor and assignment

### DIFF
--- a/include/libpmemobj++/container/basic_string.hpp
+++ b/include/libpmemobj++/container/basic_string.hpp
@@ -354,14 +354,13 @@ private:
 			pmem::detail::is_input_iterator<InputIt>::value>::type>
 	pointer assign_sso_data(InputIt first, InputIt last);
 	pointer assign_sso_data(size_type count, value_type ch);
-	pointer assign_sso_data(basic_string &&other);
+	pointer move_data(basic_string &&other);
 	template <
 		typename InputIt,
 		typename Enable = typename std::enable_if<
 			pmem::detail::is_input_iterator<InputIt>::value>::type>
 	pointer assign_large_data(InputIt first, InputIt last);
 	pointer assign_large_data(size_type count, value_type ch);
-	pointer assign_large_data(basic_string &&other);
 	pool_base get_pool() const;
 	void check_pmem() const;
 	void check_tx_stage_work() const;
@@ -643,11 +642,7 @@ basic_string<CharT, Traits>::basic_string(basic_string &&other)
 	check_pmem_tx();
 	sso._size = 0;
 
-	allocate(other.size());
-	initialize(std::move(other));
-
-	if (other.is_sso_used())
-		other.initialize(0U, value_type('\0'));
+	move_data(std::move(other));
 }
 
 /**
@@ -989,10 +984,8 @@ basic_string<CharT, Traits>::assign(basic_string &&other)
 	auto pop = get_pool();
 
 	transaction::run(pop, [&] {
-		replace_content(std::move(other));
-
-		if (other.is_sso_used())
-			other.initialize(0U, value_type('\0'));
+		destroy_data();
+		move_data(std::move(other));
 	});
 
 	return *this;
@@ -3802,7 +3795,6 @@ basic_string<CharT, Traits>::get_size(const basic_string &other) const
  * parameters. Allowed parameters are:
  * - size_type count, CharT value
  * - InputIt first, InputIt last
- * - basic_string &&
  */
 template <typename CharT, typename Traits>
 template <typename... Args>
@@ -3829,7 +3821,6 @@ basic_string<CharT, Traits>::replace_content(Args &&... args)
  * non_sso.data or sso.data. Allowed parameters are:
  * - size_type count, CharT value
  * - InputIt first, InputIt last
- * - basic_string &&
  *
  * @pre must be called in transaction scope.
  * @pre memory must be allocated before initialization.
@@ -3841,13 +3832,8 @@ basic_string<CharT, Traits>::initialize(Args &&... args)
 {
 	assert(pmemobj_tx_stage() == TX_STAGE_WORK);
 
-	auto size = get_size(std::forward<Args>(args)...);
-
 	if (is_sso_used()) {
-		auto ptr = assign_sso_data(std::forward<Args>(args)...);
-		set_sso_size(size);
-
-		return ptr;
+		return assign_sso_data(std::forward<Args>(args)...);
 	} else {
 		return assign_large_data(std::forward<Args>(args)...);
 	}
@@ -3904,6 +3890,8 @@ basic_string<CharT, Traits>::assign_sso_data(InputIt first, InputIt last)
 
 	sso_data()._data[size] = value_type('\0');
 
+	set_sso_size(size);
+
 	return &sso_data()[0];
 }
 
@@ -3922,19 +3910,9 @@ basic_string<CharT, Traits>::assign_sso_data(size_type count, value_type ch)
 
 	sso_data()._data[count] = value_type('\0');
 
+	set_sso_size(count);
+
 	return &sso_data()[0];
-}
-
-/**
- * Initialize sso data. Overload for rvalue reference of basic_string.
- */
-template <typename CharT, typename Traits>
-typename basic_string<CharT, Traits>::pointer
-basic_string<CharT, Traits>::assign_sso_data(basic_string &&other)
-{
-	assert(pmemobj_tx_stage() == TX_STAGE_WORK);
-
-	return assign_sso_data(other.cbegin(), other.cend());
 }
 
 /**
@@ -3975,21 +3953,36 @@ basic_string<CharT, Traits>::assign_large_data(size_type count, value_type ch)
 }
 
 /**
- * Initialize non_sso.data - call constructor of non_sso.data.
- * Overload for rvalue reference of basic_string.
+ * Move initialize for basic_string. Expects data is not
+ * initialized.
  */
 template <typename CharT, typename Traits>
 typename basic_string<CharT, Traits>::pointer
-basic_string<CharT, Traits>::assign_large_data(basic_string &&other)
+basic_string<CharT, Traits>::move_data(basic_string &&other)
 {
 	assert(pmemobj_tx_stage() == TX_STAGE_WORK);
 
+	typename basic_string::pointer ptr;
+
+	if (other.size() <= sso_capacity) {
+		enable_sso();
+		ptr = assign_sso_data(other.cbegin(), other.cend());
+	} else {
+		disable_sso();
+		detail::conditional_add_to_tx(&non_sso_data(), 1,
+					      POBJ_XADD_NO_SNAPSHOT);
+		detail::create<non_sso_type>(&non_sso_data());
+
+		assert(!other.is_sso_used());
+		non_sso_data() = std::move(other.non_sso_data());
+
+		ptr = non_sso_data().data();
+	}
+
 	if (other.is_sso_used())
-		return assign_large_data(other.cbegin(), other.cend());
+		other.initialize(0U, value_type('\0'));
 
-	non_sso_data() = std::move(other.non_sso_data());
-
-	return non_sso_data().data();
+	return ptr;
 }
 
 /**


### PR DESCRIPTION
Until now, move ctor and assignemnt made unnecessary copies when
non_sso was used. Fix that by just moving non_sso_data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/715)
<!-- Reviewable:end -->
