### PR TITLE
Example: Missing exception handling in Panaconda

### DIFF
--- a/examples/panaconda/panaconda.cpp
+++ b/examples/panaconda/panaconda.cpp
@@ -217,6 +217,9 @@ board_element::~board_element()
 	} catch (const pmem::transaction_scope_error &e) {
 		std::cerr << "Exception: " << e.what() << std::endl;
 		std::terminate();
+	} catch (const pmem::transaction_error &e) {
+		std::cerr << "Exception: " << e.what() << std::endl;
+		std::terminate();
 	}
 }
 


### PR DESCRIPTION
Add missing catch clause to handle transaction_error

Fix related with Coverity issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/716)
<!-- Reviewable:end -->
