### PR TITLE
use old vcpkg for pmdk build to work properly

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -84,6 +84,12 @@ jobs:
        - name: Clone the git repo
          uses: actions/checkout@v1
 
+       - name: Use old vcpkg for pmdk to build properly
+         working-directory: C:/vcpkg
+         run: |
+            git fetch --unshallow --tags
+            git checkout 6709d3d7d0cba96508ba3606f810ab562ea32556
+
        - name: Install PMDK
          run: |
             vcpkg install pmdk:x64-windows


### PR DESCRIPTION
It's a workaround, until vcpkg issue is fixed:
https://github.com/microsoft/vcpkg/issues/11096

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/736)
<!-- Reviewable:end -->
