### PR TITLE
concurrent_hash_map: fix free_data()

### DIFF
--- a/examples/doc_snippets/make_persistent.cpp
+++ b/examples/doc_snippets/make_persistent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, Intel Corporation
+ * Copyright 2016-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,6 +81,10 @@ make_persistent_example()
 
 		// transactionally delete the object, ~compound_type() is called
 		delete_persistent<compound_type>(proot->comp);
+
+		// set pointer to null so that after restart it's known whether
+		// compound_type is still allocated or not
+		proot->comp = nullptr;
 	});
 
 	// throws an transaction_scope_error exception
@@ -139,6 +143,10 @@ make_persistent_array_example()
 		// transactionally delete arrays , ~compound_type() is called
 		delete_persistent<compound_type[]>(proot->comp, 20);
 		delete_persistent<compound_type[3]>(arr1);
+
+		// set pointer to null so that after restart it's known whether
+		// compound_type is still allocated or not
+		proot->comp = nullptr;
 	});
 
 	// throws an transaction_scope_error exception

--- a/include/libpmemobj++/container/concurrent_hash_map.hpp
+++ b/include/libpmemobj++/container/concurrent_hash_map.hpp
@@ -2316,6 +2316,9 @@ public:
 	void
 	free_data()
 	{
+		if (!this->tls_ptr)
+			return;
+
 		auto pop = get_pool_base();
 
 		transaction::run(pop, [&] {

--- a/include/libpmemobj++/make_persistent.hpp
+++ b/include/libpmemobj++/make_persistent.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019, Intel Corporation
+ * Copyright 2016-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -132,6 +132,9 @@ make_persistent(Args &&... args)
  * This function can be used to *transactionally* free an object. Calls the
  * object's destructor before freeing memory. Cannot be used for array
  * types.
+ *
+ * To ensure that proper recovery is possible, ptr should be set to null after
+ * delete_persistent call and within the same transaction.
  *
  * @param[in,out] ptr persistent pointer to an object that is not an
  * array.

--- a/include/libpmemobj++/make_persistent_array.hpp
+++ b/include/libpmemobj++/make_persistent_array.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019, Intel Corporation
+ * Copyright 2016-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -194,6 +194,9 @@ make_persistent(allocation_flag flag = allocation_flag::none())
  * objects. Calls the objects' destructors before freeing memory.
  * This overload only participates in overload resolution if T is an array.
  *
+ * To ensure that proper recovery is possible, ptr should be set to null after
+ * delete_persistent call and within the same transaction.
+ *
  * @param[in,out] ptr persistent pointer to an array of objects.
  * @param[in] N the size of the array.
  *
@@ -237,6 +240,9 @@ delete_persistent(typename detail::pp_if_array<T>::type ptr, std::size_t N)
  * This function can be used to *transactionally* free an array of
  * objects. Calls the objects' destructors before freeing memory.
  * This overload only participates in overload resolution if T is an array.
+ *
+ * To ensure that proper recovery is possible, ptr should be set to null after
+ * delete_persistent call and within the same transaction.
  *
  * @param[in,out] ptr persistent pointer to an array of objects.
  *

--- a/tests/concurrent_hash_map_tx/concurrent_hash_map_tx.cpp
+++ b/tests/concurrent_hash_map_tx/concurrent_hash_map_tx.cpp
@@ -358,8 +358,28 @@ test_tx_singlethread(nvobj::pool<root> &pop)
 
 	UT_ASSERT(static_cast<int>(map->size()) == number_of_inserts);
 
+	try {
+		pmem::obj::transaction::run(pop, [&] {
+			map->free_data();
+			pmem::obj::transaction::abort(0);
+		});
+	} catch (pmem::manual_tx_abort &) {
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+
+	verify_elements(pop, number_of_inserts);
+
+	try {
+		pmem::obj::transaction::run(pop, [&] {
+			map->free_data();
+			pmem::obj::delete_persistent<persistent_map_type>(map);
+		});
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+
 	pmem::obj::transaction::run(pop, [&] {
-		pmem::obj::delete_persistent<persistent_map_type>(map);
 		pmem::obj::delete_persistent<persistent_map_type>(map2);
 	});
 }


### PR DESCRIPTION
If free_data() was called twice this led to assertion failure and
possible double free.

This patch skips freeing data when tls_ptr is already nullptr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/719)
<!-- Reviewable:end -->
