### PR TITLE
Add libcxx tests for map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,12 +64,14 @@ option(TEST_SEGMENT_VECTOR_ARRAY_EXPSIZE "enable testing of pmem::obj::segment_v
 option(TEST_SEGMENT_VECTOR_VECTOR_EXPSIZE "enable testing of pmem::obj::segment_vector with vector as segment_vector_type and exponential_size_policy" ON)
 option(TEST_SEGMENT_VECTOR_VECTOR_FIXEDSIZE "enable testing of pmem::obj::segment_vector with vector as segment_vector_type and fixed_size_policy" ON)
 option(TEST_ENUMERABLE_THREAD_SPECIFIC "enable testing of pmem::obj::experimental::enumerable_thread_specific" ON)
+option(TEST_CONCURRENT_MAP "enable testing of pmem::obj::concurrent_map (depends on TEST_STRING)" ON)
 
 option(INSTALL_ARRAY "enable installation of pmem::obj::array" ON)
 option(INSTALL_VECTOR "enable installation of pmem::obj::vector" ON)
 option(INSTALL_STRING "enable installation of pmem::obj::string (depends on INSTALL_VECTOR)" ON)
 option(INSTALL_CONCURRENT_HASHMAP "enable installation of pmem::obj::concurrent_hash_map (depends on INSTALL_STRING and INSTALL_SEGMENT_VECTOR)" ON)
 option(INSTALL_SEGMENT_VECTOR "enable installation of pmem::obj::segment_vector" ON)
+option(INSTALL_CONCURRENT_MAP "enable installation of pmem::obj::experimental::concurrent_map (depends on INSTALL_STRING)" ON)
 
 # Do not treat include directories from the interfaces
 # of consumed Imported Targets as SYSTEM by default.

--- a/tests/external/CMakeLists.txt
+++ b/tests/external/CMakeLists.txt
@@ -1032,3 +1032,146 @@ if(TEST_SEGMENT_VECTOR_VECTOR_FIXEDSIZE)
 	build_test_ext(NAME segment_vector_vector_fixedsize_libcxx_types SRC_FILES libcxx/vector/types.pass.cpp BUILD_OPTIONS -DSEGMENT_VECTOR_VECTOR_FIXEDSIZE)
 	add_test_generic(NAME segment_vector_vector_fixedsize_libcxx_types TRACERS none)
 endif()
+
+if (TEST_CONCURRENT_MAP)
+	# build_test(map_contains libcxx/map/contains.pass.cpp)
+	# add_test_generic(NAME map_contains TRACERS none pmemcheck memcheck)
+
+	# build_test(map_types libcxx/map/types.pass.cpp)
+	# add_test_generic(NAME map_types TRACERS none pmemcheck memcheck)
+
+	# build_test(map_empty libcxx/map/map.access/empty.pass.cpp)
+	# add_test_generic(NAME map_empty TRACERS none pmemcheck memcheck)
+
+	# build_test(map_iterator libcxx/map/map.access/iterator.pass.cpp)
+	# add_test_generic(NAME map_iterator TRACERS none pmemcheck memcheck)
+
+	# build_test(map_max_size libcxx/map/map.access/max_size.pass.cpp)
+	# add_test_generic(NAME map_max_size TRACERS none pmemcheck memcheck)
+
+	# build_test(map_size libcxx/map/map.access/size.pass.cpp)
+	# add_test_generic(NAME map_size TRACERS none pmemcheck memcheck)
+
+	# build_test(map_alloc libcxx/map/map.cons/alloc.pass.cpp)
+	# add_test_generic(NAME map_alloc TRACERS none pmemcheck memcheck)
+
+	# build_test(map_assign_initializer_list libcxx/map/map.cons/assign_initializer_list.pass.cpp)
+	# add_test_generic(NAME map_assign_initializer_list TRACERS none pmemcheck memcheck)
+
+	# build_test(map_compare_alloc libcxx/map/map.cons/compare_alloc.pass.cpp)
+	# add_test_generic(NAME map_compare_alloc TRACERS none pmemcheck memcheck)
+
+	# build_test(map_compare libcxx/map/map.cons/compare.pass.cpp)
+	# add_test_generic(NAME map_compare TRACERS none pmemcheck memcheck)
+
+	# build_test(map_copy_alloc libcxx/map/map.cons/copy_alloc.pass.cpp)
+	# add_test_generic(NAME map_copy_alloc TRACERS none pmemcheck memcheck)
+
+	# build_test(map_copy_assign libcxx/map/map.cons/copy_assign.pass.cpp)
+	# add_test_generic(NAME map_copy_assign TRACERS none pmemcheck memcheck)
+
+	# build_test(map_copy libcxx/map/map.cons/copy.pass.cpp)
+	# add_test_generic(NAME map_copy TRACERS none pmemcheck memcheck)
+
+	# build_test(map_default libcxx/map/map.cons/default.pass.cpp)
+	# add_test_generic(NAME map_default TRACERS none pmemcheck memcheck)
+
+	# build_test(map_default_recursive libcxx/map/map.cons/default_recursive.pass.cpp)
+	# add_test_generic(NAME map_default_recursive TRACERS none pmemcheck memcheck)
+
+	# build_test(map_dtor_noexcept libcxx/map/map.cons/dtor_noexcept.pass.cpp)
+	# add_test_generic(NAME map_dtor_noexcept TRACERS none pmemcheck memcheck)
+
+	# build_test(map_initializer_list_compare_alloc libcxx/map/map.cons/initializer_list_compare_alloc.pass.cpp)
+	# add_test_generic(NAME map_initializer_list_compare_alloc TRACERS none pmemcheck memcheck)
+
+	# build_test(map_initializer_list_compare libcxx/map/map.cons/initializer_list_compare.pass.cpp)
+	# add_test_generic(NAME map_initializer_list_compare TRACERS none pmemcheck memcheck)
+
+	# build_test(map_initializer_list libcxx/map/map.cons/initializer_list.pass.cpp)
+	# add_test_generic(NAME map_initializer_list TRACERS none pmemcheck memcheck)
+
+	# build_test(map_iter_iter_comp_alloc libcxx/map/map.cons/iter_iter_comp_alloc.pass.cpp)
+	# add_test_generic(NAME map_iter_iter_comp_alloc TRACERS none pmemcheck memcheck)
+
+	# build_test(map_iter_iter libcxx/map/map.cons/iter_iter.pass.cpp)
+	# add_test_generic(NAME map_iter_iter TRACERS none pmemcheck memcheck)
+
+	# build_test(map_move_alloc libcxx/map/map.cons/move_alloc.pass.cpp)
+	# add_test_generic(NAME map_move_alloc TRACERS none pmemcheck memcheck)
+
+	# build_test(map_move_assign libcxx/map/map.cons/move_assign.pass.cpp)
+	# add_test_generic(NAME map_move_assign TRACERS none pmemcheck memcheck)
+
+	# build_test(map_move libcxx/map/map.cons/move.pass.cpp)
+	# add_test_generic(NAME map_move TRACERS none pmemcheck memcheck)
+
+	# build_test(map_clear libcxx/map/map.modifiers/clear.pass.cpp)
+	# add_test_generic(NAME map_clear TRACERS none pmemcheck memcheck)
+
+	# build_test(map_emplace libcxx/map/map.modifiers/emplace.pass.cpp)
+	# add_test_generic(NAME map_emplace TRACERS none pmemcheck memcheck)
+
+	# build_test(map_erase_iter_iter libcxx/map/map.modifiers/erase_iter_iter.pass.cpp)
+	# add_test_generic(NAME map_erase_iter_iter TRACERS none pmemcheck memcheck)
+
+	# build_test(map_erase_key libcxx/map/map.modifiers/erase_key.pass.cpp)
+	# add_test_generic(NAME map_erase_key TRACERS none pmemcheck memcheck)
+
+	# build_test(map_insert_cv libcxx/map/map.modifiers/insert_cv.pass.cpp)
+	# add_test_generic(NAME map_insert_cv TRACERS none pmemcheck memcheck)
+
+	# build_test(map_insert_initializer_list libcxx/map/map.modifiers/insert_initializer_list.pass.cpp)
+	# add_test_generic(NAME map_insert_initializer_list TRACERS none pmemcheck memcheck)
+
+	# build_test(maps_insert_iter_iter libcxx/map/map.modifiers/insert_iter_iter.pass.cpp)
+	# add_test_generic(NAME maps_insert_iter_iter TRACERS none pmemcheck memcheck)
+
+	# build_test(map_insert_rv libcxx/map/map.modifiers/insert_rv.pass.cpp)
+	# add_test_generic(NAME map_insert_rv TRACERS none pmemcheck memcheck)
+
+	# build_test(map_try_emplace libcxx/map/map.modifiers/try.emplace.pass.cpp)
+	# add_test_generic(NAME map_try_emplace TRACERS none pmemcheck memcheck)
+
+	# build_test(map_count libcxx/map/map.ops/count.pass.cpp)
+	# add_test_generic(NAME map_count TRACERS none pmemcheck memcheck)
+
+	# build_test(map_count0 libcxx/map/map.ops/count0.pass.cpp)
+	# add_test_generic(NAME map_count0 TRACERS none pmemcheck memcheck)
+
+	# build_test(map_count_transparent libcxx/map/map.ops/count_transparent.pass.cpp)
+	# add_test_generic(NAME map_count_transparent TRACERS none pmemcheck memcheck)
+
+	# build_test(map_equal_range libcxx/map/map.ops/equal_range.pass.cpp)
+	# add_test_generic(NAME map_equal_range TRACERS none pmemcheck memcheck)
+
+	# build_test(map_equal_range0 libcxx/map/map.ops/equal_range0.pass.cpp)
+	# add_test_generic(NAME map_equal_range0 TRACERS none pmemcheck memcheck)
+
+	# build_test(map_equal_range_transparent libcxx/map/map.ops/equal_range_transparent.pass.cpp)
+	# add_test_generic(NAME map_equal_range_transparent TRACERS none pmemcheck memcheck)
+
+	# build_test(map_find libcxx/map/map.ops/find.pass.cpp)
+	# add_test_generic(NAME map_find TRACERS none pmemcheck memcheck)
+
+	# build_test(map_find0 libcxx/map/map.ops/find0.pass.cpp)
+	# add_test_generic(NAME map_find0 TRACERS none pmemcheck memcheck)
+
+	# build_test(map_lower_bound libcxx/map/map.ops/lower_bound.pass.cpp)
+	# add_test_generic(NAME map_lower_bound TRACERS none pmemcheck memcheck)
+
+	# build_test(map_lower_bound0 libcxx/map/map.ops/lower_bound0.pass.cpp)
+	# add_test_generic(NAME map_lower_bound0 TRACERS none pmemcheck memcheck)
+
+	# build_test(map_upper_bound libcxx/map/map.ops/upper_bound.pass.cpp)
+	# add_test_generic(NAME map_upper_bound TRACERS none pmemcheck memcheck)
+
+	# build_test(map_upper_bound0 libcxx/map/map.ops/upper_bound0.pass.cpp)
+	# add_test_generic(NAME map_upper_bound0 TRACERS none pmemcheck memcheck)
+
+	# build_test(map_member_swap libcxx/map/map.special/member_swap.pass.cpp)
+	# add_test_generic(NAME map_member_swap TRACERS none pmemcheck memcheck)
+
+	# build_test(map_non_member_swap libcxx/map/map.special/non_member_swap.pass.cpp)
+	# add_test_generic(NAME map_non_member_swap TRACERS none pmemcheck memcheck)
+endif()

--- a/tests/external/libcxx/map/contains.pass.cpp
+++ b/tests/external/libcxx/map/contains.pass.cpp
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03, c++11, c++14, c++17
+
+#include <cassert>
+#include <map>
+
+// <map>
+
+// bool contains(const key_type& x) const;
+
+template <typename T, typename P, typename B, typename... Pairs>
+void test(B bad, Pairs... args) {
+    T map;
+    P pairs[] = {args...};
+
+    for (auto& p : pairs) map.insert(p);
+    for (auto& p : pairs) assert(map.contains(p.first));
+
+    assert(!map.contains(bad));
+}
+
+struct E { int a = 1; double b = 1; char c = 1; };
+
+int main(int, char**)
+{
+    {
+        test<std::map<char, int>, std::pair<char, int> >(
+            'e', std::make_pair('a', 10), std::make_pair('b', 11),
+            std::make_pair('c', 12), std::make_pair('d', 13));
+
+        test<std::map<char, char>, std::pair<char, char> >(
+            'e', std::make_pair('a', 'a'), std::make_pair('b', 'a'),
+            std::make_pair('c', 'a'), std::make_pair('d', 'b'));
+
+        test<std::map<int, E>, std::pair<int, E> >(
+            -1, std::make_pair(1, E{}), std::make_pair(2, E{}),
+            std::make_pair(3, E{}), std::make_pair(4, E{}));
+    }
+    {
+        test<std::multimap<char, int>, std::pair<char, int> >(
+            'e', std::make_pair('a', 10), std::make_pair('b', 11),
+            std::make_pair('c', 12), std::make_pair('d', 13));
+
+        test<std::multimap<char, char>, std::pair<char, char> >(
+            'e', std::make_pair('a', 'a'), std::make_pair('b', 'a'),
+            std::make_pair('c', 'a'), std::make_pair('d', 'b'));
+
+        test<std::multimap<int, E>, std::pair<int, E> >(
+            -1, std::make_pair(1, E{}), std::make_pair(2, E{}),
+            std::make_pair(3, E{}), std::make_pair(4, E{}));
+    }
+
+    return 0;
+}

--- a/tests/external/libcxx/map/map.access/empty.pass.cpp
+++ b/tests/external/libcxx/map/map.access/empty.pass.cpp
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// bool empty() const;
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::map<int, double> M;
+    M m;
+    assert(m.empty());
+    m.insert(M::value_type(1, 1.5));
+    assert(!m.empty());
+    m.clear();
+    assert(m.empty());
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef std::map<int, double, std::less<int>, min_allocator<std::pair<const int, double>>> M;
+    M m;
+    assert(m.empty());
+    m.insert(M::value_type(1, 1.5));
+    assert(!m.empty());
+    m.clear();
+    assert(m.empty());
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.access/iterator.pass.cpp
+++ b/tests/external/libcxx/map/map.access/iterator.pass.cpp
@@ -1,0 +1,230 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+//       iterator begin();
+// const_iterator begin() const;
+//       iterator end();
+// const_iterator end()   const;
+//
+//       reverse_iterator rbegin();
+// const_reverse_iterator rbegin() const;
+//       reverse_iterator rend();
+// const_reverse_iterator rend()   const;
+//
+// const_iterator         cbegin()  const;
+// const_iterator         cend()    const;
+// const_reverse_iterator crbegin() const;
+// const_reverse_iterator crend()   const;
+
+#include <map>
+#include <cassert>
+#include <cstddef>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+        typedef std::pair<const int, double> V;
+        V ar[] =
+        {
+            V(1, 1),
+            V(1, 1.5),
+            V(1, 2),
+            V(2, 1),
+            V(2, 1.5),
+            V(2, 2),
+            V(3, 1),
+            V(3, 1.5),
+            V(3, 2),
+            V(4, 1),
+            V(4, 1.5),
+            V(4, 2),
+            V(5, 1),
+            V(5, 1.5),
+            V(5, 2),
+            V(6, 1),
+            V(6, 1.5),
+            V(6, 2),
+            V(7, 1),
+            V(7, 1.5),
+            V(7, 2),
+            V(8, 1),
+            V(8, 1.5),
+            V(8, 2)
+        };
+        std::map<int, double> m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        assert(static_cast<std::size_t>(std::distance(m.begin(), m.end())) == m.size());
+        assert(static_cast<std::size_t>(std::distance(m.rbegin(), m.rend())) == m.size());
+        std::map<int, double>::iterator i;
+        i = m.begin();
+        std::map<int, double>::const_iterator k = i;
+        assert(i == k);
+        for (int j = 1; static_cast<std::size_t>(j) <= m.size(); ++j, ++i)
+        {
+            assert(i->first == j);
+            assert(i->second == 1);
+            i->second = 2.5;
+            assert(i->second == 2.5);
+        }
+    }
+    {
+        typedef std::pair<const int, double> V;
+        V ar[] =
+        {
+            V(1, 1),
+            V(1, 1.5),
+            V(1, 2),
+            V(2, 1),
+            V(2, 1.5),
+            V(2, 2),
+            V(3, 1),
+            V(3, 1.5),
+            V(3, 2),
+            V(4, 1),
+            V(4, 1.5),
+            V(4, 2),
+            V(5, 1),
+            V(5, 1.5),
+            V(5, 2),
+            V(6, 1),
+            V(6, 1.5),
+            V(6, 2),
+            V(7, 1),
+            V(7, 1.5),
+            V(7, 2),
+            V(8, 1),
+            V(8, 1.5),
+            V(8, 2)
+        };
+        const std::map<int, double> m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        assert(static_cast<std::size_t>(std::distance(m.begin(), m.end())) == m.size());
+        assert(static_cast<std::size_t>(std::distance(m.cbegin(), m.cend())) == m.size());
+        assert(static_cast<std::size_t>(std::distance(m.rbegin(), m.rend())) == m.size());
+        assert(static_cast<std::size_t>(std::distance(m.crbegin(), m.crend())) == m.size());
+        std::map<int, double>::const_iterator i;
+        i = m.begin();
+        for (int j = 1; static_cast<std::size_t>(j) <= m.size(); ++j, ++i)
+        {
+            assert(i->first == j);
+            assert(i->second == 1);
+        }
+    }
+#if TEST_STD_VER >= 11
+    {
+        typedef std::pair<const int, double> V;
+        V ar[] =
+        {
+            V(1, 1),
+            V(1, 1.5),
+            V(1, 2),
+            V(2, 1),
+            V(2, 1.5),
+            V(2, 2),
+            V(3, 1),
+            V(3, 1.5),
+            V(3, 2),
+            V(4, 1),
+            V(4, 1.5),
+            V(4, 2),
+            V(5, 1),
+            V(5, 1.5),
+            V(5, 2),
+            V(6, 1),
+            V(6, 1.5),
+            V(6, 2),
+            V(7, 1),
+            V(7, 1.5),
+            V(7, 2),
+            V(8, 1),
+            V(8, 1.5),
+            V(8, 2)
+        };
+        std::map<int, double, std::less<int>, min_allocator<V>> m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        assert(static_cast<std::size_t>(std::distance(m.begin(), m.end())) == m.size());
+        assert(static_cast<std::size_t>(std::distance(m.rbegin(), m.rend())) == m.size());
+        std::map<int, double, std::less<int>, min_allocator<V>>::iterator i;
+        i = m.begin();
+        std::map<int, double, std::less<int>, min_allocator<V>>::const_iterator k = i;
+        assert(i == k);
+        for (int j = 1; static_cast<std::size_t>(j) <= m.size(); ++j, ++i)
+        {
+            assert(i->first == j);
+            assert(i->second == 1);
+            i->second = 2.5;
+            assert(i->second == 2.5);
+        }
+    }
+    {
+        typedef std::pair<const int, double> V;
+        V ar[] =
+        {
+            V(1, 1),
+            V(1, 1.5),
+            V(1, 2),
+            V(2, 1),
+            V(2, 1.5),
+            V(2, 2),
+            V(3, 1),
+            V(3, 1.5),
+            V(3, 2),
+            V(4, 1),
+            V(4, 1.5),
+            V(4, 2),
+            V(5, 1),
+            V(5, 1.5),
+            V(5, 2),
+            V(6, 1),
+            V(6, 1.5),
+            V(6, 2),
+            V(7, 1),
+            V(7, 1.5),
+            V(7, 2),
+            V(8, 1),
+            V(8, 1.5),
+            V(8, 2)
+        };
+        const std::map<int, double, std::less<int>, min_allocator<V>> m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        assert(static_cast<std::size_t>(std::distance(m.begin(), m.end())) == m.size());
+        assert(static_cast<std::size_t>(std::distance(m.cbegin(), m.cend())) == m.size());
+        assert(static_cast<std::size_t>(std::distance(m.rbegin(), m.rend())) == m.size());
+        assert(static_cast<std::size_t>(std::distance(m.crbegin(), m.crend())) == m.size());
+        std::map<int, double, std::less<int>, min_allocator<V>>::const_iterator i;
+        i = m.begin();
+        for (int j = 1; static_cast<std::size_t>(j) <= m.size(); ++j, ++i)
+        {
+            assert(i->first == j);
+            assert(i->second == 1);
+        }
+    }
+#endif
+#if TEST_STD_VER > 11
+    { // N3644 testing
+        typedef std::map<int, double> C;
+        C::iterator ii1{}, ii2{};
+        C::iterator ii4 = ii1;
+        C::const_iterator cii{};
+        assert ( ii1 == ii2 );
+        assert ( ii1 == ii4 );
+
+        assert (!(ii1 != ii2 ));
+
+        assert ( (ii1 == cii ));
+        assert ( (cii == ii1 ));
+        assert (!(ii1 != cii ));
+        assert (!(cii != ii1 ));
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.access/max_size.pass.cpp
+++ b/tests/external/libcxx/map/map.access/max_size.pass.cpp
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// size_type max_size() const;
+
+#include <cassert>
+#include <limits>
+#include <map>
+#include <type_traits>
+
+#include "test_allocator.h"
+#include "test_macros.h"
+
+int main(int, char**)
+{
+  typedef std::pair<const int, int> KV;
+  {
+    typedef limited_allocator<KV, 10> A;
+    typedef std::map<int, int, std::less<int>, A> C;
+    C c;
+    assert(c.max_size() <= 10);
+    LIBCPP_ASSERT(c.max_size() == 10);
+  }
+  {
+    typedef limited_allocator<KV, (size_t)-1> A;
+    typedef std::map<int, int, std::less<int>, A> C;
+    const C::size_type max_dist =
+        static_cast<C::size_type>(std::numeric_limits<C::difference_type>::max());
+    C c;
+    assert(c.max_size() <= max_dist);
+    LIBCPP_ASSERT(c.max_size() == max_dist);
+  }
+  {
+    typedef std::map<char, int> C;
+    const C::size_type max_dist =
+        static_cast<C::size_type>(std::numeric_limits<C::difference_type>::max());
+    C c;
+    assert(c.max_size() <= max_dist);
+    assert(c.max_size() <= alloc_max_size(c.get_allocator()));
+  }
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.access/size.pass.cpp
+++ b/tests/external/libcxx/map/map.access/size.pass.cpp
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// size_type size() const;
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::map<int, double> M;
+    M m;
+    assert(m.size() == 0);
+    m.insert(M::value_type(2, 1.5));
+    assert(m.size() == 1);
+    m.insert(M::value_type(1, 1.5));
+    assert(m.size() == 2);
+    m.insert(M::value_type(3, 1.5));
+    assert(m.size() == 3);
+    m.erase(m.begin());
+    assert(m.size() == 2);
+    m.erase(m.begin());
+    assert(m.size() == 1);
+    m.erase(m.begin());
+    assert(m.size() == 0);
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef std::map<int, double, std::less<int>, min_allocator<std::pair<const int, double>>> M;
+    M m;
+    assert(m.size() == 0);
+    m.insert(M::value_type(2, 1.5));
+    assert(m.size() == 1);
+    m.insert(M::value_type(1, 1.5));
+    assert(m.size() == 2);
+    m.insert(M::value_type(3, 1.5));
+    assert(m.size() == 3);
+    m.erase(m.begin());
+    assert(m.size() == 2);
+    m.erase(m.begin());
+    assert(m.size() == 1);
+    m.erase(m.begin());
+    assert(m.size() == 0);
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/alloc.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/alloc.pass.cpp
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// explicit map(const allocator_type& a);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::less<int> C;
+    typedef test_allocator<std::pair<const int, double> > A;
+    std::map<int, double, C, A> m(A(5));
+    assert(m.empty());
+    assert(m.begin() == m.end());
+    assert(m.get_allocator() == A(5));
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef std::less<int> C;
+    typedef min_allocator<std::pair<const int, double> > A;
+    std::map<int, double, C, A> m(A{});
+    assert(m.empty());
+    assert(m.begin() == m.end());
+    assert(m.get_allocator() == A());
+    }
+    {
+    typedef std::less<int> C;
+    typedef explicit_allocator<std::pair<const int, double> > A;
+    std::map<int, double, C, A> m(A{});
+    assert(m.empty());
+    assert(m.begin() == m.end());
+    assert(m.get_allocator() == A());
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/assign_initializer_list.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/assign_initializer_list.pass.cpp
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <map>
+
+// class map
+
+// map& operator=(initializer_list<value_type> il);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+#include "test_allocator.h"
+
+void test_basic() {
+  {
+    typedef std::pair<const int, double> V;
+    std::map<int, double> m =
+                            {
+                                {20, 1},
+                            };
+    m =
+                            {
+                                {1, 1},
+                                {1, 1.5},
+                                {1, 2},
+                                {2, 1},
+                                {2, 1.5},
+                                {2, 2},
+                                {3, 1},
+                                {3, 1.5},
+                                {3, 2}
+                            };
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    }
+    {
+    typedef std::pair<const int, double> V;
+    std::map<int, double, std::less<int>, min_allocator<V>> m =
+                            {
+                                {20, 1},
+                            };
+    m =
+                            {
+                                {1, 1},
+                                {1, 1.5},
+                                {1, 2},
+                                {2, 1},
+                                {2, 1.5},
+                                {2, 2},
+                                {3, 1},
+                                {3, 1.5},
+                                {3, 2}
+                            };
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    }
+}
+
+
+void duplicate_keys_test() {
+  typedef std::map<int, int, std::less<int>, test_allocator<std::pair<const int, int> > > Map;
+  {
+    LIBCPP_ASSERT(test_alloc_base::alloc_count == 0);
+    Map s = {{1, 0}, {2, 0}, {3, 0}};
+    LIBCPP_ASSERT(test_alloc_base::alloc_count == 3);
+    s = {{4, 0}, {4, 0}, {4, 0}, {4, 0}};
+    LIBCPP_ASSERT(test_alloc_base::alloc_count == 1);
+    assert(s.size() == 1);
+    assert(s.begin()->first == 4);
+  }
+  LIBCPP_ASSERT(test_alloc_base::alloc_count == 0);
+}
+
+int main(int, char**)
+{
+  test_basic();
+  duplicate_keys_test();
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/compare.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/compare.pass.cpp
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// explicit map(const key_compare& comp);
+
+// key_compare key_comp() const;
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "../../../test_compare.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+    typedef test_compare<std::less<int> > C;
+    const std::map<int, double, C> m(C(3));
+    assert(m.empty());
+    assert(m.begin() == m.end());
+    assert(m.key_comp() == C(3));
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef test_compare<std::less<int> > C;
+    const std::map<int, double, C, min_allocator<std::pair<const int, double>>> m(C(3));
+    assert(m.empty());
+    assert(m.begin() == m.end());
+    assert(m.key_comp() == C(3));
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/compare_alloc.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/compare_alloc.pass.cpp
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// map(const key_compare& comp, const allocator_type& a);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "../../../test_compare.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+    typedef test_compare<std::less<int> > C;
+    typedef test_allocator<std::pair<const int, double> > A;
+    std::map<int, double, C, A> m(C(4), A(5));
+    assert(m.empty());
+    assert(m.begin() == m.end());
+    assert(m.key_comp() == C(4));
+    assert(m.get_allocator() == A(5));
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef test_compare<std::less<int> > C;
+    typedef min_allocator<std::pair<const int, double> > A;
+    std::map<int, double, C, A> m(C(4), A());
+    assert(m.empty());
+    assert(m.begin() == m.end());
+    assert(m.key_comp() == C(4));
+    assert(m.get_allocator() == A());
+    }
+    {
+    typedef test_compare<std::less<int> > C;
+    typedef explicit_allocator<std::pair<const int, double> > A;
+    std::map<int, double, C, A> m(C(4), A{});
+    assert(m.empty());
+    assert(m.begin() == m.end());
+    assert(m.key_comp() == C(4));
+    assert(m.get_allocator() == A{});
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/copy.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/copy.pass.cpp
@@ -1,0 +1,131 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// map(const map& m);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "../../../test_compare.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+        typedef std::pair<const int, double> V;
+        V ar[] =
+        {
+            V(1, 1),
+            V(1, 1.5),
+            V(1, 2),
+            V(2, 1),
+            V(2, 1.5),
+            V(2, 2),
+            V(3, 1),
+            V(3, 1.5),
+            V(3, 2),
+        };
+        typedef test_compare<std::less<int> > C;
+        typedef test_allocator<V> A;
+        std::map<int, double, C, A> mo(ar, ar+sizeof(ar)/sizeof(ar[0]), C(5), A(7));
+        std::map<int, double, C, A> m = mo;
+        assert(m.get_allocator() == A(7));
+        assert(m.key_comp() == C(5));
+        assert(m.size() == 3);
+        assert(distance(m.begin(), m.end()) == 3);
+        assert(*m.begin() == V(1, 1));
+        assert(*next(m.begin()) == V(2, 1));
+        assert(*next(m.begin(), 2) == V(3, 1));
+
+        assert(mo.get_allocator() == A(7));
+        assert(mo.key_comp() == C(5));
+        assert(mo.size() == 3);
+        assert(distance(mo.begin(), mo.end()) == 3);
+        assert(*mo.begin() == V(1, 1));
+        assert(*next(mo.begin()) == V(2, 1));
+        assert(*next(mo.begin(), 2) == V(3, 1));
+    }
+#if TEST_STD_VER >= 11
+    {
+        typedef std::pair<const int, double> V;
+        V ar[] =
+        {
+            V(1, 1),
+            V(1, 1.5),
+            V(1, 2),
+            V(2, 1),
+            V(2, 1.5),
+            V(2, 2),
+            V(3, 1),
+            V(3, 1.5),
+            V(3, 2),
+        };
+        typedef test_compare<std::less<int> > C;
+        typedef other_allocator<V> A;
+        std::map<int, double, C, A> mo(ar, ar+sizeof(ar)/sizeof(ar[0]), C(5), A(7));
+        std::map<int, double, C, A> m = mo;
+        assert(m.get_allocator() == A(-2));
+        assert(m.key_comp() == C(5));
+        assert(m.size() == 3);
+        assert(distance(m.begin(), m.end()) == 3);
+        assert(*m.begin() == V(1, 1));
+        assert(*next(m.begin()) == V(2, 1));
+        assert(*next(m.begin(), 2) == V(3, 1));
+
+        assert(mo.get_allocator() == A(7));
+        assert(mo.key_comp() == C(5));
+        assert(mo.size() == 3);
+        assert(distance(mo.begin(), mo.end()) == 3);
+        assert(*mo.begin() == V(1, 1));
+        assert(*next(mo.begin()) == V(2, 1));
+        assert(*next(mo.begin(), 2) == V(3, 1));
+    }
+    {
+        typedef std::pair<const int, double> V;
+        V ar[] =
+        {
+            V(1, 1),
+            V(1, 1.5),
+            V(1, 2),
+            V(2, 1),
+            V(2, 1.5),
+            V(2, 2),
+            V(3, 1),
+            V(3, 1.5),
+            V(3, 2),
+        };
+        typedef test_compare<std::less<int> > C;
+        typedef min_allocator<V> A;
+        std::map<int, double, C, A> mo(ar, ar+sizeof(ar)/sizeof(ar[0]), C(5), A());
+        std::map<int, double, C, A> m = mo;
+        assert(m.get_allocator() == A());
+        assert(m.key_comp() == C(5));
+        assert(m.size() == 3);
+        assert(distance(m.begin(), m.end()) == 3);
+        assert(*m.begin() == V(1, 1));
+        assert(*next(m.begin()) == V(2, 1));
+        assert(*next(m.begin(), 2) == V(3, 1));
+
+        assert(mo.get_allocator() == A());
+        assert(mo.key_comp() == C(5));
+        assert(mo.size() == 3);
+        assert(distance(mo.begin(), mo.end()) == 3);
+        assert(*mo.begin() == V(1, 1));
+        assert(*next(mo.begin()) == V(2, 1));
+        assert(*next(mo.begin(), 2) == V(3, 1));
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/copy_alloc.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/copy_alloc.pass.cpp
@@ -1,0 +1,131 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// map(const map& m, const allocator_type& a);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "../../../test_compare.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::pair<const int, double> V;
+    V ar[] =
+    {
+        V(1, 1),
+        V(1, 1.5),
+        V(1, 2),
+        V(2, 1),
+        V(2, 1.5),
+        V(2, 2),
+        V(3, 1),
+        V(3, 1.5),
+        V(3, 2),
+    };
+    typedef test_compare<std::less<int> > C;
+    typedef test_allocator<V> A;
+    std::map<int, double, C, A> mo(ar, ar+sizeof(ar)/sizeof(ar[0]), C(5), A(7));
+    std::map<int, double, C, A> m(mo, A(3));
+    assert(m.get_allocator() == A(3));
+    assert(m.key_comp() == C(5));
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+
+    assert(mo.get_allocator() == A(7));
+    assert(mo.key_comp() == C(5));
+    assert(mo.size() == 3);
+    assert(distance(mo.begin(), mo.end()) == 3);
+    assert(*mo.begin() == V(1, 1));
+    assert(*next(mo.begin()) == V(2, 1));
+    assert(*next(mo.begin(), 2) == V(3, 1));
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef std::pair<const int, double> V;
+    V ar[] =
+    {
+        V(1, 1),
+        V(1, 1.5),
+        V(1, 2),
+        V(2, 1),
+        V(2, 1.5),
+        V(2, 2),
+        V(3, 1),
+        V(3, 1.5),
+        V(3, 2),
+    };
+    typedef test_compare<std::less<int> > C;
+    typedef min_allocator<V> A;
+    std::map<int, double, C, A> mo(ar, ar+sizeof(ar)/sizeof(ar[0]), C(5), A());
+    std::map<int, double, C, A> m(mo, A());
+    assert(m.get_allocator() == A());
+    assert(m.key_comp() == C(5));
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+
+    assert(mo.get_allocator() == A());
+    assert(mo.key_comp() == C(5));
+    assert(mo.size() == 3);
+    assert(distance(mo.begin(), mo.end()) == 3);
+    assert(*mo.begin() == V(1, 1));
+    assert(*next(mo.begin()) == V(2, 1));
+    assert(*next(mo.begin(), 2) == V(3, 1));
+    }
+    {
+    typedef std::pair<const int, double> V;
+    V ar[] =
+    {
+        V(1, 1),
+        V(1, 1.5),
+        V(1, 2),
+        V(2, 1),
+        V(2, 1.5),
+        V(2, 2),
+        V(3, 1),
+        V(3, 1.5),
+        V(3, 2),
+    };
+    typedef test_compare<std::less<int> > C;
+    typedef explicit_allocator<V> A;
+    std::map<int, double, C, A> mo(ar, ar+sizeof(ar)/sizeof(ar[0]), C(5), A{});
+    std::map<int, double, C, A> m(mo, A{});
+    assert(m.get_allocator() == A());
+    assert(m.key_comp() == C(5));
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+
+    assert(mo.get_allocator() == A());
+    assert(mo.key_comp() == C(5));
+    assert(mo.size() == 3);
+    assert(distance(mo.begin(), mo.end()) == 3);
+    assert(*mo.begin() == V(1, 1));
+    assert(*next(mo.begin()) == V(2, 1));
+    assert(*next(mo.begin(), 2) == V(3, 1));
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/copy_assign.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/copy_assign.pass.cpp
@@ -1,0 +1,343 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// map& operator=(const map& m);
+
+#include <map>
+#include <cassert>
+#include <vector>
+#include <algorithm>
+#include <iterator>
+
+#include <iostream>
+
+#include "test_macros.h"
+#include "../../../test_compare.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+
+#if TEST_STD_VER >= 11
+std::vector<int> ca_allocs;
+std::vector<int> ca_deallocs;
+
+template <class T>
+class counting_allocatorT {
+public:
+    typedef T value_type;
+    int foo{0};
+    counting_allocatorT(int f) noexcept : foo(f) {}
+
+    using propagate_on_container_copy_assignment = std::true_type;
+    template <class U> counting_allocatorT(const counting_allocatorT<U>& other) noexcept {foo = other.foo;}
+    template <class U> bool operator==(const counting_allocatorT<U>& other) const noexcept { return foo == other.foo; }
+    template <class U> bool operator!=(const counting_allocatorT<U>& other) const noexcept { return foo != other.foo; }
+
+    T * allocate(const size_t n) const {
+        ca_allocs.push_back(foo);
+        void * const pv = ::malloc(n * sizeof(T));
+        return static_cast<T *>(pv);
+    }
+    void deallocate(T * const p, size_t) const noexcept {
+        ca_deallocs.push_back(foo);
+        free(p);
+    }
+};
+
+template <class T>
+class counting_allocatorF {
+public:
+    typedef T value_type;
+    int foo{0};
+    counting_allocatorF(int f) noexcept : foo(f) {}
+
+    using propagate_on_container_copy_assignment = std::false_type;
+    template <class U> counting_allocatorF(const counting_allocatorF<U>& other) noexcept {foo = other.foo;}
+    template <class U> bool operator==(const counting_allocatorF<U>& other) const noexcept { return foo == other.foo; }
+    template <class U> bool operator!=(const counting_allocatorF<U>& other) const noexcept { return foo != other.foo; }
+
+    T * allocate(const size_t n) const {
+        ca_allocs.push_back(foo);
+        void * const pv = ::malloc(n * sizeof(T));
+        return static_cast<T *>(pv);
+    }
+    void deallocate(T * const p, size_t) const noexcept {
+        ca_deallocs.push_back(foo);
+        free(p);
+    }
+};
+
+bool balanced_allocs() {
+    std::vector<int> temp1, temp2;
+
+    std::cout << "Allocations = " << ca_allocs.size() << ", deallocatons = " << ca_deallocs.size() << std::endl;
+    if (ca_allocs.size() != ca_deallocs.size())
+        return false;
+
+    temp1 = ca_allocs;
+    std::sort(temp1.begin(), temp1.end());
+    temp2.clear();
+    std::unique_copy(temp1.begin(), temp1.end(), std::back_inserter<std::vector<int>>(temp2));
+    std::cout << "There were " << temp2.size() << " different allocators\n";
+
+    for (std::vector<int>::const_iterator it = temp2.begin(); it != temp2.end(); ++it ) {
+        std::cout << *it << ": " << std::count(ca_allocs.begin(), ca_allocs.end(), *it) << " vs " << std::count(ca_deallocs.begin(), ca_deallocs.end(), *it) << std::endl;
+        if ( std::count(ca_allocs.begin(), ca_allocs.end(), *it) != std::count(ca_deallocs.begin(), ca_deallocs.end(), *it))
+            return false;
+        }
+
+    temp1 = ca_allocs;
+    std::sort(temp1.begin(), temp1.end());
+    temp2.clear();
+    std::unique_copy(temp1.begin(), temp1.end(), std::back_inserter<std::vector<int>>(temp2));
+    std::cout << "There were " << temp2.size() << " different (de)allocators\n";
+    for (std::vector<int>::const_iterator it = ca_deallocs.begin(); it != ca_deallocs.end(); ++it ) {
+        std::cout << *it << ": " << std::count(ca_allocs.begin(), ca_allocs.end(), *it) << " vs " << std::count(ca_deallocs.begin(), ca_deallocs.end(), *it) << std::endl;
+        if ( std::count(ca_allocs.begin(), ca_allocs.end(), *it) != std::count(ca_deallocs.begin(), ca_deallocs.end(), *it))
+            return false;
+        }
+
+    return true;
+    }
+#endif
+
+int main(int, char**)
+{
+    {
+        typedef std::pair<const int, double> V;
+        V ar[] =
+        {
+            V(1, 1),
+            V(1, 1.5),
+            V(1, 2),
+            V(2, 1),
+            V(2, 1.5),
+            V(2, 2),
+            V(3, 1),
+            V(3, 1.5),
+            V(3, 2)
+        };
+        typedef test_compare<std::less<int> > C;
+        typedef test_allocator<V> A;
+        std::map<int, double, C, A> mo(ar, ar+sizeof(ar)/sizeof(ar[0]), C(5), A(2));
+        std::map<int, double, C, A> m(ar, ar+sizeof(ar)/sizeof(ar[0])/2, C(3), A(7));
+        m = mo;
+        assert(m.get_allocator() == A(7));
+        assert(m.key_comp() == C(5));
+        assert(m.size() == 3);
+        assert(distance(m.begin(), m.end()) == 3);
+        assert(*m.begin() == V(1, 1));
+        assert(*next(m.begin()) == V(2, 1));
+        assert(*next(m.begin(), 2) == V(3, 1));
+
+        assert(mo.get_allocator() == A(2));
+        assert(mo.key_comp() == C(5));
+        assert(mo.size() == 3);
+        assert(distance(mo.begin(), mo.end()) == 3);
+        assert(*mo.begin() == V(1, 1));
+        assert(*next(mo.begin()) == V(2, 1));
+        assert(*next(mo.begin(), 2) == V(3, 1));
+    }
+    {
+        typedef std::pair<const int, double> V;
+        const V ar[] =
+        {
+            V(1, 1),
+            V(2, 1),
+            V(3, 1),
+        };
+        std::map<int, double> m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        std::map<int, double> *p = &m;
+        m = *p;
+
+        assert(m.size() == 3);
+        assert(std::equal(m.begin(), m.end(), ar));
+    }
+    {
+        typedef std::pair<const int, double> V;
+        V ar[] =
+        {
+            V(1, 1),
+            V(1, 1.5),
+            V(1, 2),
+            V(2, 1),
+            V(2, 1.5),
+            V(2, 2),
+            V(3, 1),
+            V(3, 1.5),
+            V(3, 2)
+        };
+        typedef test_compare<std::less<int> > C;
+        typedef other_allocator<V> A;
+        std::map<int, double, C, A> mo(ar, ar+sizeof(ar)/sizeof(ar[0]), C(5), A(2));
+        std::map<int, double, C, A> m(ar, ar+sizeof(ar)/sizeof(ar[0])/2, C(3), A(7));
+        m = mo;
+        assert(m.get_allocator() == A(2));
+        assert(m.key_comp() == C(5));
+        assert(m.size() == 3);
+        assert(distance(m.begin(), m.end()) == 3);
+        assert(*m.begin() == V(1, 1));
+        assert(*next(m.begin()) == V(2, 1));
+        assert(*next(m.begin(), 2) == V(3, 1));
+
+        assert(mo.get_allocator() == A(2));
+        assert(mo.key_comp() == C(5));
+        assert(mo.size() == 3);
+        assert(distance(mo.begin(), mo.end()) == 3);
+        assert(*mo.begin() == V(1, 1));
+        assert(*next(mo.begin()) == V(2, 1));
+        assert(*next(mo.begin(), 2) == V(3, 1));
+    }
+#if TEST_STD_VER >= 11
+    {
+        typedef std::pair<const int, double> V;
+        V ar[] =
+        {
+            V(1, 1),
+            V(1, 1.5),
+            V(1, 2),
+            V(2, 1),
+            V(2, 1.5),
+            V(2, 2),
+            V(3, 1),
+            V(3, 1.5),
+            V(3, 2)
+        };
+        typedef test_compare<std::less<int> > C;
+        typedef min_allocator<V> A;
+        std::map<int, double, C, A> mo(ar, ar+sizeof(ar)/sizeof(ar[0]), C(5), A());
+        std::map<int, double, C, A> m(ar, ar+sizeof(ar)/sizeof(ar[0])/2, C(3), A());
+        m = mo;
+        assert(m.get_allocator() == A());
+        assert(m.key_comp() == C(5));
+        assert(m.size() == 3);
+        assert(distance(m.begin(), m.end()) == 3);
+        assert(*m.begin() == V(1, 1));
+        assert(*next(m.begin()) == V(2, 1));
+        assert(*next(m.begin(), 2) == V(3, 1));
+
+        assert(mo.get_allocator() == A());
+        assert(mo.key_comp() == C(5));
+        assert(mo.size() == 3);
+        assert(distance(mo.begin(), mo.end()) == 3);
+        assert(*mo.begin() == V(1, 1));
+        assert(*next(mo.begin()) == V(2, 1));
+        assert(*next(mo.begin(), 2) == V(3, 1));
+    }
+    {
+        typedef std::pair<const int, double> V;
+        V ar[] =
+        {
+            V(1, 1),
+            V(1, 1.5),
+            V(1, 2),
+            V(2, 1),
+            V(2, 1.5),
+            V(2, 2),
+            V(3, 1),
+            V(3, 1.5),
+            V(3, 2)
+        };
+        typedef test_compare<std::less<int> > C;
+        typedef min_allocator<V> A;
+        std::map<int, double, C, A> mo(ar, ar+sizeof(ar)/sizeof(ar[0]), C(5), A());
+        std::map<int, double, C, A> m(ar, ar+sizeof(ar)/sizeof(ar[0])/2, C(3), A());
+        m = mo;
+        assert(m.get_allocator() == A());
+        assert(m.key_comp() == C(5));
+        assert(m.size() == 3);
+        assert(distance(m.begin(), m.end()) == 3);
+        assert(*m.begin() == V(1, 1));
+        assert(*next(m.begin()) == V(2, 1));
+        assert(*next(m.begin(), 2) == V(3, 1));
+
+        assert(mo.get_allocator() == A());
+        assert(mo.key_comp() == C(5));
+        assert(mo.size() == 3);
+        assert(distance(mo.begin(), mo.end()) == 3);
+        assert(*mo.begin() == V(1, 1));
+        assert(*next(mo.begin()) == V(2, 1));
+        assert(*next(mo.begin(), 2) == V(3, 1));
+    }
+
+    assert(balanced_allocs());
+    {
+        typedef std::pair<const int, double> V;
+        V ar[] =
+        {
+            V(1, 1),
+            V(1, 1.5),
+            V(1, 2),
+            V(2, 1),
+            V(2, 1.5),
+            V(2, 2),
+            V(3, 1),
+            V(3, 1.5),
+            V(3, 2)
+        };
+        typedef test_compare<std::less<int> > C;
+        typedef counting_allocatorT<V> A;
+        std::map<int, double, C, A> mo(ar, ar+sizeof(ar)/sizeof(ar[0]), C(5), A(1));
+        std::map<int, double, C, A> m(ar, ar+sizeof(ar)/sizeof(ar[0])/2, C(3), A(2));
+        m = mo;
+        assert(m.key_comp() == C(5));
+        assert(m.size() == 3);
+        assert(distance(m.begin(), m.end()) == 3);
+        assert(*m.begin() == V(1, 1));
+        assert(*next(m.begin()) == V(2, 1));
+        assert(*next(m.begin(), 2) == V(3, 1));
+
+        assert(mo.key_comp() == C(5));
+        assert(mo.size() == 3);
+        assert(distance(mo.begin(), mo.end()) == 3);
+        assert(*mo.begin() == V(1, 1));
+        assert(*next(mo.begin()) == V(2, 1));
+        assert(*next(mo.begin(), 2) == V(3, 1));
+    }
+    assert(balanced_allocs());
+    {
+        typedef std::pair<const int, double> V;
+        V ar[] =
+        {
+            V(1, 1),
+            V(1, 1.5),
+            V(1, 2),
+            V(2, 1),
+            V(2, 1.5),
+            V(2, 2),
+            V(3, 1),
+            V(3, 1.5),
+            V(3, 2)
+        };
+        typedef test_compare<std::less<int> > C;
+        typedef counting_allocatorF<V> A;
+        std::map<int, double, C, A> mo(ar, ar+sizeof(ar)/sizeof(ar[0]), C(5), A(100));
+        std::map<int, double, C, A> m(ar, ar+sizeof(ar)/sizeof(ar[0])/2, C(3), A(200));
+        m = mo;
+        assert(m.key_comp() == C(5));
+        assert(m.size() == 3);
+        assert(distance(m.begin(), m.end()) == 3);
+        assert(*m.begin() == V(1, 1));
+        assert(*next(m.begin()) == V(2, 1));
+        assert(*next(m.begin(), 2) == V(3, 1));
+
+        assert(mo.key_comp() == C(5));
+        assert(mo.size() == 3);
+        assert(distance(mo.begin(), mo.end()) == 3);
+        assert(*mo.begin() == V(1, 1));
+        assert(*next(mo.begin()) == V(2, 1));
+        assert(*next(mo.begin(), 2) == V(3, 1));
+    }
+    assert(balanced_allocs());
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/default.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/default.pass.cpp
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// map();
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+    std::map<int, double> m;
+    assert(m.empty());
+    assert(m.begin() == m.end());
+    }
+#if TEST_STD_VER >= 11
+    {
+    std::map<int, double, std::less<int>, min_allocator<std::pair<const int, double>>> m;
+    assert(m.empty());
+    assert(m.begin() == m.end());
+    }
+    {
+    typedef explicit_allocator<std::pair<const int, double>> A;
+        {
+        std::map<int, double, std::less<int>, A> m;
+        assert(m.empty());
+        assert(m.begin() == m.end());
+        }
+        {
+        A a;
+        std::map<int, double, std::less<int>, A> m(a);
+        assert(m.empty());
+        assert(m.begin() == m.end());
+        }
+    }
+    {
+    std::map<int, double> m = {};
+    assert(m.empty());
+    assert(m.begin() == m.end());
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/default_recursive.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/default_recursive.pass.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// map();
+
+#include <map>
+
+#include "test_macros.h"
+
+struct X
+{
+    std::map<int, X> m;
+    std::map<int, X>::iterator i;
+    std::map<int, X>::const_iterator ci;
+    std::map<int, X>::reverse_iterator ri;
+    std::map<int, X>::const_reverse_iterator cri;
+};
+
+int main(int, char**)
+{
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/dtor_noexcept.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/dtor_noexcept.pass.cpp
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// ~map() // implied noexcept;
+
+// UNSUPPORTED: c++98, c++03
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "MoveOnly.h"
+#include "test_allocator.h"
+
+template <class T>
+struct some_comp
+{
+    typedef T value_type;
+    ~some_comp() noexcept(false);
+    bool operator()(const T&, const T&) const noexcept { return false; }
+};
+
+int main(int, char**)
+{
+    typedef std::pair<const MoveOnly, MoveOnly> V;
+    {
+        typedef std::map<MoveOnly, MoveOnly> C;
+        static_assert(std::is_nothrow_destructible<C>::value, "");
+    }
+    {
+        typedef std::map<MoveOnly, MoveOnly, std::less<MoveOnly>, test_allocator<V>> C;
+        static_assert(std::is_nothrow_destructible<C>::value, "");
+    }
+    {
+        typedef std::map<MoveOnly, MoveOnly, std::less<MoveOnly>, other_allocator<V>> C;
+        static_assert(std::is_nothrow_destructible<C>::value, "");
+    }
+#if defined(_LIBCPP_VERSION)
+    {
+        typedef std::map<MoveOnly, MoveOnly, some_comp<MoveOnly>> C;
+        static_assert(!std::is_nothrow_destructible<C>::value, "");
+    }
+#endif // _LIBCPP_VERSION
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/initializer_list.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/initializer_list.pass.cpp
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <map>
+
+// class map
+
+// map(initializer_list<value_type> il);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::pair<const int, double> V;
+    std::map<int, double> m =
+                            {
+                                {1, 1},
+                                {1, 1.5},
+                                {1, 2},
+                                {2, 1},
+                                {2, 1.5},
+                                {2, 2},
+                                {3, 1},
+                                {3, 1.5},
+                                {3, 2}
+                            };
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    }
+    {
+    typedef std::pair<const int, double> V;
+    std::map<int, double, std::less<int>, min_allocator<V>> m =
+                            {
+                                {1, 1},
+                                {1, 1.5},
+                                {1, 2},
+                                {2, 1},
+                                {2, 1.5},
+                                {2, 2},
+                                {3, 1},
+                                {3, 1.5},
+                                {3, 2}
+                            };
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    }
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/initializer_list_compare.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/initializer_list_compare.pass.cpp
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <map>
+
+// class map
+
+// map(initializer_list<value_type> il, const key_compare& comp);
+
+#include <map>
+#include <cassert>
+#include "test_macros.h"
+#include "../../../test_compare.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::pair<const int, double> V;
+    typedef test_compare<std::less<int> > C;
+    std::map<int, double, C> m({
+                                {1, 1},
+                                {1, 1.5},
+                                {1, 2},
+                                {2, 1},
+                                {2, 1.5},
+                                {2, 2},
+                                {3, 1},
+                                {3, 1.5},
+                                {3, 2}
+                               }, C(3));
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    assert(m.key_comp() == C(3));
+    }
+    {
+    typedef std::pair<const int, double> V;
+    typedef test_compare<std::less<int> > C;
+    std::map<int, double, C, min_allocator<std::pair<const int, double>>> m({
+                                {1, 1},
+                                {1, 1.5},
+                                {1, 2},
+                                {2, 1},
+                                {2, 1.5},
+                                {2, 2},
+                                {3, 1},
+                                {3, 1.5},
+                                {3, 2}
+                               }, C(3));
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    assert(m.key_comp() == C(3));
+    }
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/initializer_list_compare_alloc.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/initializer_list_compare_alloc.pass.cpp
@@ -1,0 +1,122 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <map>
+
+// class map
+
+// map(initializer_list<value_type> il, const key_compare& comp, const allocator_type& a);
+
+#include <map>
+#include <cassert>
+#include "test_macros.h"
+#include "../../../test_compare.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::pair<const int, double> V;
+    typedef test_compare<std::less<int> > C;
+    typedef test_allocator<std::pair<const int, double> > A;
+    std::map<int, double, C, A> m({
+                                   {1, 1},
+                                   {1, 1.5},
+                                   {1, 2},
+                                   {2, 1},
+                                   {2, 1.5},
+                                   {2, 2},
+                                   {3, 1},
+                                   {3, 1.5},
+                                   {3, 2}
+                                  }, C(3), A(6));
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    assert(m.key_comp() == C(3));
+    assert(m.get_allocator() == A(6));
+    }
+    {
+    typedef std::pair<const int, double> V;
+    typedef test_compare<std::less<int> > C;
+    typedef min_allocator<std::pair<const int, double> > A;
+    std::map<int, double, C, A> m({
+                                   {1, 1},
+                                   {1, 1.5},
+                                   {1, 2},
+                                   {2, 1},
+                                   {2, 1.5},
+                                   {2, 2},
+                                   {3, 1},
+                                   {3, 1.5},
+                                   {3, 2}
+                                  }, C(3), A());
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    assert(m.key_comp() == C(3));
+    assert(m.get_allocator() == A());
+    }
+    {
+    typedef std::pair<const int, double> V;
+    typedef min_allocator<V> A;
+    typedef test_compare<std::less<int> > C;
+    typedef std::map<int, double, C, A> M;
+    A a;
+    M m ({ {1, 1},
+           {1, 1.5},
+           {1, 2},
+           {2, 1},
+           {2, 1.5},
+           {2, 2},
+           {3, 1},
+           {3, 1.5},
+           {3, 2}
+          }, a);
+
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    assert(m.get_allocator() == a);
+    }
+    {
+    typedef std::pair<const int, double> V;
+    typedef explicit_allocator<V> A;
+    typedef test_compare<std::less<int> > C;
+    A a;
+    std::map<int, double, C, A> m({
+                                   {1, 1},
+                                   {1, 1.5},
+                                   {1, 2},
+                                   {2, 1},
+                                   {2, 1.5},
+                                   {2, 2},
+                                   {3, 1},
+                                   {3, 1.5},
+                                   {3, 2}
+                                  }, C(3), a);
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    assert(m.key_comp() == C(3));
+    assert(m.get_allocator() == a);
+    }
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/iter_iter.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/iter_iter.pass.cpp
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// template <class InputIterator>
+//     map(InputIterator first, InputIterator last);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::pair<const int, double> V;
+    V ar[] =
+    {
+        V(1, 1),
+        V(1, 1.5),
+        V(1, 2),
+        V(2, 1),
+        V(2, 1.5),
+        V(2, 2),
+        V(3, 1),
+        V(3, 1.5),
+        V(3, 2),
+    };
+    std::map<int, double> m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef std::pair<const int, double> V;
+    V ar[] =
+    {
+        V(1, 1),
+        V(1, 1.5),
+        V(1, 2),
+        V(2, 1),
+        V(2, 1.5),
+        V(2, 2),
+        V(3, 1),
+        V(3, 1.5),
+        V(3, 2),
+    };
+    std::map<int, double, std::less<int>, min_allocator<std::pair<const int, double>>> m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/iter_iter_comp_alloc.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/iter_iter_comp_alloc.pass.cpp
@@ -1,0 +1,124 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// template <class InputIterator>
+//     map(InputIterator first, InputIterator last,
+//         const key_compare& comp, const allocator_type& a);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "../../../test_compare.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::pair<const int, double> V;
+    V ar[] =
+    {
+        V(1, 1),
+        V(1, 1.5),
+        V(1, 2),
+        V(2, 1),
+        V(2, 1.5),
+        V(2, 2),
+        V(3, 1),
+        V(3, 1.5),
+        V(3, 2),
+    };
+    typedef test_compare<std::less<int> > C;
+    typedef test_allocator<V> A;
+    std::map<int, double, C, A> m(ar, ar+sizeof(ar)/sizeof(ar[0]), C(5), A(7));
+    assert(m.get_allocator() == A(7));
+    assert(m.key_comp() == C(5));
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef std::pair<const int, double> V;
+    V ar[] =
+    {
+        V(1, 1),
+        V(1, 1.5),
+        V(1, 2),
+        V(2, 1),
+        V(2, 1.5),
+        V(2, 2),
+        V(3, 1),
+        V(3, 1.5),
+        V(3, 2),
+    };
+    typedef test_compare<std::less<int> > C;
+    typedef min_allocator<V> A;
+    std::map<int, double, C, A> m(ar, ar+sizeof(ar)/sizeof(ar[0]), C(5), A());
+    assert(m.get_allocator() == A());
+    assert(m.key_comp() == C(5));
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    }
+#if TEST_STD_VER > 11
+    {
+    typedef std::pair<const int, double> V;
+    V ar[] =
+    {
+        V(1, 1),
+        V(1, 1.5),
+        V(1, 2),
+        V(2, 1),
+        V(2, 1.5),
+        V(2, 2),
+        V(3, 1),
+        V(3, 1.5),
+        V(3, 2),
+    };
+    {
+    typedef min_allocator<V> A;
+    typedef test_compare<std::less<int> > C;
+    A a;
+    std::map<int, double, C, A> m(ar, ar+sizeof(ar)/sizeof(ar[0]), a );
+
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    assert(m.get_allocator() == a);
+    }
+    {
+    typedef explicit_allocator<V> A;
+    typedef test_compare<std::less<int> > C;
+    A a;
+    std::map<int, double, C, A> m(ar, ar+sizeof(ar)/sizeof(ar[0]), a );
+
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    assert(m.get_allocator() == a);
+    }
+    }
+#endif
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/move.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/move.pass.cpp
@@ -1,0 +1,120 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <map>
+
+// class map
+
+// map(map&& m);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "../../../test_compare.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    typedef std::pair<const int, double> V;
+    {
+        typedef test_compare<std::less<int> > C;
+        typedef test_allocator<V> A;
+        std::map<int, double, C, A> mo(C(5), A(7));
+        std::map<int, double, C, A> m = std::move(mo);
+        assert(m.get_allocator() == A(7));
+        assert(m.key_comp() == C(5));
+        assert(m.size() == 0);
+        assert(distance(m.begin(), m.end()) == 0);
+
+        assert(mo.get_allocator() == A(test_alloc_base::moved_value));
+        assert(mo.key_comp() == C(5));
+        assert(mo.size() == 0);
+        assert(distance(mo.begin(), mo.end()) == 0);
+    }
+    {
+        V ar[] =
+        {
+            V(1, 1),
+            V(1, 1.5),
+            V(1, 2),
+            V(2, 1),
+            V(2, 1.5),
+            V(2, 2),
+            V(3, 1),
+            V(3, 1.5),
+            V(3, 2),
+        };
+        typedef test_compare<std::less<int> > C;
+        typedef test_allocator<V> A;
+        std::map<int, double, C, A> mo(ar, ar+sizeof(ar)/sizeof(ar[0]), C(5), A(7));
+        std::map<int, double, C, A> m = std::move(mo);
+        assert(m.get_allocator() == A(7));
+        assert(m.key_comp() == C(5));
+        assert(m.size() == 3);
+        assert(distance(m.begin(), m.end()) == 3);
+        assert(*m.begin() == V(1, 1));
+        assert(*next(m.begin()) == V(2, 1));
+        assert(*next(m.begin(), 2) == V(3, 1));
+
+        assert(mo.get_allocator() == A(test_alloc_base::moved_value));
+        assert(mo.key_comp() == C(5));
+        assert(mo.size() == 0);
+        assert(distance(mo.begin(), mo.end()) == 0);
+    }
+    {
+        typedef test_compare<std::less<int> > C;
+        typedef min_allocator<V> A;
+        std::map<int, double, C, A> mo(C(5), A());
+        std::map<int, double, C, A> m = std::move(mo);
+        assert(m.get_allocator() == A());
+        assert(m.key_comp() == C(5));
+        assert(m.size() == 0);
+        assert(distance(m.begin(), m.end()) == 0);
+
+        assert(mo.get_allocator() == A());
+        assert(mo.key_comp() == C(5));
+        assert(mo.size() == 0);
+        assert(distance(mo.begin(), mo.end()) == 0);
+    }
+    {
+        V ar[] =
+        {
+            V(1, 1),
+            V(1, 1.5),
+            V(1, 2),
+            V(2, 1),
+            V(2, 1.5),
+            V(2, 2),
+            V(3, 1),
+            V(3, 1.5),
+            V(3, 2),
+        };
+        typedef test_compare<std::less<int> > C;
+        typedef min_allocator<V> A;
+        std::map<int, double, C, A> mo(ar, ar+sizeof(ar)/sizeof(ar[0]), C(5), A());
+        std::map<int, double, C, A> m = std::move(mo);
+        assert(m.get_allocator() == A());
+        assert(m.key_comp() == C(5));
+        assert(m.size() == 3);
+        assert(distance(m.begin(), m.end()) == 3);
+        assert(*m.begin() == V(1, 1));
+        assert(*next(m.begin()) == V(2, 1));
+        assert(*next(m.begin(), 2) == V(3, 1));
+
+        assert(mo.get_allocator() == A());
+        assert(mo.key_comp() == C(5));
+        assert(mo.size() == 0);
+        assert(distance(mo.begin(), mo.end()) == 0);
+    }
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/move_alloc.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/move_alloc.pass.cpp
@@ -1,0 +1,276 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <map>
+
+// class map
+
+// map(map&& m, const allocator_type& a);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "MoveOnly.h"
+#include "../../../test_compare.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+#include "Counter.h"
+
+int main(int, char**)
+{
+    {
+        typedef std::pair<MoveOnly, MoveOnly> V;
+        typedef std::pair<const MoveOnly, MoveOnly> VC;
+        typedef test_compare<std::less<MoveOnly> > C;
+        typedef test_allocator<VC> A;
+        typedef std::map<MoveOnly, MoveOnly, C, A> M;
+        typedef std::move_iterator<V*> I;
+        V a1[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m1(I(a1), I(a1+sizeof(a1)/sizeof(a1[0])), C(5), A(7));
+        V a2[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m2(I(a2), I(a2+sizeof(a2)/sizeof(a2[0])), C(5), A(7));
+        M m3(std::move(m1), A(7));
+        assert(m3 == m2);
+        assert(m3.get_allocator() == A(7));
+        assert(m3.key_comp() == C(5));
+        LIBCPP_ASSERT(m1.empty());
+    }
+    {
+        typedef std::pair<MoveOnly, MoveOnly> V;
+        typedef std::pair<const MoveOnly, MoveOnly> VC;
+        typedef test_compare<std::less<MoveOnly> > C;
+        typedef test_allocator<VC> A;
+        typedef std::map<MoveOnly, MoveOnly, C, A> M;
+        typedef std::move_iterator<V*> I;
+        V a1[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m1(I(a1), I(a1+sizeof(a1)/sizeof(a1[0])), C(5), A(7));
+        V a2[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m2(I(a2), I(a2+sizeof(a2)/sizeof(a2[0])), C(5), A(7));
+        M m3(std::move(m1), A(5));
+        assert(m3 == m2);
+        assert(m3.get_allocator() == A(5));
+        assert(m3.key_comp() == C(5));
+        LIBCPP_ASSERT(m1.empty());
+    }
+    {
+        typedef std::pair<MoveOnly, MoveOnly> V;
+        typedef std::pair<const MoveOnly, MoveOnly> VC;
+        typedef test_compare<std::less<MoveOnly> > C;
+        typedef other_allocator<VC> A;
+        typedef std::map<MoveOnly, MoveOnly, C, A> M;
+        typedef std::move_iterator<V*> I;
+        V a1[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m1(I(a1), I(a1+sizeof(a1)/sizeof(a1[0])), C(5), A(7));
+        V a2[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m2(I(a2), I(a2+sizeof(a2)/sizeof(a2[0])), C(5), A(7));
+        M m3(std::move(m1), A(5));
+        assert(m3 == m2);
+        assert(m3.get_allocator() == A(5));
+        assert(m3.key_comp() == C(5));
+        LIBCPP_ASSERT(m1.empty());
+    }
+    {
+        typedef Counter<int> T;
+        typedef std::pair<int, T> V;
+        typedef std::pair<const int, T> VC;
+        typedef test_allocator<VC> A;
+        typedef std::less<int> C;
+        typedef std::map<const int, T, C, A> M;
+        typedef V* I;
+        Counter_base::gConstructed = 0;
+        {
+            V a1[] =
+            {
+                V(1, 1),
+                V(1, 2),
+                V(1, 3),
+                V(2, 1),
+                V(2, 2),
+                V(2, 3),
+                V(3, 1),
+                V(3, 2),
+                V(3, 3)
+            };
+            const size_t num = sizeof(a1)/sizeof(a1[0]);
+            assert(Counter_base::gConstructed == num);
+
+            M m1(I(a1), I(a1+num), C(), A());
+            assert(Counter_base::gConstructed == num+3);
+
+            M m2(m1);
+            assert(m2 == m1);
+            assert(Counter_base::gConstructed == num+6);
+
+            M m3(std::move(m1), A());
+            assert(m3 == m2);
+            LIBCPP_ASSERT(m1.empty());
+            assert(Counter_base::gConstructed >= (int)(num+6));
+            assert(Counter_base::gConstructed <= (int)(num+6+m1.size()));
+
+            {
+            M m4(std::move(m2), A(5));
+            assert(Counter_base::gConstructed >= (int)(num+6));
+            assert(Counter_base::gConstructed <= (int)(num+6+m1.size()+m2.size()));
+            assert(m4 == m3);
+            LIBCPP_ASSERT(m2.empty());
+            }
+            assert(Counter_base::gConstructed >= (int)(num+3));
+            assert(Counter_base::gConstructed <= (int)(num+3+m1.size()+m2.size()));
+        }
+        assert(Counter_base::gConstructed == 0);
+    }
+    {
+        typedef std::pair<MoveOnly, MoveOnly> V;
+        typedef std::pair<const MoveOnly, MoveOnly> VC;
+        typedef test_compare<std::less<MoveOnly> > C;
+        typedef min_allocator<VC> A;
+        typedef std::map<MoveOnly, MoveOnly, C, A> M;
+        typedef std::move_iterator<V*> I;
+        V a1[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m1(I(a1), I(a1+sizeof(a1)/sizeof(a1[0])), C(5), A());
+        V a2[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m2(I(a2), I(a2+sizeof(a2)/sizeof(a2[0])), C(5), A());
+        M m3(std::move(m1), A());
+        assert(m3 == m2);
+        assert(m3.get_allocator() == A());
+        assert(m3.key_comp() == C(5));
+        LIBCPP_ASSERT(m1.empty());
+    }
+    {
+        typedef std::pair<MoveOnly, MoveOnly> V;
+        typedef std::pair<const MoveOnly, MoveOnly> VC;
+        typedef test_compare<std::less<MoveOnly> > C;
+        typedef explicit_allocator<VC> A;
+        typedef std::map<MoveOnly, MoveOnly, C, A> M;
+        typedef std::move_iterator<V*> I;
+        V a1[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m1(I(a1), I(a1+sizeof(a1)/sizeof(a1[0])), C(5), A{});
+        V a2[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m2(I(a2), I(a2+sizeof(a2)/sizeof(a2[0])), C(5), A{});
+        M m3(std::move(m1), A{});
+        assert(m3 == m2);
+        assert(m3.get_allocator() == A{});
+        assert(m3.key_comp() == C(5));
+        LIBCPP_ASSERT(m1.empty());
+    }
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.cons/move_assign.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/move_assign.pass.cpp
@@ -1,0 +1,190 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <map>
+
+// class map
+
+// map& operator=(map&& m);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "MoveOnly.h"
+#include "../../../test_compare.h"
+#include "test_allocator.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+        typedef std::pair<MoveOnly, MoveOnly> V;
+        typedef std::pair<const MoveOnly, MoveOnly> VC;
+        typedef test_compare<std::less<MoveOnly> > C;
+        typedef test_allocator<VC> A;
+        typedef std::map<MoveOnly, MoveOnly, C, A> M;
+        typedef std::move_iterator<V*> I;
+        V a1[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m1(I(a1), I(a1+sizeof(a1)/sizeof(a1[0])), C(5), A(7));
+        V a2[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m2(I(a2), I(a2+sizeof(a2)/sizeof(a2[0])), C(5), A(7));
+        M m3(C(3), A(7));
+        m3 = std::move(m1);
+        assert(m3 == m2);
+        assert(m3.get_allocator() == A(7));
+        assert(m3.key_comp() == C(5));
+        assert(m1.empty());
+    }
+    {
+        typedef std::pair<MoveOnly, MoveOnly> V;
+        typedef std::pair<const MoveOnly, MoveOnly> VC;
+        typedef test_compare<std::less<MoveOnly> > C;
+        typedef test_allocator<VC> A;
+        typedef std::map<MoveOnly, MoveOnly, C, A> M;
+        typedef std::move_iterator<V*> I;
+        V a1[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m1(I(a1), I(a1+sizeof(a1)/sizeof(a1[0])), C(5), A(7));
+        V a2[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m2(I(a2), I(a2+sizeof(a2)/sizeof(a2[0])), C(5), A(7));
+        M m3(C(3), A(5));
+        m3 = std::move(m1);
+        assert(m3 == m2);
+        assert(m3.get_allocator() == A(5));
+        assert(m3.key_comp() == C(5));
+        assert(m1.empty());
+    }
+    {
+        typedef std::pair<MoveOnly, MoveOnly> V;
+        typedef std::pair<const MoveOnly, MoveOnly> VC;
+        typedef test_compare<std::less<MoveOnly> > C;
+        typedef other_allocator<VC> A;
+        typedef std::map<MoveOnly, MoveOnly, C, A> M;
+        typedef std::move_iterator<V*> I;
+        V a1[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m1(I(a1), I(a1+sizeof(a1)/sizeof(a1[0])), C(5), A(7));
+        V a2[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m2(I(a2), I(a2+sizeof(a2)/sizeof(a2[0])), C(5), A(7));
+        M m3(C(3), A(5));
+        m3 = std::move(m1);
+        assert(m3 == m2);
+        assert(m3.get_allocator() == A(7));
+        assert(m3.key_comp() == C(5));
+        assert(m1.empty());
+    }
+    {
+        typedef std::pair<MoveOnly, MoveOnly> V;
+        typedef std::pair<const MoveOnly, MoveOnly> VC;
+        typedef test_compare<std::less<MoveOnly> > C;
+        typedef min_allocator<VC> A;
+        typedef std::map<MoveOnly, MoveOnly, C, A> M;
+        typedef std::move_iterator<V*> I;
+        V a1[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m1(I(a1), I(a1+sizeof(a1)/sizeof(a1[0])), C(5), A());
+        V a2[] =
+        {
+            V(1, 1),
+            V(1, 2),
+            V(1, 3),
+            V(2, 1),
+            V(2, 2),
+            V(2, 3),
+            V(3, 1),
+            V(3, 2),
+            V(3, 3)
+        };
+        M m2(I(a2), I(a2+sizeof(a2)/sizeof(a2[0])), C(5), A());
+        M m3(C(3), A());
+        m3 = std::move(m1);
+        assert(m3 == m2);
+        assert(m3.get_allocator() == A());
+        assert(m3.key_comp() == C(5));
+        assert(m1.empty());
+    }
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.modifiers/clear.pass.cpp
+++ b/tests/external/libcxx/map/map.modifiers/clear.pass.cpp
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// void clear() noexcept;
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+        typedef std::map<int, double> M;
+        typedef std::pair<int, double> P;
+        P ar[] =
+        {
+            P(1, 1.5),
+            P(2, 2.5),
+            P(3, 3.5),
+            P(4, 4.5),
+            P(5, 5.5),
+            P(6, 6.5),
+            P(7, 7.5),
+            P(8, 8.5),
+        };
+        M m(ar, ar + sizeof(ar)/sizeof(ar[0]));
+        assert(m.size() == 8);
+        ASSERT_NOEXCEPT(m.clear());
+        m.clear();
+        assert(m.size() == 0);
+    }
+#if TEST_STD_VER >= 11
+    {
+        typedef std::map<int, double, std::less<int>, min_allocator<std::pair<const int, double>>> M;
+        typedef std::pair<int, double> P;
+        P ar[] =
+        {
+            P(1, 1.5),
+            P(2, 2.5),
+            P(3, 3.5),
+            P(4, 4.5),
+            P(5, 5.5),
+            P(6, 6.5),
+            P(7, 7.5),
+            P(8, 8.5),
+        };
+        M m(ar, ar + sizeof(ar)/sizeof(ar[0]));
+        assert(m.size() == 8);
+        ASSERT_NOEXCEPT(m.clear());
+        m.clear();
+        assert(m.size() == 0);
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.modifiers/emplace.pass.cpp
+++ b/tests/external/libcxx/map/map.modifiers/emplace.pass.cpp
@@ -1,0 +1,165 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <map>
+
+// class map
+
+// template <class... Args>
+//   pair<iterator, bool> emplace(Args&&... args);
+
+#include <map>
+#include <cassert>
+#include <tuple>
+
+#include "test_macros.h"
+#include "../../../Emplaceable.h"
+#include "DefaultOnly.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+        typedef std::map<int, DefaultOnly> M;
+        typedef std::pair<M::iterator, bool> R;
+        M m;
+        assert(DefaultOnly::count == 0);
+        R r = m.emplace();
+        assert(r.second);
+        assert(r.first == m.begin());
+        assert(m.size() == 1);
+        assert(m.begin()->first == 0);
+        assert(m.begin()->second == DefaultOnly());
+        assert(DefaultOnly::count == 1);
+        r = m.emplace(std::piecewise_construct, std::forward_as_tuple(1),
+                                                std::forward_as_tuple());
+        assert(r.second);
+        assert(r.first == next(m.begin()));
+        assert(m.size() == 2);
+        assert(next(m.begin())->first == 1);
+        assert(next(m.begin())->second == DefaultOnly());
+        assert(DefaultOnly::count == 2);
+        r = m.emplace(std::piecewise_construct, std::forward_as_tuple(1),
+                                                std::forward_as_tuple());
+        assert(!r.second);
+        assert(r.first == next(m.begin()));
+        assert(m.size() == 2);
+        assert(next(m.begin())->first == 1);
+        assert(next(m.begin())->second == DefaultOnly());
+        assert(DefaultOnly::count == 2);
+    }
+    assert(DefaultOnly::count == 0);
+    {
+        typedef std::map<int, Emplaceable> M;
+        typedef std::pair<M::iterator, bool> R;
+        M m;
+        R r = m.emplace(std::piecewise_construct, std::forward_as_tuple(2),
+                                                  std::forward_as_tuple());
+        assert(r.second);
+        assert(r.first == m.begin());
+        assert(m.size() == 1);
+        assert(m.begin()->first == 2);
+        assert(m.begin()->second == Emplaceable());
+        r = m.emplace(std::piecewise_construct, std::forward_as_tuple(1),
+                                                std::forward_as_tuple(2, 3.5));
+        assert(r.second);
+        assert(r.first == m.begin());
+        assert(m.size() == 2);
+        assert(m.begin()->first == 1);
+        assert(m.begin()->second == Emplaceable(2, 3.5));
+        r = m.emplace(std::piecewise_construct, std::forward_as_tuple(1),
+                                                std::forward_as_tuple(2, 3.5));
+        assert(!r.second);
+        assert(r.first == m.begin());
+        assert(m.size() == 2);
+        assert(m.begin()->first == 1);
+        assert(m.begin()->second == Emplaceable(2, 3.5));
+    }
+    {
+        typedef std::map<int, double> M;
+        typedef std::pair<M::iterator, bool> R;
+        M m;
+        R r = m.emplace(M::value_type(2, 3.5));
+        assert(r.second);
+        assert(r.first == m.begin());
+        assert(m.size() == 1);
+        assert(m.begin()->first == 2);
+        assert(m.begin()->second == 3.5);
+    }
+    {
+        typedef std::map<int, DefaultOnly, std::less<int>, min_allocator<std::pair<const int, DefaultOnly>>> M;
+        typedef std::pair<M::iterator, bool> R;
+        M m;
+        assert(DefaultOnly::count == 0);
+        R r = m.emplace();
+        assert(r.second);
+        assert(r.first == m.begin());
+        assert(m.size() == 1);
+        assert(m.begin()->first == 0);
+        assert(m.begin()->second == DefaultOnly());
+        assert(DefaultOnly::count == 1);
+        r = m.emplace(std::piecewise_construct, std::forward_as_tuple(1),
+                                                std::forward_as_tuple());
+        assert(r.second);
+        assert(r.first == next(m.begin()));
+        assert(m.size() == 2);
+        assert(next(m.begin())->first == 1);
+        assert(next(m.begin())->second == DefaultOnly());
+        assert(DefaultOnly::count == 2);
+        r = m.emplace(std::piecewise_construct, std::forward_as_tuple(1),
+                                                std::forward_as_tuple());
+        assert(!r.second);
+        assert(r.first == next(m.begin()));
+        assert(m.size() == 2);
+        assert(next(m.begin())->first == 1);
+        assert(next(m.begin())->second == DefaultOnly());
+        assert(DefaultOnly::count == 2);
+    }
+    assert(DefaultOnly::count == 0);
+    {
+        typedef std::map<int, Emplaceable, std::less<int>, min_allocator<std::pair<const int, Emplaceable>>> M;
+        typedef std::pair<M::iterator, bool> R;
+        M m;
+        R r = m.emplace(std::piecewise_construct, std::forward_as_tuple(2),
+                                                  std::forward_as_tuple());
+        assert(r.second);
+        assert(r.first == m.begin());
+        assert(m.size() == 1);
+        assert(m.begin()->first == 2);
+        assert(m.begin()->second == Emplaceable());
+        r = m.emplace(std::piecewise_construct, std::forward_as_tuple(1),
+                                                std::forward_as_tuple(2, 3.5));
+        assert(r.second);
+        assert(r.first == m.begin());
+        assert(m.size() == 2);
+        assert(m.begin()->first == 1);
+        assert(m.begin()->second == Emplaceable(2, 3.5));
+        r = m.emplace(std::piecewise_construct, std::forward_as_tuple(1),
+                                                std::forward_as_tuple(2, 3.5));
+        assert(!r.second);
+        assert(r.first == m.begin());
+        assert(m.size() == 2);
+        assert(m.begin()->first == 1);
+        assert(m.begin()->second == Emplaceable(2, 3.5));
+    }
+    {
+        typedef std::map<int, double, std::less<int>, min_allocator<std::pair<const int, double>>> M;
+        typedef std::pair<M::iterator, bool> R;
+        M m;
+        R r = m.emplace(M::value_type(2, 3.5));
+        assert(r.second);
+        assert(r.first == m.begin());
+        assert(m.size() == 1);
+        assert(m.begin()->first == 2);
+        assert(m.begin()->second == 3.5);
+    }
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.modifiers/erase_iter_iter.pass.cpp
+++ b/tests/external/libcxx/map/map.modifiers/erase_iter_iter.pass.cpp
@@ -1,0 +1,159 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// iterator erase(const_iterator first, const_iterator last);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+        typedef std::map<int, double> M;
+        typedef std::pair<int, double> P;
+        typedef M::iterator I;
+        P ar[] =
+        {
+            P(1, 1.5),
+            P(2, 2.5),
+            P(3, 3.5),
+            P(4, 4.5),
+            P(5, 5.5),
+            P(6, 6.5),
+            P(7, 7.5),
+            P(8, 8.5),
+        };
+        M m(ar, ar + sizeof(ar)/sizeof(ar[0]));
+        assert(m.size() == 8);
+        I i = m.erase(m.cbegin(), m.cbegin());
+        assert(m.size() == 8);
+        assert(i == m.begin());
+        assert(m.begin()->first == 1);
+        assert(m.begin()->second == 1.5);
+        assert(next(m.begin())->first == 2);
+        assert(next(m.begin())->second == 2.5);
+        assert(next(m.begin(), 2)->first == 3);
+        assert(next(m.begin(), 2)->second == 3.5);
+        assert(next(m.begin(), 3)->first == 4);
+        assert(next(m.begin(), 3)->second == 4.5);
+        assert(next(m.begin(), 4)->first == 5);
+        assert(next(m.begin(), 4)->second == 5.5);
+        assert(next(m.begin(), 5)->first == 6);
+        assert(next(m.begin(), 5)->second == 6.5);
+        assert(next(m.begin(), 6)->first == 7);
+        assert(next(m.begin(), 6)->second == 7.5);
+        assert(next(m.begin(), 7)->first == 8);
+        assert(next(m.begin(), 7)->second == 8.5);
+
+        i = m.erase(m.cbegin(), next(m.cbegin(), 2));
+        assert(m.size() == 6);
+        assert(i == m.begin());
+        assert(next(m.begin(), 0)->first == 3);
+        assert(next(m.begin(), 0)->second == 3.5);
+        assert(next(m.begin(), 1)->first == 4);
+        assert(next(m.begin(), 1)->second == 4.5);
+        assert(next(m.begin(), 2)->first == 5);
+        assert(next(m.begin(), 2)->second == 5.5);
+        assert(next(m.begin(), 3)->first == 6);
+        assert(next(m.begin(), 3)->second == 6.5);
+        assert(next(m.begin(), 4)->first == 7);
+        assert(next(m.begin(), 4)->second == 7.5);
+        assert(next(m.begin(), 5)->first == 8);
+        assert(next(m.begin(), 5)->second == 8.5);
+
+        i = m.erase(next(m.cbegin(), 2), next(m.cbegin(), 6));
+        assert(m.size() == 2);
+        assert(i == next(m.begin(), 2));
+        assert(next(m.begin(), 0)->first == 3);
+        assert(next(m.begin(), 0)->second == 3.5);
+        assert(next(m.begin(), 1)->first == 4);
+        assert(next(m.begin(), 1)->second == 4.5);
+
+        i = m.erase(m.cbegin(), m.cend());
+        assert(m.size() == 0);
+        assert(i == m.begin());
+        assert(i == m.end());
+    }
+#if TEST_STD_VER >= 11
+    {
+        typedef std::map<int, double, std::less<int>, min_allocator<std::pair<const int, double>>> M;
+        typedef std::pair<int, double> P;
+        typedef M::iterator I;
+        P ar[] =
+        {
+            P(1, 1.5),
+            P(2, 2.5),
+            P(3, 3.5),
+            P(4, 4.5),
+            P(5, 5.5),
+            P(6, 6.5),
+            P(7, 7.5),
+            P(8, 8.5),
+        };
+        M m(ar, ar + sizeof(ar)/sizeof(ar[0]));
+        assert(m.size() == 8);
+        I i = m.erase(m.cbegin(), m.cbegin());
+        assert(m.size() == 8);
+        assert(i == m.begin());
+        assert(m.begin()->first == 1);
+        assert(m.begin()->second == 1.5);
+        assert(next(m.begin())->first == 2);
+        assert(next(m.begin())->second == 2.5);
+        assert(next(m.begin(), 2)->first == 3);
+        assert(next(m.begin(), 2)->second == 3.5);
+        assert(next(m.begin(), 3)->first == 4);
+        assert(next(m.begin(), 3)->second == 4.5);
+        assert(next(m.begin(), 4)->first == 5);
+        assert(next(m.begin(), 4)->second == 5.5);
+        assert(next(m.begin(), 5)->first == 6);
+        assert(next(m.begin(), 5)->second == 6.5);
+        assert(next(m.begin(), 6)->first == 7);
+        assert(next(m.begin(), 6)->second == 7.5);
+        assert(next(m.begin(), 7)->first == 8);
+        assert(next(m.begin(), 7)->second == 8.5);
+
+        i = m.erase(m.cbegin(), next(m.cbegin(), 2));
+        assert(m.size() == 6);
+        assert(i == m.begin());
+        assert(next(m.begin(), 0)->first == 3);
+        assert(next(m.begin(), 0)->second == 3.5);
+        assert(next(m.begin(), 1)->first == 4);
+        assert(next(m.begin(), 1)->second == 4.5);
+        assert(next(m.begin(), 2)->first == 5);
+        assert(next(m.begin(), 2)->second == 5.5);
+        assert(next(m.begin(), 3)->first == 6);
+        assert(next(m.begin(), 3)->second == 6.5);
+        assert(next(m.begin(), 4)->first == 7);
+        assert(next(m.begin(), 4)->second == 7.5);
+        assert(next(m.begin(), 5)->first == 8);
+        assert(next(m.begin(), 5)->second == 8.5);
+
+        i = m.erase(next(m.cbegin(), 2), next(m.cbegin(), 6));
+        assert(m.size() == 2);
+        assert(i == next(m.begin(), 2));
+        assert(next(m.begin(), 0)->first == 3);
+        assert(next(m.begin(), 0)->second == 3.5);
+        assert(next(m.begin(), 1)->first == 4);
+        assert(next(m.begin(), 1)->second == 4.5);
+
+        i = m.erase(m.cbegin(), m.cend());
+        assert(m.size() == 0);
+        assert(i == m.begin());
+        assert(i == m.end());
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.modifiers/erase_key.pass.cpp
+++ b/tests/external/libcxx/map/map.modifiers/erase_key.pass.cpp
@@ -1,0 +1,277 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// size_type erase(const key_type& k);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+        typedef std::map<int, double> M;
+        typedef std::pair<int, double> P;
+        typedef M::size_type R;
+        P ar[] =
+        {
+            P(1, 1.5),
+            P(2, 2.5),
+            P(3, 3.5),
+            P(4, 4.5),
+            P(5, 5.5),
+            P(6, 6.5),
+            P(7, 7.5),
+            P(8, 8.5),
+        };
+        M m(ar, ar + sizeof(ar)/sizeof(ar[0]));
+        assert(m.size() == 8);
+        R s = m.erase(9);
+        assert(s == 0);
+        assert(m.size() == 8);
+        assert(m.begin()->first == 1);
+        assert(m.begin()->second == 1.5);
+        assert(next(m.begin())->first == 2);
+        assert(next(m.begin())->second == 2.5);
+        assert(next(m.begin(), 2)->first == 3);
+        assert(next(m.begin(), 2)->second == 3.5);
+        assert(next(m.begin(), 3)->first == 4);
+        assert(next(m.begin(), 3)->second == 4.5);
+        assert(next(m.begin(), 4)->first == 5);
+        assert(next(m.begin(), 4)->second == 5.5);
+        assert(next(m.begin(), 5)->first == 6);
+        assert(next(m.begin(), 5)->second == 6.5);
+        assert(next(m.begin(), 6)->first == 7);
+        assert(next(m.begin(), 6)->second == 7.5);
+        assert(next(m.begin(), 7)->first == 8);
+        assert(next(m.begin(), 7)->second == 8.5);
+
+        s = m.erase(4);
+        assert(m.size() == 7);
+        assert(s == 1);
+        assert(m.begin()->first == 1);
+        assert(m.begin()->second == 1.5);
+        assert(next(m.begin())->first == 2);
+        assert(next(m.begin())->second == 2.5);
+        assert(next(m.begin(), 2)->first == 3);
+        assert(next(m.begin(), 2)->second == 3.5);
+        assert(next(m.begin(), 3)->first == 5);
+        assert(next(m.begin(), 3)->second == 5.5);
+        assert(next(m.begin(), 4)->first == 6);
+        assert(next(m.begin(), 4)->second == 6.5);
+        assert(next(m.begin(), 5)->first == 7);
+        assert(next(m.begin(), 5)->second == 7.5);
+        assert(next(m.begin(), 6)->first == 8);
+        assert(next(m.begin(), 6)->second == 8.5);
+
+        s = m.erase(1);
+        assert(m.size() == 6);
+        assert(s == 1);
+        assert(m.begin()->first == 2);
+        assert(m.begin()->second == 2.5);
+        assert(next(m.begin())->first == 3);
+        assert(next(m.begin())->second == 3.5);
+        assert(next(m.begin(), 2)->first == 5);
+        assert(next(m.begin(), 2)->second == 5.5);
+        assert(next(m.begin(), 3)->first == 6);
+        assert(next(m.begin(), 3)->second == 6.5);
+        assert(next(m.begin(), 4)->first == 7);
+        assert(next(m.begin(), 4)->second == 7.5);
+        assert(next(m.begin(), 5)->first == 8);
+        assert(next(m.begin(), 5)->second == 8.5);
+
+        s = m.erase(8);
+        assert(m.size() == 5);
+        assert(s == 1);
+        assert(m.begin()->first == 2);
+        assert(m.begin()->second == 2.5);
+        assert(next(m.begin())->first == 3);
+        assert(next(m.begin())->second == 3.5);
+        assert(next(m.begin(), 2)->first == 5);
+        assert(next(m.begin(), 2)->second == 5.5);
+        assert(next(m.begin(), 3)->first == 6);
+        assert(next(m.begin(), 3)->second == 6.5);
+        assert(next(m.begin(), 4)->first == 7);
+        assert(next(m.begin(), 4)->second == 7.5);
+
+        s = m.erase(3);
+        assert(m.size() == 4);
+        assert(s == 1);
+        assert(m.begin()->first == 2);
+        assert(m.begin()->second == 2.5);
+        assert(next(m.begin())->first == 5);
+        assert(next(m.begin())->second == 5.5);
+        assert(next(m.begin(), 2)->first == 6);
+        assert(next(m.begin(), 2)->second == 6.5);
+        assert(next(m.begin(), 3)->first == 7);
+        assert(next(m.begin(), 3)->second == 7.5);
+
+        s = m.erase(6);
+        assert(m.size() == 3);
+        assert(s == 1);
+        assert(m.begin()->first == 2);
+        assert(m.begin()->second == 2.5);
+        assert(next(m.begin())->first == 5);
+        assert(next(m.begin())->second == 5.5);
+        assert(next(m.begin(), 2)->first == 7);
+        assert(next(m.begin(), 2)->second == 7.5);
+
+        s = m.erase(7);
+        assert(m.size() == 2);
+        assert(s == 1);
+        assert(m.begin()->first == 2);
+        assert(m.begin()->second == 2.5);
+        assert(next(m.begin())->first == 5);
+        assert(next(m.begin())->second == 5.5);
+
+        s = m.erase(2);
+        assert(m.size() == 1);
+        assert(s == 1);
+        assert(m.begin()->first == 5);
+        assert(m.begin()->second == 5.5);
+
+        s = m.erase(5);
+        assert(m.size() == 0);
+        assert(s == 1);
+    }
+#if TEST_STD_VER >= 11
+    {
+        typedef std::map<int, double, std::less<int>, min_allocator<std::pair<const int, double>>> M;
+        typedef std::pair<int, double> P;
+        typedef M::size_type R;
+        P ar[] =
+        {
+            P(1, 1.5),
+            P(2, 2.5),
+            P(3, 3.5),
+            P(4, 4.5),
+            P(5, 5.5),
+            P(6, 6.5),
+            P(7, 7.5),
+            P(8, 8.5),
+        };
+        M m(ar, ar + sizeof(ar)/sizeof(ar[0]));
+        assert(m.size() == 8);
+        R s = m.erase(9);
+        assert(s == 0);
+        assert(m.size() == 8);
+        assert(m.begin()->first == 1);
+        assert(m.begin()->second == 1.5);
+        assert(next(m.begin())->first == 2);
+        assert(next(m.begin())->second == 2.5);
+        assert(next(m.begin(), 2)->first == 3);
+        assert(next(m.begin(), 2)->second == 3.5);
+        assert(next(m.begin(), 3)->first == 4);
+        assert(next(m.begin(), 3)->second == 4.5);
+        assert(next(m.begin(), 4)->first == 5);
+        assert(next(m.begin(), 4)->second == 5.5);
+        assert(next(m.begin(), 5)->first == 6);
+        assert(next(m.begin(), 5)->second == 6.5);
+        assert(next(m.begin(), 6)->first == 7);
+        assert(next(m.begin(), 6)->second == 7.5);
+        assert(next(m.begin(), 7)->first == 8);
+        assert(next(m.begin(), 7)->second == 8.5);
+
+        s = m.erase(4);
+        assert(m.size() == 7);
+        assert(s == 1);
+        assert(m.begin()->first == 1);
+        assert(m.begin()->second == 1.5);
+        assert(next(m.begin())->first == 2);
+        assert(next(m.begin())->second == 2.5);
+        assert(next(m.begin(), 2)->first == 3);
+        assert(next(m.begin(), 2)->second == 3.5);
+        assert(next(m.begin(), 3)->first == 5);
+        assert(next(m.begin(), 3)->second == 5.5);
+        assert(next(m.begin(), 4)->first == 6);
+        assert(next(m.begin(), 4)->second == 6.5);
+        assert(next(m.begin(), 5)->first == 7);
+        assert(next(m.begin(), 5)->second == 7.5);
+        assert(next(m.begin(), 6)->first == 8);
+        assert(next(m.begin(), 6)->second == 8.5);
+
+        s = m.erase(1);
+        assert(m.size() == 6);
+        assert(s == 1);
+        assert(m.begin()->first == 2);
+        assert(m.begin()->second == 2.5);
+        assert(next(m.begin())->first == 3);
+        assert(next(m.begin())->second == 3.5);
+        assert(next(m.begin(), 2)->first == 5);
+        assert(next(m.begin(), 2)->second == 5.5);
+        assert(next(m.begin(), 3)->first == 6);
+        assert(next(m.begin(), 3)->second == 6.5);
+        assert(next(m.begin(), 4)->first == 7);
+        assert(next(m.begin(), 4)->second == 7.5);
+        assert(next(m.begin(), 5)->first == 8);
+        assert(next(m.begin(), 5)->second == 8.5);
+
+        s = m.erase(8);
+        assert(m.size() == 5);
+        assert(s == 1);
+        assert(m.begin()->first == 2);
+        assert(m.begin()->second == 2.5);
+        assert(next(m.begin())->first == 3);
+        assert(next(m.begin())->second == 3.5);
+        assert(next(m.begin(), 2)->first == 5);
+        assert(next(m.begin(), 2)->second == 5.5);
+        assert(next(m.begin(), 3)->first == 6);
+        assert(next(m.begin(), 3)->second == 6.5);
+        assert(next(m.begin(), 4)->first == 7);
+        assert(next(m.begin(), 4)->second == 7.5);
+
+        s = m.erase(3);
+        assert(m.size() == 4);
+        assert(s == 1);
+        assert(m.begin()->first == 2);
+        assert(m.begin()->second == 2.5);
+        assert(next(m.begin())->first == 5);
+        assert(next(m.begin())->second == 5.5);
+        assert(next(m.begin(), 2)->first == 6);
+        assert(next(m.begin(), 2)->second == 6.5);
+        assert(next(m.begin(), 3)->first == 7);
+        assert(next(m.begin(), 3)->second == 7.5);
+
+        s = m.erase(6);
+        assert(m.size() == 3);
+        assert(s == 1);
+        assert(m.begin()->first == 2);
+        assert(m.begin()->second == 2.5);
+        assert(next(m.begin())->first == 5);
+        assert(next(m.begin())->second == 5.5);
+        assert(next(m.begin(), 2)->first == 7);
+        assert(next(m.begin(), 2)->second == 7.5);
+
+        s = m.erase(7);
+        assert(m.size() == 2);
+        assert(s == 1);
+        assert(m.begin()->first == 2);
+        assert(m.begin()->second == 2.5);
+        assert(next(m.begin())->first == 5);
+        assert(next(m.begin())->second == 5.5);
+
+        s = m.erase(2);
+        assert(m.size() == 1);
+        assert(s == 1);
+        assert(m.begin()->first == 5);
+        assert(m.begin()->second == 5.5);
+
+        s = m.erase(5);
+        assert(m.size() == 0);
+        assert(s == 1);
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.modifiers/insert_cv.pass.cpp
+++ b/tests/external/libcxx/map/map.modifiers/insert_cv.pass.cpp
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// pair<iterator, bool> insert(const value_type& v);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+
+template <class Container>
+void do_insert_cv_test()
+{
+    typedef Container M;
+    typedef std::pair<typename M::iterator, bool> R;
+    typedef typename M::value_type VT;
+    M m;
+
+    const VT v1(2, 2.5);
+    R r = m.insert(v1);
+    assert(r.second);
+    assert(r.first == m.begin());
+    assert(m.size() == 1);
+    assert(r.first->first == 2);
+    assert(r.first->second == 2.5);
+
+    const VT v2(1, 1.5);
+    r = m.insert(v2);
+    assert(r.second);
+    assert(r.first == m.begin());
+    assert(m.size() == 2);
+    assert(r.first->first == 1);
+    assert(r.first->second == 1.5);
+
+    const VT v3(3, 3.5);
+    r = m.insert(v3);
+    assert(r.second);
+    assert(r.first == prev(m.end()));
+    assert(m.size() == 3);
+    assert(r.first->first == 3);
+    assert(r.first->second == 3.5);
+
+    const VT v4(3, 4.5);
+    r = m.insert(v4);
+    assert(!r.second);
+    assert(r.first == prev(m.end()));
+    assert(m.size() == 3);
+    assert(r.first->first == 3);
+    assert(r.first->second == 3.5);
+}
+
+int main(int, char**)
+{
+    do_insert_cv_test<std::map<int, double> >();
+#if TEST_STD_VER >= 11
+    {
+        typedef std::map<int, double, std::less<int>, min_allocator<std::pair<const int, double>>> M;
+        do_insert_cv_test<M>();
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.modifiers/insert_initializer_list.pass.cpp
+++ b/tests/external/libcxx/map/map.modifiers/insert_initializer_list.pass.cpp
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <map>
+
+// class map
+
+// void insert(initializer_list<value_type> il);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::pair<const int, double> V;
+    std::map<int, double> m =
+                            {
+                                {1, 1},
+                                {1, 1.5},
+                                {1, 2},
+                                {3, 1},
+                                {3, 1.5},
+                                {3, 2}
+                            };
+    m.insert({
+                 {2, 1},
+                 {2, 1.5},
+                 {2, 2},
+             });
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    }
+    {
+    typedef std::pair<const int, double> V;
+    std::map<int, double, std::less<int>, min_allocator<V>> m =
+                            {
+                                {1, 1},
+                                {1, 1.5},
+                                {1, 2},
+                                {3, 1},
+                                {3, 1.5},
+                                {3, 2}
+                            };
+    m.insert({
+                 {2, 1},
+                 {2, 1.5},
+                 {2, 2},
+             });
+    assert(m.size() == 3);
+    assert(distance(m.begin(), m.end()) == 3);
+    assert(*m.begin() == V(1, 1));
+    assert(*next(m.begin()) == V(2, 1));
+    assert(*next(m.begin(), 2) == V(3, 1));
+    }
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.modifiers/insert_iter_iter.pass.cpp
+++ b/tests/external/libcxx/map/map.modifiers/insert_iter_iter.pass.cpp
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// template <class InputIterator>
+//   void insert(InputIterator first, InputIterator last);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "test_iterators.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+        typedef std::map<int, double> M;
+        typedef std::pair<int, double> P;
+        P ar[] =
+        {
+            P(1, 1),
+            P(1, 1.5),
+            P(1, 2),
+            P(2, 1),
+            P(2, 1.5),
+            P(2, 2),
+            P(3, 1),
+            P(3, 1.5),
+            P(3, 2),
+        };
+        M m;
+        m.insert(input_iterator<P*>(ar), input_iterator<P*>(ar + sizeof(ar)/sizeof(ar[0])));
+        assert(m.size() == 3);
+        assert(m.begin()->first == 1);
+        assert(m.begin()->second == 1);
+        assert(next(m.begin())->first == 2);
+        assert(next(m.begin())->second == 1);
+        assert(next(m.begin(), 2)->first == 3);
+        assert(next(m.begin(), 2)->second == 1);
+    }
+#if TEST_STD_VER >= 11
+    {
+        typedef std::map<int, double, std::less<int>, min_allocator<std::pair<const int, double>>> M;
+        typedef std::pair<int, double> P;
+        P ar[] =
+        {
+            P(1, 1),
+            P(1, 1.5),
+            P(1, 2),
+            P(2, 1),
+            P(2, 1.5),
+            P(2, 2),
+            P(3, 1),
+            P(3, 1.5),
+            P(3, 2),
+        };
+        M m;
+        m.insert(input_iterator<P*>(ar), input_iterator<P*>(ar + sizeof(ar)/sizeof(ar[0])));
+        assert(m.size() == 3);
+        assert(m.begin()->first == 1);
+        assert(m.begin()->second == 1);
+        assert(next(m.begin())->first == 2);
+        assert(next(m.begin())->second == 1);
+        assert(next(m.begin(), 2)->first == 3);
+        assert(next(m.begin(), 2)->second == 1);
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.modifiers/insert_rv.pass.cpp
+++ b/tests/external/libcxx/map/map.modifiers/insert_rv.pass.cpp
@@ -1,0 +1,108 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03
+
+// <map>
+
+// class map
+
+// pair<iterator, bool> insert( value_type&& v);  // C++17 and later
+// template <class P>
+//   pair<iterator, bool> insert(P&& p);
+
+#include <map>
+#include <cassert>
+
+#include "MoveOnly.h"
+#include "min_allocator.h"
+#include "test_macros.h"
+
+template <class Container, class Pair>
+void do_insert_rv_test()
+{
+    typedef Container M;
+    typedef Pair P;
+    typedef std::pair<typename M::iterator, bool> R;
+    M m;
+    R r = m.insert(P(2, 2));
+    assert(r.second);
+    assert(r.first == m.begin());
+    assert(m.size() == 1);
+    assert(r.first->first == 2);
+    assert(r.first->second == 2);
+
+    r = m.insert(P(1, 1));
+    assert(r.second);
+    assert(r.first == m.begin());
+    assert(m.size() == 2);
+    assert(r.first->first == 1);
+    assert(r.first->second == 1);
+
+    r = m.insert(P(3, 3));
+    assert(r.second);
+    assert(r.first == prev(m.end()));
+    assert(m.size() == 3);
+    assert(r.first->first == 3);
+    assert(r.first->second == 3);
+
+    r = m.insert(P(3, 3));
+    assert(!r.second);
+    assert(r.first == prev(m.end()));
+    assert(m.size() == 3);
+    assert(r.first->first == 3);
+    assert(r.first->second == 3);
+}
+
+int main(int, char**)
+{
+    do_insert_rv_test<std::map<int, MoveOnly>, std::pair<int, MoveOnly>>();
+    do_insert_rv_test<std::map<int, MoveOnly>, std::pair<const int, MoveOnly>>();
+
+    {
+        typedef std::map<int, MoveOnly, std::less<int>, min_allocator<std::pair<const int, MoveOnly>>> M;
+        typedef std::pair<int, MoveOnly> P;
+        typedef std::pair<const int, MoveOnly> CP;
+        do_insert_rv_test<M, P>();
+        do_insert_rv_test<M, CP>();
+    }
+    {
+        typedef std::map<int, MoveOnly> M;
+        typedef std::pair<M::iterator, bool> R;
+        M m;
+        R r = m.insert({2, MoveOnly(2)});
+        assert(r.second);
+        assert(r.first == m.begin());
+        assert(m.size() == 1);
+        assert(r.first->first == 2);
+        assert(r.first->second == 2);
+
+        r = m.insert({1, MoveOnly(1)});
+        assert(r.second);
+        assert(r.first == m.begin());
+        assert(m.size() == 2);
+        assert(r.first->first == 1);
+        assert(r.first->second == 1);
+
+        r = m.insert({3, MoveOnly(3)});
+        assert(r.second);
+        assert(r.first == prev(m.end()));
+        assert(m.size() == 3);
+        assert(r.first->first == 3);
+        assert(r.first->second == 3);
+
+        r = m.insert({3, MoveOnly(3)});
+        assert(!r.second);
+        assert(r.first == prev(m.end()));
+        assert(m.size() == 3);
+        assert(r.first->first == 3);
+        assert(r.first->second == 3);
+    }
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.modifiers/try.emplace.pass.cpp
+++ b/tests/external/libcxx/map/map.modifiers/try.emplace.pass.cpp
@@ -1,0 +1,185 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// UNSUPPORTED: c++98, c++03, c++11, c++14
+
+// <map>
+
+// class map
+
+// template <class... Args>
+//  pair<iterator, bool> try_emplace(const key_type& k, Args&&... args);          // C++17
+// template <class... Args>
+//  pair<iterator, bool> try_emplace(key_type&& k, Args&&... args);               // C++17
+// template <class... Args>
+//  iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args); // C++17
+// template <class... Args>
+//  iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args);      // C++17
+
+#include <map>
+#include <cassert>
+#include <tuple>
+
+#include "test_macros.h"
+
+class Moveable
+{
+    Moveable(const Moveable&);
+    Moveable& operator=(const Moveable&);
+
+    int int_;
+    double double_;
+public:
+    Moveable() : int_(0), double_(0) {}
+    Moveable(int i, double d) : int_(i), double_(d) {}
+    Moveable(Moveable&& x)
+        : int_(x.int_), double_(x.double_)
+            {x.int_ = -1; x.double_ = -1;}
+    Moveable& operator=(Moveable&& x)
+        {int_ = x.int_; x.int_ = -1;
+         double_ = x.double_; x.double_ = -1;
+         return *this;
+        }
+
+    bool operator==(const Moveable& x) const
+        {return int_ == x.int_ && double_ == x.double_;}
+    bool operator<(const Moveable& x) const
+        {return int_ < x.int_ || (int_ == x.int_ && double_ < x.double_);}
+
+    int get() const {return int_;}
+    bool moved() const {return int_ == -1;}
+};
+
+
+int main(int, char**)
+{
+    { // pair<iterator, bool> try_emplace(const key_type& k, Args&&... args);
+        typedef std::map<int, Moveable> M;
+        typedef std::pair<M::iterator, bool> R;
+        M m;
+        R r;
+        for (int i = 0; i < 20; i += 2)
+            m.emplace (i, Moveable(i, (double) i));
+        assert(m.size() == 10);
+
+        Moveable mv1(3, 3.0);
+        for (int i=0; i < 20; i += 2)
+        {
+            r = m.try_emplace(i, std::move(mv1));
+            assert(m.size() == 10);
+            assert(!r.second);              // was not inserted
+            assert(!mv1.moved());           // was not moved from
+            assert(r.first->first == i);    // key
+        }
+
+        r = m.try_emplace(-1, std::move(mv1));
+        assert(m.size() == 11);
+        assert(r.second);                   // was inserted
+        assert(mv1.moved());                // was moved from
+        assert(r.first->first == -1);       // key
+        assert(r.first->second.get() == 3); // value
+
+        Moveable mv2(5, 3.0);
+        r = m.try_emplace(5, std::move(mv2));
+        assert(m.size() == 12);
+        assert(r.second);                   // was inserted
+        assert(mv2.moved());                // was moved from
+        assert(r.first->first == 5);        // key
+        assert(r.first->second.get() == 5); // value
+
+        Moveable mv3(-1, 3.0);
+        r = m.try_emplace(117, std::move(mv2));
+        assert(m.size() == 13);
+        assert(r.second);                    // was inserted
+        assert(mv2.moved());                 // was moved from
+        assert(r.first->first == 117);       // key
+        assert(r.first->second.get() == -1); // value
+    }
+
+    {  // pair<iterator, bool> try_emplace(key_type&& k, Args&&... args);
+        typedef std::map<Moveable, Moveable> M;
+        typedef std::pair<M::iterator, bool> R;
+        M m;
+        R r;
+        for ( int i = 0; i < 20; i += 2 )
+            m.emplace ( Moveable(i, (double) i), Moveable(i+1, (double) i+1));
+        assert(m.size() == 10);
+
+        Moveable mvkey1(2, 2.0);
+        Moveable mv1(4, 4.0);
+        r = m.try_emplace(std::move(mvkey1), std::move(mv1));
+        assert(m.size() == 10);
+        assert(!r.second);                 // was not inserted
+        assert(!mv1.moved());              // was not moved from
+        assert(!mvkey1.moved());           // was not moved from
+        assert(r.first->first == mvkey1);  // key
+
+        Moveable mvkey2(3, 3.0);
+        r = m.try_emplace(std::move(mvkey2), std::move(mv1));
+        assert(m.size() == 11);
+        assert(r.second);                   // was inserted
+        assert(mv1.moved());                // was moved from
+        assert(mvkey2.moved());             // was moved from
+        assert(r.first->first.get()  == 3); // key
+        assert(r.first->second.get() == 4); // value
+    }
+
+    {  // iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args);
+        typedef std::map<int, Moveable> M;
+        M m;
+        M::iterator r;
+        for ( int i = 0; i < 20; i += 2 )
+            m.try_emplace ( i, Moveable(i, (double) i));
+        assert(m.size() == 10);
+        M::const_iterator it = m.find(2);
+
+        Moveable mv1(3, 3.0);
+        for (int i=0; i < 20; i += 2)
+        {
+            r = m.try_emplace(it, i, std::move(mv1));
+            assert(m.size() == 10);
+            assert(!mv1.moved());         // was not moved from
+            assert(r->first == i);        // key
+            assert(r->second.get() == i); // value
+        }
+
+        r = m.try_emplace(it, 3, std::move(mv1));
+        assert(m.size() == 11);
+        assert(mv1.moved());          // was moved from
+        assert(r->first == 3);        // key
+        assert(r->second.get() == 3); // value
+    }
+
+    {  // iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args);
+        typedef std::map<Moveable, Moveable> M;
+        M m;
+        M::iterator r;
+        for ( int i = 0; i < 20; i += 2 )
+            m.emplace ( Moveable(i, (double) i), Moveable(i+1, (double) i+1));
+        assert(m.size() == 10);
+        M::const_iterator it = std::next(m.cbegin());
+
+        Moveable mvkey1(2, 2.0);
+        Moveable mv1(4, 4.0);
+        r = m.try_emplace(it, std::move(mvkey1), std::move(mv1));
+        assert(m.size() == 10);
+        assert(!mv1.moved());        // was not moved from
+        assert(!mvkey1.moved());     // was not moved from
+        assert(r->first == mvkey1);  // key
+
+        Moveable mvkey2(3, 3.0);
+        r = m.try_emplace(it, std::move(mvkey2), std::move(mv1));
+        assert(m.size() == 11);
+        assert(mv1.moved());          // was moved from
+        assert(mvkey2.moved());       // was moved from
+        assert(r->first.get()  == 3); // key
+        assert(r->second.get() == 4); // value
+    }
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.ops/count.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/count.pass.cpp
@@ -1,0 +1,195 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// size_type count(const key_type& k) const;
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+#include "private_constructor.h"
+#include "is_transparent.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::pair<const int, double> V;
+    typedef std::map<int, double> M;
+    {
+        typedef M::size_type R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        const M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.count(5);
+        assert(r == 1);
+        r = m.count(6);
+        assert(r == 1);
+        r = m.count(7);
+        assert(r == 1);
+        r = m.count(8);
+        assert(r == 1);
+        r = m.count(9);
+        assert(r == 1);
+        r = m.count(10);
+        assert(r == 1);
+        r = m.count(11);
+        assert(r == 1);
+        r = m.count(12);
+        assert(r == 1);
+        r = m.count(4);
+        assert(r == 0);
+    }
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef std::pair<const int, double> V;
+    typedef std::map<int, double, std::less<int>, min_allocator<V>> M;
+    {
+        typedef M::size_type R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        const M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.count(5);
+        assert(r == 1);
+        r = m.count(6);
+        assert(r == 1);
+        r = m.count(7);
+        assert(r == 1);
+        r = m.count(8);
+        assert(r == 1);
+        r = m.count(9);
+        assert(r == 1);
+        r = m.count(10);
+        assert(r == 1);
+        r = m.count(11);
+        assert(r == 1);
+        r = m.count(12);
+        assert(r == 1);
+        r = m.count(4);
+        assert(r == 0);
+    }
+    }
+#endif
+#if TEST_STD_VER > 11
+    {
+    typedef std::pair<const int, double> V;
+    typedef std::map<int, double, std::less <>> M;
+    typedef M::size_type R;
+
+    V ar[] =
+    {
+        V(5, 5),
+        V(6, 6),
+        V(7, 7),
+        V(8, 8),
+        V(9, 9),
+        V(10, 10),
+        V(11, 11),
+        V(12, 12)
+    };
+    const M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+    R r = m.count(5);
+    assert(r == 1);
+    r = m.count(6);
+    assert(r == 1);
+    r = m.count(7);
+    assert(r == 1);
+    r = m.count(8);
+    assert(r == 1);
+    r = m.count(9);
+    assert(r == 1);
+    r = m.count(10);
+    assert(r == 1);
+    r = m.count(11);
+    assert(r == 1);
+    r = m.count(12);
+    assert(r == 1);
+    r = m.count(4);
+    assert(r == 0);
+
+    r = m.count(C2Int(5));
+    assert(r == 1);
+    r = m.count(C2Int(6));
+    assert(r == 1);
+    r = m.count(C2Int(7));
+    assert(r == 1);
+    r = m.count(C2Int(8));
+    assert(r == 1);
+    r = m.count(C2Int(9));
+    assert(r == 1);
+    r = m.count(C2Int(10));
+    assert(r == 1);
+    r = m.count(C2Int(11));
+    assert(r == 1);
+    r = m.count(C2Int(12));
+    assert(r == 1);
+    r = m.count(C2Int(4));
+    assert(r == 0);
+    }
+
+    {
+    typedef PrivateConstructor PC;
+    typedef std::map<PC, double, std::less<>> M;
+    typedef M::size_type R;
+
+    M m;
+    m [ PC::make(5)  ] = 5;
+    m [ PC::make(6)  ] = 6;
+    m [ PC::make(7)  ] = 7;
+    m [ PC::make(8)  ] = 8;
+    m [ PC::make(9)  ] = 9;
+    m [ PC::make(10) ] = 10;
+    m [ PC::make(11) ] = 11;
+    m [ PC::make(12) ] = 12;
+
+    R r = m.count(5);
+    assert(r == 1);
+    r = m.count(6);
+    assert(r == 1);
+    r = m.count(7);
+    assert(r == 1);
+    r = m.count(8);
+    assert(r == 1);
+    r = m.count(9);
+    assert(r == 1);
+    r = m.count(10);
+    assert(r == 1);
+    r = m.count(11);
+    assert(r == 1);
+    r = m.count(12);
+    assert(r == 1);
+    r = m.count(4);
+    assert(r == 0);
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.ops/count0.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/count0.pass.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// XFAIL: c++98, c++03, c++11
+
+// <map>
+
+// class map
+
+//       iterator find(const key_type& k);
+// const_iterator find(const key_type& k) const;
+//
+//   The member function templates find, count, lower_bound, upper_bound, and
+// equal_range shall not participate in overload resolution unless the
+// qualified-id Compare::is_transparent is valid and denotes a type
+
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "is_transparent.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::map<int, double, transparent_less> M;
+    assert(M().count(C2Int{5}) == 0);
+    }
+    {
+    typedef std::map<int, double, transparent_less_not_referenceable> M;
+    assert(M().count(C2Int{5}) == 0);
+    }
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.ops/count_transparent.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/count_transparent.pass.cpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03, c++11
+
+// <map>
+
+// class map
+
+// template<typename K>
+//   size_type count(const K& x) const;        // C++14
+
+#include <cassert>
+#include <map>
+#include <utility>
+
+#include "min_allocator.h"
+#include "private_constructor.h"
+#include "test_macros.h"
+
+struct Comp {
+  using is_transparent = void;
+
+  bool operator()(const std::pair<int, int> &lhs,
+                  const std::pair<int, int> &rhs) const {
+    return lhs < rhs;
+  }
+
+  bool operator()(const std::pair<int, int> &lhs, int rhs) const {
+    return lhs.first < rhs;
+  }
+
+  bool operator()(int lhs, const std::pair<int, int> &rhs) const {
+    return lhs < rhs.first;
+  }
+};
+
+int main(int, char**) {
+  std::map<std::pair<int, int>, int, Comp> s{
+      {{2, 1}, 1}, {{1, 2}, 2}, {{1, 3}, 3}, {{1, 4}, 4}, {{2, 2}, 5}};
+
+  auto cnt = s.count(1);
+  assert(cnt == 3);
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.ops/equal_range.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/equal_range.pass.cpp
@@ -1,0 +1,492 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// pair<iterator,iterator>             equal_range(const key_type& k);
+// pair<const_iterator,const_iterator> equal_range(const key_type& k) const;
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+#include "private_constructor.h"
+#include "is_transparent.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::pair<const int, double> V;
+    typedef std::map<int, double> M;
+    {
+        typedef std::pair<M::iterator, M::iterator> R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(7, 6),
+            V(9, 7),
+            V(11, 8),
+            V(13, 9),
+            V(15, 10),
+            V(17, 11),
+            V(19, 12)
+        };
+        M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.equal_range(5);
+        assert(r.first == next(m.begin(), 0));
+        assert(r.second == next(m.begin(), 1));
+        r = m.equal_range(7);
+        assert(r.first == next(m.begin(), 1));
+        assert(r.second == next(m.begin(), 2));
+        r = m.equal_range(9);
+        assert(r.first == next(m.begin(), 2));
+        assert(r.second == next(m.begin(), 3));
+        r = m.equal_range(11);
+        assert(r.first == next(m.begin(), 3));
+        assert(r.second == next(m.begin(), 4));
+        r = m.equal_range(13);
+        assert(r.first == next(m.begin(), 4));
+        assert(r.second == next(m.begin(), 5));
+        r = m.equal_range(15);
+        assert(r.first == next(m.begin(), 5));
+        assert(r.second == next(m.begin(), 6));
+        r = m.equal_range(17);
+        assert(r.first == next(m.begin(), 6));
+        assert(r.second == next(m.begin(), 7));
+        r = m.equal_range(19);
+        assert(r.first == next(m.begin(), 7));
+        assert(r.second == next(m.begin(), 8));
+        r = m.equal_range(4);
+        assert(r.first == next(m.begin(), 0));
+        assert(r.second == next(m.begin(), 0));
+        r = m.equal_range(6);
+        assert(r.first == next(m.begin(), 1));
+        assert(r.second == next(m.begin(), 1));
+        r = m.equal_range(8);
+        assert(r.first == next(m.begin(), 2));
+        assert(r.second == next(m.begin(), 2));
+        r = m.equal_range(10);
+        assert(r.first == next(m.begin(), 3));
+        assert(r.second == next(m.begin(), 3));
+        r = m.equal_range(12);
+        assert(r.first == next(m.begin(), 4));
+        assert(r.second == next(m.begin(), 4));
+        r = m.equal_range(14);
+        assert(r.first == next(m.begin(), 5));
+        assert(r.second == next(m.begin(), 5));
+        r = m.equal_range(16);
+        assert(r.first == next(m.begin(), 6));
+        assert(r.second == next(m.begin(), 6));
+        r = m.equal_range(18);
+        assert(r.first == next(m.begin(), 7));
+        assert(r.second == next(m.begin(), 7));
+        r = m.equal_range(20);
+        assert(r.first == next(m.begin(), 8));
+        assert(r.second == next(m.begin(), 8));
+    }
+    {
+        typedef std::pair<M::const_iterator, M::const_iterator> R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(7, 6),
+            V(9, 7),
+            V(11, 8),
+            V(13, 9),
+            V(15, 10),
+            V(17, 11),
+            V(19, 12)
+        };
+        const M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.equal_range(5);
+        assert(r.first == next(m.begin(), 0));
+        assert(r.second == next(m.begin(), 1));
+        r = m.equal_range(7);
+        assert(r.first == next(m.begin(), 1));
+        assert(r.second == next(m.begin(), 2));
+        r = m.equal_range(9);
+        assert(r.first == next(m.begin(), 2));
+        assert(r.second == next(m.begin(), 3));
+        r = m.equal_range(11);
+        assert(r.first == next(m.begin(), 3));
+        assert(r.second == next(m.begin(), 4));
+        r = m.equal_range(13);
+        assert(r.first == next(m.begin(), 4));
+        assert(r.second == next(m.begin(), 5));
+        r = m.equal_range(15);
+        assert(r.first == next(m.begin(), 5));
+        assert(r.second == next(m.begin(), 6));
+        r = m.equal_range(17);
+        assert(r.first == next(m.begin(), 6));
+        assert(r.second == next(m.begin(), 7));
+        r = m.equal_range(19);
+        assert(r.first == next(m.begin(), 7));
+        assert(r.second == next(m.begin(), 8));
+        r = m.equal_range(4);
+        assert(r.first == next(m.begin(), 0));
+        assert(r.second == next(m.begin(), 0));
+        r = m.equal_range(6);
+        assert(r.first == next(m.begin(), 1));
+        assert(r.second == next(m.begin(), 1));
+        r = m.equal_range(8);
+        assert(r.first == next(m.begin(), 2));
+        assert(r.second == next(m.begin(), 2));
+        r = m.equal_range(10);
+        assert(r.first == next(m.begin(), 3));
+        assert(r.second == next(m.begin(), 3));
+        r = m.equal_range(12);
+        assert(r.first == next(m.begin(), 4));
+        assert(r.second == next(m.begin(), 4));
+        r = m.equal_range(14);
+        assert(r.first == next(m.begin(), 5));
+        assert(r.second == next(m.begin(), 5));
+        r = m.equal_range(16);
+        assert(r.first == next(m.begin(), 6));
+        assert(r.second == next(m.begin(), 6));
+        r = m.equal_range(18);
+        assert(r.first == next(m.begin(), 7));
+        assert(r.second == next(m.begin(), 7));
+        r = m.equal_range(20);
+        assert(r.first == next(m.begin(), 8));
+        assert(r.second == next(m.begin(), 8));
+    }
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef std::pair<const int, double> V;
+    typedef std::map<int, double, std::less<int>, min_allocator<V>> M;
+    {
+        typedef std::pair<M::iterator, M::iterator> R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(7, 6),
+            V(9, 7),
+            V(11, 8),
+            V(13, 9),
+            V(15, 10),
+            V(17, 11),
+            V(19, 12)
+        };
+        M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.equal_range(5);
+        assert(r.first == next(m.begin(), 0));
+        assert(r.second == next(m.begin(), 1));
+        r = m.equal_range(7);
+        assert(r.first == next(m.begin(), 1));
+        assert(r.second == next(m.begin(), 2));
+        r = m.equal_range(9);
+        assert(r.first == next(m.begin(), 2));
+        assert(r.second == next(m.begin(), 3));
+        r = m.equal_range(11);
+        assert(r.first == next(m.begin(), 3));
+        assert(r.second == next(m.begin(), 4));
+        r = m.equal_range(13);
+        assert(r.first == next(m.begin(), 4));
+        assert(r.second == next(m.begin(), 5));
+        r = m.equal_range(15);
+        assert(r.first == next(m.begin(), 5));
+        assert(r.second == next(m.begin(), 6));
+        r = m.equal_range(17);
+        assert(r.first == next(m.begin(), 6));
+        assert(r.second == next(m.begin(), 7));
+        r = m.equal_range(19);
+        assert(r.first == next(m.begin(), 7));
+        assert(r.second == next(m.begin(), 8));
+        r = m.equal_range(4);
+        assert(r.first == next(m.begin(), 0));
+        assert(r.second == next(m.begin(), 0));
+        r = m.equal_range(6);
+        assert(r.first == next(m.begin(), 1));
+        assert(r.second == next(m.begin(), 1));
+        r = m.equal_range(8);
+        assert(r.first == next(m.begin(), 2));
+        assert(r.second == next(m.begin(), 2));
+        r = m.equal_range(10);
+        assert(r.first == next(m.begin(), 3));
+        assert(r.second == next(m.begin(), 3));
+        r = m.equal_range(12);
+        assert(r.first == next(m.begin(), 4));
+        assert(r.second == next(m.begin(), 4));
+        r = m.equal_range(14);
+        assert(r.first == next(m.begin(), 5));
+        assert(r.second == next(m.begin(), 5));
+        r = m.equal_range(16);
+        assert(r.first == next(m.begin(), 6));
+        assert(r.second == next(m.begin(), 6));
+        r = m.equal_range(18);
+        assert(r.first == next(m.begin(), 7));
+        assert(r.second == next(m.begin(), 7));
+        r = m.equal_range(20);
+        assert(r.first == next(m.begin(), 8));
+        assert(r.second == next(m.begin(), 8));
+    }
+    {
+        typedef std::pair<M::const_iterator, M::const_iterator> R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(7, 6),
+            V(9, 7),
+            V(11, 8),
+            V(13, 9),
+            V(15, 10),
+            V(17, 11),
+            V(19, 12)
+        };
+        const M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.equal_range(5);
+        assert(r.first == next(m.begin(), 0));
+        assert(r.second == next(m.begin(), 1));
+        r = m.equal_range(7);
+        assert(r.first == next(m.begin(), 1));
+        assert(r.second == next(m.begin(), 2));
+        r = m.equal_range(9);
+        assert(r.first == next(m.begin(), 2));
+        assert(r.second == next(m.begin(), 3));
+        r = m.equal_range(11);
+        assert(r.first == next(m.begin(), 3));
+        assert(r.second == next(m.begin(), 4));
+        r = m.equal_range(13);
+        assert(r.first == next(m.begin(), 4));
+        assert(r.second == next(m.begin(), 5));
+        r = m.equal_range(15);
+        assert(r.first == next(m.begin(), 5));
+        assert(r.second == next(m.begin(), 6));
+        r = m.equal_range(17);
+        assert(r.first == next(m.begin(), 6));
+        assert(r.second == next(m.begin(), 7));
+        r = m.equal_range(19);
+        assert(r.first == next(m.begin(), 7));
+        assert(r.second == next(m.begin(), 8));
+        r = m.equal_range(4);
+        assert(r.first == next(m.begin(), 0));
+        assert(r.second == next(m.begin(), 0));
+        r = m.equal_range(6);
+        assert(r.first == next(m.begin(), 1));
+        assert(r.second == next(m.begin(), 1));
+        r = m.equal_range(8);
+        assert(r.first == next(m.begin(), 2));
+        assert(r.second == next(m.begin(), 2));
+        r = m.equal_range(10);
+        assert(r.first == next(m.begin(), 3));
+        assert(r.second == next(m.begin(), 3));
+        r = m.equal_range(12);
+        assert(r.first == next(m.begin(), 4));
+        assert(r.second == next(m.begin(), 4));
+        r = m.equal_range(14);
+        assert(r.first == next(m.begin(), 5));
+        assert(r.second == next(m.begin(), 5));
+        r = m.equal_range(16);
+        assert(r.first == next(m.begin(), 6));
+        assert(r.second == next(m.begin(), 6));
+        r = m.equal_range(18);
+        assert(r.first == next(m.begin(), 7));
+        assert(r.second == next(m.begin(), 7));
+        r = m.equal_range(20);
+        assert(r.first == next(m.begin(), 8));
+        assert(r.second == next(m.begin(), 8));
+    }
+    }
+#endif
+#if TEST_STD_VER > 11
+    {
+    typedef std::pair<const int, double> V;
+    typedef std::map<int, double, std::less<>> M;
+    typedef std::pair<M::iterator, M::iterator> R;
+
+    V ar[] =
+    {
+        V(5, 5),
+        V(7, 6),
+        V(9, 7),
+        V(11, 8),
+        V(13, 9),
+        V(15, 10),
+        V(17, 11),
+        V(19, 12)
+    };
+    M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+    R r = m.equal_range(5);
+    assert(r.first == next(m.begin(), 0));
+    assert(r.second == next(m.begin(), 1));
+    r = m.equal_range(7);
+    assert(r.first == next(m.begin(), 1));
+    assert(r.second == next(m.begin(), 2));
+    r = m.equal_range(9);
+    assert(r.first == next(m.begin(), 2));
+    assert(r.second == next(m.begin(), 3));
+    r = m.equal_range(11);
+    assert(r.first == next(m.begin(), 3));
+    assert(r.second == next(m.begin(), 4));
+    r = m.equal_range(13);
+    assert(r.first == next(m.begin(), 4));
+    assert(r.second == next(m.begin(), 5));
+    r = m.equal_range(15);
+    assert(r.first == next(m.begin(), 5));
+    assert(r.second == next(m.begin(), 6));
+    r = m.equal_range(17);
+    assert(r.first == next(m.begin(), 6));
+    assert(r.second == next(m.begin(), 7));
+    r = m.equal_range(19);
+    assert(r.first == next(m.begin(), 7));
+    assert(r.second == next(m.begin(), 8));
+    r = m.equal_range(4);
+    assert(r.first == next(m.begin(), 0));
+    assert(r.second == next(m.begin(), 0));
+    r = m.equal_range(6);
+    assert(r.first == next(m.begin(), 1));
+    assert(r.second == next(m.begin(), 1));
+    r = m.equal_range(8);
+    assert(r.first == next(m.begin(), 2));
+    assert(r.second == next(m.begin(), 2));
+    r = m.equal_range(10);
+    assert(r.first == next(m.begin(), 3));
+    assert(r.second == next(m.begin(), 3));
+    r = m.equal_range(12);
+    assert(r.first == next(m.begin(), 4));
+    assert(r.second == next(m.begin(), 4));
+    r = m.equal_range(14);
+    assert(r.first == next(m.begin(), 5));
+    assert(r.second == next(m.begin(), 5));
+    r = m.equal_range(16);
+    assert(r.first == next(m.begin(), 6));
+    assert(r.second == next(m.begin(), 6));
+    r = m.equal_range(18);
+    assert(r.first == next(m.begin(), 7));
+    assert(r.second == next(m.begin(), 7));
+    r = m.equal_range(20);
+    assert(r.first == next(m.begin(), 8));
+    assert(r.second == next(m.begin(), 8));
+
+    r = m.equal_range(C2Int(5));
+    assert(r.first == next(m.begin(), 0));
+    assert(r.second == next(m.begin(), 1));
+    r = m.equal_range(C2Int(7));
+    assert(r.first == next(m.begin(), 1));
+    assert(r.second == next(m.begin(), 2));
+    r = m.equal_range(C2Int(9));
+    assert(r.first == next(m.begin(), 2));
+    assert(r.second == next(m.begin(), 3));
+    r = m.equal_range(C2Int(11));
+    assert(r.first == next(m.begin(), 3));
+    assert(r.second == next(m.begin(), 4));
+    r = m.equal_range(C2Int(13));
+    assert(r.first == next(m.begin(), 4));
+    assert(r.second == next(m.begin(), 5));
+    r = m.equal_range(C2Int(15));
+    assert(r.first == next(m.begin(), 5));
+    assert(r.second == next(m.begin(), 6));
+    r = m.equal_range(C2Int(17));
+    assert(r.first == next(m.begin(), 6));
+    assert(r.second == next(m.begin(), 7));
+    r = m.equal_range(C2Int(19));
+    assert(r.first == next(m.begin(), 7));
+    assert(r.second == next(m.begin(), 8));
+    r = m.equal_range(C2Int(4));
+    assert(r.first == next(m.begin(), 0));
+    assert(r.second == next(m.begin(), 0));
+    r = m.equal_range(C2Int(6));
+    assert(r.first == next(m.begin(), 1));
+    assert(r.second == next(m.begin(), 1));
+    r = m.equal_range(C2Int(8));
+    assert(r.first == next(m.begin(), 2));
+    assert(r.second == next(m.begin(), 2));
+    r = m.equal_range(C2Int(10));
+    assert(r.first == next(m.begin(), 3));
+    assert(r.second == next(m.begin(), 3));
+    r = m.equal_range(C2Int(12));
+    assert(r.first == next(m.begin(), 4));
+    assert(r.second == next(m.begin(), 4));
+    r = m.equal_range(C2Int(14));
+    assert(r.first == next(m.begin(), 5));
+    assert(r.second == next(m.begin(), 5));
+    r = m.equal_range(C2Int(16));
+    assert(r.first == next(m.begin(), 6));
+    assert(r.second == next(m.begin(), 6));
+    r = m.equal_range(C2Int(18));
+    assert(r.first == next(m.begin(), 7));
+    assert(r.second == next(m.begin(), 7));
+    r = m.equal_range(C2Int(20));
+    assert(r.first == next(m.begin(), 8));
+    assert(r.second == next(m.begin(), 8));
+    }
+    {
+    typedef PrivateConstructor PC;
+    typedef std::map<PC, double, std::less<>> M;
+    typedef std::pair<M::iterator, M::iterator> R;
+
+    M m;
+    m [ PC::make(5)  ] = 5;
+    m [ PC::make(7)  ] = 6;
+    m [ PC::make(9)  ] = 7;
+    m [ PC::make(11) ] = 8;
+    m [ PC::make(13) ] = 9;
+    m [ PC::make(15) ] = 10;
+    m [ PC::make(17) ] = 11;
+    m [ PC::make(19) ] = 12;
+
+    R r = m.equal_range(5);
+    assert(r.first == next(m.begin(), 0));
+    assert(r.second == next(m.begin(), 1));
+    r = m.equal_range(7);
+    assert(r.first == next(m.begin(), 1));
+    assert(r.second == next(m.begin(), 2));
+    r = m.equal_range(9);
+    assert(r.first == next(m.begin(), 2));
+    assert(r.second == next(m.begin(), 3));
+    r = m.equal_range(11);
+    assert(r.first == next(m.begin(), 3));
+    assert(r.second == next(m.begin(), 4));
+    r = m.equal_range(13);
+    assert(r.first == next(m.begin(), 4));
+    assert(r.second == next(m.begin(), 5));
+    r = m.equal_range(15);
+    assert(r.first == next(m.begin(), 5));
+    assert(r.second == next(m.begin(), 6));
+    r = m.equal_range(17);
+    assert(r.first == next(m.begin(), 6));
+    assert(r.second == next(m.begin(), 7));
+    r = m.equal_range(19);
+    assert(r.first == next(m.begin(), 7));
+    assert(r.second == next(m.begin(), 8));
+    r = m.equal_range(4);
+    assert(r.first == next(m.begin(), 0));
+    assert(r.second == next(m.begin(), 0));
+    r = m.equal_range(6);
+    assert(r.first == next(m.begin(), 1));
+    assert(r.second == next(m.begin(), 1));
+    r = m.equal_range(8);
+    assert(r.first == next(m.begin(), 2));
+    assert(r.second == next(m.begin(), 2));
+    r = m.equal_range(10);
+    assert(r.first == next(m.begin(), 3));
+    assert(r.second == next(m.begin(), 3));
+    r = m.equal_range(12);
+    assert(r.first == next(m.begin(), 4));
+    assert(r.second == next(m.begin(), 4));
+    r = m.equal_range(14);
+    assert(r.first == next(m.begin(), 5));
+    assert(r.second == next(m.begin(), 5));
+    r = m.equal_range(16);
+    assert(r.first == next(m.begin(), 6));
+    assert(r.second == next(m.begin(), 6));
+    r = m.equal_range(18);
+    assert(r.first == next(m.begin(), 7));
+    assert(r.second == next(m.begin(), 7));
+    r = m.equal_range(20);
+    assert(r.first == next(m.begin(), 8));
+    assert(r.second == next(m.begin(), 8));
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.ops/equal_range0.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/equal_range0.pass.cpp
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// XFAIL: c++98, c++03, c++11
+
+// <map>
+
+// class map
+
+//       iterator find(const key_type& k);
+// const_iterator find(const key_type& k) const;
+//
+//   The member function templates find, count, lower_bound, upper_bound, and
+// equal_range shall not participate in overload resolution unless the
+// qualified-id Compare::is_transparent is valid and denotes a type
+
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "is_transparent.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::map<int, double, transparent_less> M;
+    typedef std::pair<typename M::iterator, typename M::iterator> P;
+    M example;
+    P result = example.equal_range(C2Int{5});
+    assert(result.first == result.second);
+    }
+    {
+    typedef std::map<int, double, transparent_less_not_referenceable> M;
+    typedef std::pair<typename M::iterator, typename M::iterator> P;
+    M example;
+    P result = example.equal_range(C2Int{5});
+    assert(result.first == result.second);
+    }
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.ops/equal_range_transparent.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/equal_range_transparent.pass.cpp
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++98, c++03, c++11
+
+// <map>
+
+// class map
+
+// template<typename K>
+//         pair<iterator,iterator>             equal_range(const K& x); // C++14
+// template<typename K>
+//         pair<const_iterator,const_iterator> equal_range(const K& x) const;
+//         // C++14
+
+#include <cassert>
+#include <map>
+#include <utility>
+
+#include "min_allocator.h"
+#include "private_constructor.h"
+#include "test_macros.h"
+
+struct Comp {
+  using is_transparent = void;
+
+  bool operator()(const std::pair<int, int> &lhs,
+                  const std::pair<int, int> &rhs) const {
+    return lhs < rhs;
+  }
+
+  bool operator()(const std::pair<int, int> &lhs, int rhs) const {
+    return lhs.first < rhs;
+  }
+
+  bool operator()(int lhs, const std::pair<int, int> &rhs) const {
+    return lhs < rhs.first;
+  }
+};
+
+int main(int, char**) {
+  std::map<std::pair<int, int>, int, Comp> s{
+      {{2, 1}, 1}, {{1, 2}, 2}, {{1, 3}, 3}, {{1, 4}, 4}, {{2, 2}, 5}};
+
+  auto er = s.equal_range(1);
+  long nels = 0;
+
+  for (auto it = er.first; it != er.second; it++) {
+    assert(it->first.first == 1);
+    nels++;
+  }
+
+  assert(nels == 3);
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.ops/find.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/find.pass.cpp
@@ -1,0 +1,262 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+//       iterator find(const key_type& k);
+// const_iterator find(const key_type& k) const;
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+#include "private_constructor.h"
+#include "is_transparent.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::pair<const int, double> V;
+    typedef std::map<int, double> M;
+    {
+        typedef M::iterator R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.find(5);
+        assert(r == m.begin());
+        r = m.find(6);
+        assert(r == next(m.begin()));
+        r = m.find(7);
+        assert(r == next(m.begin(), 2));
+        r = m.find(8);
+        assert(r == next(m.begin(), 3));
+        r = m.find(9);
+        assert(r == next(m.begin(), 4));
+        r = m.find(10);
+        assert(r == next(m.begin(), 5));
+        r = m.find(11);
+        assert(r == next(m.begin(), 6));
+        r = m.find(12);
+        assert(r == next(m.begin(), 7));
+        r = m.find(4);
+        assert(r == next(m.begin(), 8));
+    }
+    {
+        typedef M::const_iterator R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        const M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.find(5);
+        assert(r == m.begin());
+        r = m.find(6);
+        assert(r == next(m.begin()));
+        r = m.find(7);
+        assert(r == next(m.begin(), 2));
+        r = m.find(8);
+        assert(r == next(m.begin(), 3));
+        r = m.find(9);
+        assert(r == next(m.begin(), 4));
+        r = m.find(10);
+        assert(r == next(m.begin(), 5));
+        r = m.find(11);
+        assert(r == next(m.begin(), 6));
+        r = m.find(12);
+        assert(r == next(m.begin(), 7));
+        r = m.find(4);
+        assert(r == next(m.begin(), 8));
+    }
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef std::pair<const int, double> V;
+    typedef std::map<int, double, std::less<int>, min_allocator<V>> M;
+    {
+        typedef M::iterator R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.find(5);
+        assert(r == m.begin());
+        r = m.find(6);
+        assert(r == next(m.begin()));
+        r = m.find(7);
+        assert(r == next(m.begin(), 2));
+        r = m.find(8);
+        assert(r == next(m.begin(), 3));
+        r = m.find(9);
+        assert(r == next(m.begin(), 4));
+        r = m.find(10);
+        assert(r == next(m.begin(), 5));
+        r = m.find(11);
+        assert(r == next(m.begin(), 6));
+        r = m.find(12);
+        assert(r == next(m.begin(), 7));
+        r = m.find(4);
+        assert(r == next(m.begin(), 8));
+    }
+    {
+        typedef M::const_iterator R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        const M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.find(5);
+        assert(r == m.begin());
+        r = m.find(6);
+        assert(r == next(m.begin()));
+        r = m.find(7);
+        assert(r == next(m.begin(), 2));
+        r = m.find(8);
+        assert(r == next(m.begin(), 3));
+        r = m.find(9);
+        assert(r == next(m.begin(), 4));
+        r = m.find(10);
+        assert(r == next(m.begin(), 5));
+        r = m.find(11);
+        assert(r == next(m.begin(), 6));
+        r = m.find(12);
+        assert(r == next(m.begin(), 7));
+        r = m.find(4);
+        assert(r == next(m.begin(), 8));
+    }
+    }
+#endif
+#if TEST_STD_VER > 11
+    {
+    typedef std::pair<const int, double> V;
+    typedef std::map<int, double, std::less<>> M;
+    typedef M::iterator R;
+
+    V ar[] =
+    {
+        V(5, 5),
+        V(6, 6),
+        V(7, 7),
+        V(8, 8),
+        V(9, 9),
+        V(10, 10),
+        V(11, 11),
+        V(12, 12)
+    };
+    M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+    R r = m.find(5);
+    assert(r == m.begin());
+    r = m.find(6);
+    assert(r == next(m.begin()));
+    r = m.find(7);
+    assert(r == next(m.begin(), 2));
+    r = m.find(8);
+    assert(r == next(m.begin(), 3));
+    r = m.find(9);
+    assert(r == next(m.begin(), 4));
+    r = m.find(10);
+    assert(r == next(m.begin(), 5));
+    r = m.find(11);
+    assert(r == next(m.begin(), 6));
+    r = m.find(12);
+    assert(r == next(m.begin(), 7));
+    r = m.find(4);
+    assert(r == next(m.begin(), 8));
+
+    r = m.find(C2Int(5));
+    assert(r == m.begin());
+    r = m.find(C2Int(6));
+    assert(r == next(m.begin()));
+    r = m.find(C2Int(7));
+    assert(r == next(m.begin(), 2));
+    r = m.find(C2Int(8));
+    assert(r == next(m.begin(), 3));
+    r = m.find(C2Int(9));
+    assert(r == next(m.begin(), 4));
+    r = m.find(C2Int(10));
+    assert(r == next(m.begin(), 5));
+    r = m.find(C2Int(11));
+    assert(r == next(m.begin(), 6));
+    r = m.find(C2Int(12));
+    assert(r == next(m.begin(), 7));
+    r = m.find(C2Int(4));
+    assert(r == next(m.begin(), 8));
+    }
+
+    {
+    typedef PrivateConstructor PC;
+    typedef std::map<PC, double, std::less<>> M;
+    typedef M::iterator R;
+
+    M m;
+    m [ PC::make(5)  ] = 5;
+    m [ PC::make(6)  ] = 6;
+    m [ PC::make(7)  ] = 7;
+    m [ PC::make(8)  ] = 8;
+    m [ PC::make(9)  ] = 9;
+    m [ PC::make(10) ] = 10;
+    m [ PC::make(11) ] = 11;
+    m [ PC::make(12) ] = 12;
+
+    R r = m.find(5);
+    assert(r == m.begin());
+    r = m.find(6);
+    assert(r == next(m.begin()));
+    r = m.find(7);
+    assert(r == next(m.begin(), 2));
+    r = m.find(8);
+    assert(r == next(m.begin(), 3));
+    r = m.find(9);
+    assert(r == next(m.begin(), 4));
+    r = m.find(10);
+    assert(r == next(m.begin(), 5));
+    r = m.find(11);
+    assert(r == next(m.begin(), 6));
+    r = m.find(12);
+    assert(r == next(m.begin(), 7));
+    r = m.find(4);
+    assert(r == next(m.begin(), 8));
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.ops/find0.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/find0.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// XFAIL: c++98, c++03, c++11
+
+// <map>
+
+// class map
+
+//       iterator find(const key_type& k);
+// const_iterator find(const key_type& k) const;
+//
+//   The member function templates find, count, lower_bound, upper_bound, and
+// equal_range shall not participate in overload resolution unless the
+// qualified-id Compare::is_transparent is valid and denotes a type
+
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "is_transparent.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::map<int, double, transparent_less> M;
+    M example;
+    assert(example.find(C2Int{5}) == example.end());
+    }
+    {
+    typedef std::map<int, double, transparent_less_not_referenceable> M;
+    M example;
+    assert(example.find(C2Int{5}) == example.end());
+    }
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.ops/lower_bound.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/lower_bound.pass.cpp
@@ -1,0 +1,374 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+//       iterator lower_bound(const key_type& k);
+// const_iterator lower_bound(const key_type& k) const;
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+#include "private_constructor.h"
+#include "is_transparent.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::pair<const int, double> V;
+    typedef std::map<int, double> M;
+    {
+        typedef M::iterator R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(7, 6),
+            V(9, 7),
+            V(11, 8),
+            V(13, 9),
+            V(15, 10),
+            V(17, 11),
+            V(19, 12)
+        };
+        M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.lower_bound(5);
+        assert(r == m.begin());
+        r = m.lower_bound(7);
+        assert(r == next(m.begin()));
+        r = m.lower_bound(9);
+        assert(r == next(m.begin(), 2));
+        r = m.lower_bound(11);
+        assert(r == next(m.begin(), 3));
+        r = m.lower_bound(13);
+        assert(r == next(m.begin(), 4));
+        r = m.lower_bound(15);
+        assert(r == next(m.begin(), 5));
+        r = m.lower_bound(17);
+        assert(r == next(m.begin(), 6));
+        r = m.lower_bound(19);
+        assert(r == next(m.begin(), 7));
+        r = m.lower_bound(4);
+        assert(r == next(m.begin(), 0));
+        r = m.lower_bound(6);
+        assert(r == next(m.begin(), 1));
+        r = m.lower_bound(8);
+        assert(r == next(m.begin(), 2));
+        r = m.lower_bound(10);
+        assert(r == next(m.begin(), 3));
+        r = m.lower_bound(12);
+        assert(r == next(m.begin(), 4));
+        r = m.lower_bound(14);
+        assert(r == next(m.begin(), 5));
+        r = m.lower_bound(16);
+        assert(r == next(m.begin(), 6));
+        r = m.lower_bound(18);
+        assert(r == next(m.begin(), 7));
+        r = m.lower_bound(20);
+        assert(r == next(m.begin(), 8));
+    }
+    {
+        typedef M::const_iterator R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(7, 6),
+            V(9, 7),
+            V(11, 8),
+            V(13, 9),
+            V(15, 10),
+            V(17, 11),
+            V(19, 12)
+        };
+        const M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.lower_bound(5);
+        assert(r == m.begin());
+        r = m.lower_bound(7);
+        assert(r == next(m.begin()));
+        r = m.lower_bound(9);
+        assert(r == next(m.begin(), 2));
+        r = m.lower_bound(11);
+        assert(r == next(m.begin(), 3));
+        r = m.lower_bound(13);
+        assert(r == next(m.begin(), 4));
+        r = m.lower_bound(15);
+        assert(r == next(m.begin(), 5));
+        r = m.lower_bound(17);
+        assert(r == next(m.begin(), 6));
+        r = m.lower_bound(19);
+        assert(r == next(m.begin(), 7));
+        r = m.lower_bound(4);
+        assert(r == next(m.begin(), 0));
+        r = m.lower_bound(6);
+        assert(r == next(m.begin(), 1));
+        r = m.lower_bound(8);
+        assert(r == next(m.begin(), 2));
+        r = m.lower_bound(10);
+        assert(r == next(m.begin(), 3));
+        r = m.lower_bound(12);
+        assert(r == next(m.begin(), 4));
+        r = m.lower_bound(14);
+        assert(r == next(m.begin(), 5));
+        r = m.lower_bound(16);
+        assert(r == next(m.begin(), 6));
+        r = m.lower_bound(18);
+        assert(r == next(m.begin(), 7));
+        r = m.lower_bound(20);
+        assert(r == next(m.begin(), 8));
+    }
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef std::pair<const int, double> V;
+    typedef std::map<int, double, std::less<int>, min_allocator<V>> M;
+    {
+        typedef M::iterator R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(7, 6),
+            V(9, 7),
+            V(11, 8),
+            V(13, 9),
+            V(15, 10),
+            V(17, 11),
+            V(19, 12)
+        };
+        M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.lower_bound(5);
+        assert(r == m.begin());
+        r = m.lower_bound(7);
+        assert(r == next(m.begin()));
+        r = m.lower_bound(9);
+        assert(r == next(m.begin(), 2));
+        r = m.lower_bound(11);
+        assert(r == next(m.begin(), 3));
+        r = m.lower_bound(13);
+        assert(r == next(m.begin(), 4));
+        r = m.lower_bound(15);
+        assert(r == next(m.begin(), 5));
+        r = m.lower_bound(17);
+        assert(r == next(m.begin(), 6));
+        r = m.lower_bound(19);
+        assert(r == next(m.begin(), 7));
+        r = m.lower_bound(4);
+        assert(r == next(m.begin(), 0));
+        r = m.lower_bound(6);
+        assert(r == next(m.begin(), 1));
+        r = m.lower_bound(8);
+        assert(r == next(m.begin(), 2));
+        r = m.lower_bound(10);
+        assert(r == next(m.begin(), 3));
+        r = m.lower_bound(12);
+        assert(r == next(m.begin(), 4));
+        r = m.lower_bound(14);
+        assert(r == next(m.begin(), 5));
+        r = m.lower_bound(16);
+        assert(r == next(m.begin(), 6));
+        r = m.lower_bound(18);
+        assert(r == next(m.begin(), 7));
+        r = m.lower_bound(20);
+        assert(r == next(m.begin(), 8));
+    }
+    {
+        typedef M::const_iterator R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(7, 6),
+            V(9, 7),
+            V(11, 8),
+            V(13, 9),
+            V(15, 10),
+            V(17, 11),
+            V(19, 12)
+        };
+        const M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.lower_bound(5);
+        assert(r == m.begin());
+        r = m.lower_bound(7);
+        assert(r == next(m.begin()));
+        r = m.lower_bound(9);
+        assert(r == next(m.begin(), 2));
+        r = m.lower_bound(11);
+        assert(r == next(m.begin(), 3));
+        r = m.lower_bound(13);
+        assert(r == next(m.begin(), 4));
+        r = m.lower_bound(15);
+        assert(r == next(m.begin(), 5));
+        r = m.lower_bound(17);
+        assert(r == next(m.begin(), 6));
+        r = m.lower_bound(19);
+        assert(r == next(m.begin(), 7));
+        r = m.lower_bound(4);
+        assert(r == next(m.begin(), 0));
+        r = m.lower_bound(6);
+        assert(r == next(m.begin(), 1));
+        r = m.lower_bound(8);
+        assert(r == next(m.begin(), 2));
+        r = m.lower_bound(10);
+        assert(r == next(m.begin(), 3));
+        r = m.lower_bound(12);
+        assert(r == next(m.begin(), 4));
+        r = m.lower_bound(14);
+        assert(r == next(m.begin(), 5));
+        r = m.lower_bound(16);
+        assert(r == next(m.begin(), 6));
+        r = m.lower_bound(18);
+        assert(r == next(m.begin(), 7));
+        r = m.lower_bound(20);
+        assert(r == next(m.begin(), 8));
+    }
+    }
+#endif
+#if TEST_STD_VER > 11
+    {
+    typedef std::pair<const int, double> V;
+    typedef std::map<int, double, std::less <>> M;
+    typedef M::iterator R;
+
+    V ar[] =
+    {
+        V(5, 5),
+        V(7, 6),
+        V(9, 7),
+        V(11, 8),
+        V(13, 9),
+        V(15, 10),
+        V(17, 11),
+        V(19, 12)
+    };
+    M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+    R r = m.lower_bound(5);
+    assert(r == m.begin());
+    r = m.lower_bound(7);
+    assert(r == next(m.begin()));
+    r = m.lower_bound(9);
+    assert(r == next(m.begin(), 2));
+    r = m.lower_bound(11);
+    assert(r == next(m.begin(), 3));
+    r = m.lower_bound(13);
+    assert(r == next(m.begin(), 4));
+    r = m.lower_bound(15);
+    assert(r == next(m.begin(), 5));
+    r = m.lower_bound(17);
+    assert(r == next(m.begin(), 6));
+    r = m.lower_bound(19);
+    assert(r == next(m.begin(), 7));
+    r = m.lower_bound(4);
+    assert(r == next(m.begin(), 0));
+    r = m.lower_bound(6);
+    assert(r == next(m.begin(), 1));
+    r = m.lower_bound(8);
+    assert(r == next(m.begin(), 2));
+    r = m.lower_bound(10);
+    assert(r == next(m.begin(), 3));
+    r = m.lower_bound(12);
+    assert(r == next(m.begin(), 4));
+    r = m.lower_bound(14);
+    assert(r == next(m.begin(), 5));
+    r = m.lower_bound(16);
+    assert(r == next(m.begin(), 6));
+    r = m.lower_bound(18);
+    assert(r == next(m.begin(), 7));
+    r = m.lower_bound(20);
+    assert(r == next(m.begin(), 8));
+
+    r = m.lower_bound(C2Int(5));
+    assert(r == m.begin());
+    r = m.lower_bound(C2Int(7));
+    assert(r == next(m.begin()));
+    r = m.lower_bound(C2Int(9));
+    assert(r == next(m.begin(), 2));
+    r = m.lower_bound(C2Int(11));
+    assert(r == next(m.begin(), 3));
+    r = m.lower_bound(C2Int(13));
+    assert(r == next(m.begin(), 4));
+    r = m.lower_bound(C2Int(15));
+    assert(r == next(m.begin(), 5));
+    r = m.lower_bound(C2Int(17));
+    assert(r == next(m.begin(), 6));
+    r = m.lower_bound(C2Int(19));
+    assert(r == next(m.begin(), 7));
+    r = m.lower_bound(C2Int(4));
+    assert(r == next(m.begin(), 0));
+    r = m.lower_bound(C2Int(6));
+    assert(r == next(m.begin(), 1));
+    r = m.lower_bound(C2Int(8));
+    assert(r == next(m.begin(), 2));
+    r = m.lower_bound(C2Int(10));
+    assert(r == next(m.begin(), 3));
+    r = m.lower_bound(C2Int(12));
+    assert(r == next(m.begin(), 4));
+    r = m.lower_bound(C2Int(14));
+    assert(r == next(m.begin(), 5));
+    r = m.lower_bound(C2Int(16));
+    assert(r == next(m.begin(), 6));
+    r = m.lower_bound(C2Int(18));
+    assert(r == next(m.begin(), 7));
+    r = m.lower_bound(C2Int(20));
+    assert(r == next(m.begin(), 8));
+    }
+
+    {
+    typedef PrivateConstructor PC;
+    typedef std::map<PC, double, std::less<>> M;
+    typedef M::iterator R;
+
+    M m;
+    m [ PC::make(5)  ] = 5;
+    m [ PC::make(7)  ] = 6;
+    m [ PC::make(9)  ] = 7;
+    m [ PC::make(11) ] = 8;
+    m [ PC::make(13) ] = 9;
+    m [ PC::make(15) ] = 10;
+    m [ PC::make(17) ] = 11;
+    m [ PC::make(19) ] = 12;
+
+    R r = m.lower_bound(5);
+    assert(r == m.begin());
+    r = m.lower_bound(7);
+    assert(r == next(m.begin()));
+    r = m.lower_bound(9);
+    assert(r == next(m.begin(), 2));
+    r = m.lower_bound(11);
+    assert(r == next(m.begin(), 3));
+    r = m.lower_bound(13);
+    assert(r == next(m.begin(), 4));
+    r = m.lower_bound(15);
+    assert(r == next(m.begin(), 5));
+    r = m.lower_bound(17);
+    assert(r == next(m.begin(), 6));
+    r = m.lower_bound(19);
+    assert(r == next(m.begin(), 7));
+    r = m.lower_bound(4);
+    assert(r == next(m.begin(), 0));
+    r = m.lower_bound(6);
+    assert(r == next(m.begin(), 1));
+    r = m.lower_bound(8);
+    assert(r == next(m.begin(), 2));
+    r = m.lower_bound(10);
+    assert(r == next(m.begin(), 3));
+    r = m.lower_bound(12);
+    assert(r == next(m.begin(), 4));
+    r = m.lower_bound(14);
+    assert(r == next(m.begin(), 5));
+    r = m.lower_bound(16);
+    assert(r == next(m.begin(), 6));
+    r = m.lower_bound(18);
+    assert(r == next(m.begin(), 7));
+    r = m.lower_bound(20);
+    assert(r == next(m.begin(), 8));
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.ops/lower_bound0.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/lower_bound0.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// XFAIL: c++98, c++03, c++11
+
+// <map>
+
+// class map
+
+//       iterator lower_bound(const key_type& k);
+// const_iterator lower_bound(const key_type& k) const;
+//
+//   The member function templates find, count, lower_bound, upper_bound, and
+// equal_range shall not participate in overload resolution unless the
+// qualified-id Compare::is_transparent is valid and denotes a type
+
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "is_transparent.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::map<int, double, transparent_less> M;
+    M example;
+    assert(example.lower_bound(C2Int{5}) == example.end());
+    }
+    {
+    typedef std::map<int, double, transparent_less_not_referenceable> M;
+    M example;
+    assert(example.lower_bound(C2Int{5}) == example.end());
+    }
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.ops/upper_bound.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/upper_bound.pass.cpp
@@ -1,0 +1,337 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+//       iterator upper_bound(const key_type& k);
+// const_iterator upper_bound(const key_type& k) const;
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+#include "private_constructor.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::pair<const int, double> V;
+    typedef std::map<int, double> M;
+    {
+        typedef M::iterator R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(7, 6),
+            V(9, 7),
+            V(11, 8),
+            V(13, 9),
+            V(15, 10),
+            V(17, 11),
+            V(19, 12)
+        };
+        M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.upper_bound(5);
+        assert(r == next(m.begin(), 1));
+        r = m.upper_bound(7);
+        assert(r == next(m.begin(), 2));
+        r = m.upper_bound(9);
+        assert(r == next(m.begin(), 3));
+        r = m.upper_bound(11);
+        assert(r == next(m.begin(), 4));
+        r = m.upper_bound(13);
+        assert(r == next(m.begin(), 5));
+        r = m.upper_bound(15);
+        assert(r == next(m.begin(), 6));
+        r = m.upper_bound(17);
+        assert(r == next(m.begin(), 7));
+        r = m.upper_bound(19);
+        assert(r == next(m.begin(), 8));
+        r = m.upper_bound(4);
+        assert(r == next(m.begin(), 0));
+        r = m.upper_bound(6);
+        assert(r == next(m.begin(), 1));
+        r = m.upper_bound(8);
+        assert(r == next(m.begin(), 2));
+        r = m.upper_bound(10);
+        assert(r == next(m.begin(), 3));
+        r = m.upper_bound(12);
+        assert(r == next(m.begin(), 4));
+        r = m.upper_bound(14);
+        assert(r == next(m.begin(), 5));
+        r = m.upper_bound(16);
+        assert(r == next(m.begin(), 6));
+        r = m.upper_bound(18);
+        assert(r == next(m.begin(), 7));
+        r = m.upper_bound(20);
+        assert(r == next(m.begin(), 8));
+    }
+    {
+        typedef M::const_iterator R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(7, 6),
+            V(9, 7),
+            V(11, 8),
+            V(13, 9),
+            V(15, 10),
+            V(17, 11),
+            V(19, 12)
+        };
+        const M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.upper_bound(5);
+        assert(r == next(m.begin(), 1));
+        r = m.upper_bound(7);
+        assert(r == next(m.begin(), 2));
+        r = m.upper_bound(9);
+        assert(r == next(m.begin(), 3));
+        r = m.upper_bound(11);
+        assert(r == next(m.begin(), 4));
+        r = m.upper_bound(13);
+        assert(r == next(m.begin(), 5));
+        r = m.upper_bound(15);
+        assert(r == next(m.begin(), 6));
+        r = m.upper_bound(17);
+        assert(r == next(m.begin(), 7));
+        r = m.upper_bound(19);
+        assert(r == next(m.begin(), 8));
+        r = m.upper_bound(4);
+        assert(r == next(m.begin(), 0));
+        r = m.upper_bound(6);
+        assert(r == next(m.begin(), 1));
+        r = m.upper_bound(8);
+        assert(r == next(m.begin(), 2));
+        r = m.upper_bound(10);
+        assert(r == next(m.begin(), 3));
+        r = m.upper_bound(12);
+        assert(r == next(m.begin(), 4));
+        r = m.upper_bound(14);
+        assert(r == next(m.begin(), 5));
+        r = m.upper_bound(16);
+        assert(r == next(m.begin(), 6));
+        r = m.upper_bound(18);
+        assert(r == next(m.begin(), 7));
+        r = m.upper_bound(20);
+        assert(r == next(m.begin(), 8));
+    }
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef std::pair<const int, double> V;
+    typedef std::map<int, double, std::less<int>, min_allocator<V>> M;
+    {
+        typedef M::iterator R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(7, 6),
+            V(9, 7),
+            V(11, 8),
+            V(13, 9),
+            V(15, 10),
+            V(17, 11),
+            V(19, 12)
+        };
+        M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.upper_bound(5);
+        assert(r == next(m.begin(), 1));
+        r = m.upper_bound(7);
+        assert(r == next(m.begin(), 2));
+        r = m.upper_bound(9);
+        assert(r == next(m.begin(), 3));
+        r = m.upper_bound(11);
+        assert(r == next(m.begin(), 4));
+        r = m.upper_bound(13);
+        assert(r == next(m.begin(), 5));
+        r = m.upper_bound(15);
+        assert(r == next(m.begin(), 6));
+        r = m.upper_bound(17);
+        assert(r == next(m.begin(), 7));
+        r = m.upper_bound(19);
+        assert(r == next(m.begin(), 8));
+        r = m.upper_bound(4);
+        assert(r == next(m.begin(), 0));
+        r = m.upper_bound(6);
+        assert(r == next(m.begin(), 1));
+        r = m.upper_bound(8);
+        assert(r == next(m.begin(), 2));
+        r = m.upper_bound(10);
+        assert(r == next(m.begin(), 3));
+        r = m.upper_bound(12);
+        assert(r == next(m.begin(), 4));
+        r = m.upper_bound(14);
+        assert(r == next(m.begin(), 5));
+        r = m.upper_bound(16);
+        assert(r == next(m.begin(), 6));
+        r = m.upper_bound(18);
+        assert(r == next(m.begin(), 7));
+        r = m.upper_bound(20);
+        assert(r == next(m.begin(), 8));
+    }
+    {
+        typedef M::const_iterator R;
+        V ar[] =
+        {
+            V(5, 5),
+            V(7, 6),
+            V(9, 7),
+            V(11, 8),
+            V(13, 9),
+            V(15, 10),
+            V(17, 11),
+            V(19, 12)
+        };
+        const M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+        R r = m.upper_bound(5);
+        assert(r == next(m.begin(), 1));
+        r = m.upper_bound(7);
+        assert(r == next(m.begin(), 2));
+        r = m.upper_bound(9);
+        assert(r == next(m.begin(), 3));
+        r = m.upper_bound(11);
+        assert(r == next(m.begin(), 4));
+        r = m.upper_bound(13);
+        assert(r == next(m.begin(), 5));
+        r = m.upper_bound(15);
+        assert(r == next(m.begin(), 6));
+        r = m.upper_bound(17);
+        assert(r == next(m.begin(), 7));
+        r = m.upper_bound(19);
+        assert(r == next(m.begin(), 8));
+        r = m.upper_bound(4);
+        assert(r == next(m.begin(), 0));
+        r = m.upper_bound(6);
+        assert(r == next(m.begin(), 1));
+        r = m.upper_bound(8);
+        assert(r == next(m.begin(), 2));
+        r = m.upper_bound(10);
+        assert(r == next(m.begin(), 3));
+        r = m.upper_bound(12);
+        assert(r == next(m.begin(), 4));
+        r = m.upper_bound(14);
+        assert(r == next(m.begin(), 5));
+        r = m.upper_bound(16);
+        assert(r == next(m.begin(), 6));
+        r = m.upper_bound(18);
+        assert(r == next(m.begin(), 7));
+        r = m.upper_bound(20);
+        assert(r == next(m.begin(), 8));
+    }
+    }
+#endif
+#if TEST_STD_VER > 11
+    {
+    typedef std::pair<const int, double> V;
+    typedef std::map<int, double, std::less<>> M;
+    typedef M::iterator R;
+    V ar[] =
+    {
+        V(5, 5),
+        V(7, 6),
+        V(9, 7),
+        V(11, 8),
+        V(13, 9),
+        V(15, 10),
+        V(17, 11),
+        V(19, 12)
+    };
+    M m(ar, ar+sizeof(ar)/sizeof(ar[0]));
+    R r = m.upper_bound(5);
+    assert(r == next(m.begin(), 1));
+    r = m.upper_bound(7);
+    assert(r == next(m.begin(), 2));
+    r = m.upper_bound(9);
+    assert(r == next(m.begin(), 3));
+    r = m.upper_bound(11);
+    assert(r == next(m.begin(), 4));
+    r = m.upper_bound(13);
+    assert(r == next(m.begin(), 5));
+    r = m.upper_bound(15);
+    assert(r == next(m.begin(), 6));
+    r = m.upper_bound(17);
+    assert(r == next(m.begin(), 7));
+    r = m.upper_bound(19);
+    assert(r == next(m.begin(), 8));
+    r = m.upper_bound(4);
+    assert(r == next(m.begin(), 0));
+    r = m.upper_bound(6);
+    assert(r == next(m.begin(), 1));
+    r = m.upper_bound(8);
+    assert(r == next(m.begin(), 2));
+    r = m.upper_bound(10);
+    assert(r == next(m.begin(), 3));
+    r = m.upper_bound(12);
+    assert(r == next(m.begin(), 4));
+    r = m.upper_bound(14);
+    assert(r == next(m.begin(), 5));
+    r = m.upper_bound(16);
+    assert(r == next(m.begin(), 6));
+    r = m.upper_bound(18);
+    assert(r == next(m.begin(), 7));
+    r = m.upper_bound(20);
+    assert(r == next(m.begin(), 8));
+    }
+
+    {
+    typedef PrivateConstructor PC;
+    typedef std::map<PC, double, std::less<>> M;
+    typedef M::iterator R;
+
+    M m;
+    m [ PC::make(5)  ] = 5;
+    m [ PC::make(7)  ] = 6;
+    m [ PC::make(9)  ] = 7;
+    m [ PC::make(11) ] = 8;
+    m [ PC::make(13) ] = 9;
+    m [ PC::make(15) ] = 10;
+    m [ PC::make(17) ] = 11;
+    m [ PC::make(19) ] = 12;
+
+    R r = m.upper_bound(5);
+    assert(r == next(m.begin(), 1));
+    r = m.upper_bound(7);
+    assert(r == next(m.begin(), 2));
+    r = m.upper_bound(9);
+    assert(r == next(m.begin(), 3));
+    r = m.upper_bound(11);
+    assert(r == next(m.begin(), 4));
+    r = m.upper_bound(13);
+    assert(r == next(m.begin(), 5));
+    r = m.upper_bound(15);
+    assert(r == next(m.begin(), 6));
+    r = m.upper_bound(17);
+    assert(r == next(m.begin(), 7));
+    r = m.upper_bound(19);
+    assert(r == next(m.begin(), 8));
+    r = m.upper_bound(4);
+    assert(r == next(m.begin(), 0));
+    r = m.upper_bound(6);
+    assert(r == next(m.begin(), 1));
+    r = m.upper_bound(8);
+    assert(r == next(m.begin(), 2));
+    r = m.upper_bound(10);
+    assert(r == next(m.begin(), 3));
+    r = m.upper_bound(12);
+    assert(r == next(m.begin(), 4));
+    r = m.upper_bound(14);
+    assert(r == next(m.begin(), 5));
+    r = m.upper_bound(16);
+    assert(r == next(m.begin(), 6));
+    r = m.upper_bound(18);
+    assert(r == next(m.begin(), 7));
+    r = m.upper_bound(20);
+    assert(r == next(m.begin(), 8));
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.ops/upper_bound0.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/upper_bound0.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// XFAIL: c++98, c++03, c++11
+
+// <map>
+
+// class map
+
+//       iterator upper_bound(const key_type& k);
+// const_iterator upper_bound(const key_type& k) const;
+//
+//   The member function templates find, count, lower_bound, upper_bound, and
+// equal_range shall not participate in overload resolution unless the
+// qualified-id Compare::is_transparent is valid and denotes a type
+
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "is_transparent.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::map<int, double, transparent_less> M;
+    M example;
+    assert(example.upper_bound(C2Int{5}) == example.end());
+    }
+    {
+    typedef std::map<int, double, transparent_less_not_referenceable> M;
+    M example;
+    assert(example.upper_bound(C2Int{5}) == example.end());
+    }
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.special/member_swap.pass.cpp
+++ b/tests/external/libcxx/map/map.special/member_swap.pass.cpp
@@ -1,0 +1,178 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// void swap(map& m);
+
+#include <map>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    typedef std::pair<const int, double> V;
+    {
+    typedef std::map<int, double> M;
+    {
+        M m1;
+        M m2;
+        M m1_save = m1;
+        M m2_save = m2;
+        m1.swap(m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+    }
+    {
+        V ar2[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        M m1;
+        M m2(ar2, ar2+sizeof(ar2)/sizeof(ar2[0]));
+        M m1_save = m1;
+        M m2_save = m2;
+        m1.swap(m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+    }
+    {
+        V ar1[] =
+        {
+            V(1, 1),
+            V(2, 2),
+            V(3, 3),
+            V(4, 4)
+        };
+        M m1(ar1, ar1+sizeof(ar1)/sizeof(ar1[0]));
+        M m2;
+        M m1_save = m1;
+        M m2_save = m2;
+        m1.swap(m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+    }
+    {
+        V ar1[] =
+        {
+            V(1, 1),
+            V(2, 2),
+            V(3, 3),
+            V(4, 4)
+        };
+        V ar2[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        M m1(ar1, ar1+sizeof(ar1)/sizeof(ar1[0]));
+        M m2(ar2, ar2+sizeof(ar2)/sizeof(ar2[0]));
+        M m1_save = m1;
+        M m2_save = m2;
+        m1.swap(m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+    }
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef std::map<int, double, std::less<int>, min_allocator<V>> M;
+    {
+        M m1;
+        M m2;
+        M m1_save = m1;
+        M m2_save = m2;
+        m1.swap(m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+    }
+    {
+        V ar2[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        M m1;
+        M m2(ar2, ar2+sizeof(ar2)/sizeof(ar2[0]));
+        M m1_save = m1;
+        M m2_save = m2;
+        m1.swap(m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+    }
+    {
+        V ar1[] =
+        {
+            V(1, 1),
+            V(2, 2),
+            V(3, 3),
+            V(4, 4)
+        };
+        M m1(ar1, ar1+sizeof(ar1)/sizeof(ar1[0]));
+        M m2;
+        M m1_save = m1;
+        M m2_save = m2;
+        m1.swap(m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+    }
+    {
+        V ar1[] =
+        {
+            V(1, 1),
+            V(2, 2),
+            V(3, 3),
+            V(4, 4)
+        };
+        V ar2[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        M m1(ar1, ar1+sizeof(ar1)/sizeof(ar1[0]));
+        M m2(ar2, ar2+sizeof(ar2)/sizeof(ar2[0]));
+        M m1_save = m1;
+        M m2_save = m2;
+        m1.swap(m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+    }
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/map.special/non_member_swap.pass.cpp
+++ b/tests/external/libcxx/map/map.special/non_member_swap.pass.cpp
@@ -1,0 +1,283 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// class map
+
+// template <class Key, class T, class Compare, class Allocator>
+//   void
+//   swap(map<Key, T, Compare, Allocator>& x, map<Key, T, Compare, Allocator>& y);
+
+#include <map>
+#include <cassert>
+#include "test_macros.h"
+#include "test_allocator.h"
+#include "../../../test_compare.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    typedef std::pair<const int, double> V;
+    {
+    typedef std::map<int, double> M;
+    {
+        M m1;
+        M m2;
+        M m1_save = m1;
+        M m2_save = m2;
+        swap(m1, m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+    }
+    {
+        V ar2[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        M m1;
+        M m2(ar2, ar2+sizeof(ar2)/sizeof(ar2[0]));
+        M m1_save = m1;
+        M m2_save = m2;
+        swap(m1, m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+    }
+    {
+        V ar1[] =
+        {
+            V(1, 1),
+            V(2, 2),
+            V(3, 3),
+            V(4, 4)
+        };
+        M m1(ar1, ar1+sizeof(ar1)/sizeof(ar1[0]));
+        M m2;
+        M m1_save = m1;
+        M m2_save = m2;
+        swap(m1, m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+    }
+    {
+        V ar1[] =
+        {
+            V(1, 1),
+            V(2, 2),
+            V(3, 3),
+            V(4, 4)
+        };
+        V ar2[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        M m1(ar1, ar1+sizeof(ar1)/sizeof(ar1[0]));
+        M m2(ar2, ar2+sizeof(ar2)/sizeof(ar2[0]));
+        M m1_save = m1;
+        M m2_save = m2;
+        swap(m1, m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+    }
+    }
+    {
+        typedef test_allocator<V> A;
+        typedef test_compare<std::less<int> > C;
+        typedef std::map<int, double, C, A> M;
+        V ar1[] =
+        {
+            V(1, 1),
+            V(2, 2),
+            V(3, 3),
+            V(4, 4)
+        };
+        V ar2[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        M m1(ar1, ar1+sizeof(ar1)/sizeof(ar1[0]), C(1), A(1, 1));
+        M m2(ar2, ar2+sizeof(ar2)/sizeof(ar2[0]), C(2), A(1, 2));
+        M m1_save = m1;
+        M m2_save = m2;
+        swap(m1, m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+        assert(m1.key_comp() == C(2));
+        assert(m1.get_allocator().get_id() == 1); // not swapped
+        assert(m2.key_comp() == C(1));
+        assert(m2.get_allocator().get_id() == 2);
+    }
+    {
+        typedef other_allocator<V> A;
+        typedef test_compare<std::less<int> > C;
+        typedef std::map<int, double, C, A> M;
+        V ar1[] =
+        {
+            V(1, 1),
+            V(2, 2),
+            V(3, 3),
+            V(4, 4)
+        };
+        V ar2[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        M m1(ar1, ar1+sizeof(ar1)/sizeof(ar1[0]), C(1), A(1));
+        M m2(ar2, ar2+sizeof(ar2)/sizeof(ar2[0]), C(2), A(2));
+        M m1_save = m1;
+        M m2_save = m2;
+        swap(m1, m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+        assert(m1.key_comp() == C(2));
+        assert(m1.get_allocator() == A(2));
+        assert(m2.key_comp() == C(1));
+        assert(m2.get_allocator() == A(1));
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef std::map<int, double, std::less<int>, min_allocator<V>> M;
+    {
+        M m1;
+        M m2;
+        M m1_save = m1;
+        M m2_save = m2;
+        swap(m1, m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+    }
+    {
+        V ar2[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        M m1;
+        M m2(ar2, ar2+sizeof(ar2)/sizeof(ar2[0]));
+        M m1_save = m1;
+        M m2_save = m2;
+        swap(m1, m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+    }
+    {
+        V ar1[] =
+        {
+            V(1, 1),
+            V(2, 2),
+            V(3, 3),
+            V(4, 4)
+        };
+        M m1(ar1, ar1+sizeof(ar1)/sizeof(ar1[0]));
+        M m2;
+        M m1_save = m1;
+        M m2_save = m2;
+        swap(m1, m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+    }
+    {
+        V ar1[] =
+        {
+            V(1, 1),
+            V(2, 2),
+            V(3, 3),
+            V(4, 4)
+        };
+        V ar2[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        M m1(ar1, ar1+sizeof(ar1)/sizeof(ar1[0]));
+        M m2(ar2, ar2+sizeof(ar2)/sizeof(ar2[0]));
+        M m1_save = m1;
+        M m2_save = m2;
+        swap(m1, m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+    }
+    }
+    {
+        typedef min_allocator<V> A;
+        typedef test_compare<std::less<int> > C;
+        typedef std::map<int, double, C, A> M;
+        V ar1[] =
+        {
+            V(1, 1),
+            V(2, 2),
+            V(3, 3),
+            V(4, 4)
+        };
+        V ar2[] =
+        {
+            V(5, 5),
+            V(6, 6),
+            V(7, 7),
+            V(8, 8),
+            V(9, 9),
+            V(10, 10),
+            V(11, 11),
+            V(12, 12)
+        };
+        M m1(ar1, ar1+sizeof(ar1)/sizeof(ar1[0]), C(1), A());
+        M m2(ar2, ar2+sizeof(ar2)/sizeof(ar2[0]), C(2), A());
+        M m1_save = m1;
+        M m2_save = m2;
+        swap(m1, m2);
+        assert(m1 == m2_save);
+        assert(m2 == m1_save);
+        assert(m1.key_comp() == C(2));
+        assert(m1.get_allocator() == A());
+        assert(m2.key_comp() == C(1));
+        assert(m2.get_allocator() == A());
+    }
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/map/types.pass.cpp
+++ b/tests/external/libcxx/map/types.pass.cpp
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <map>
+
+// template <class Key, class T, class Compare = less<Key>,
+//           class Allocator = allocator<pair<const Key, T>>>
+// class map
+// {
+// public:
+//     // types:
+//     typedef Key                                      key_type;
+//     typedef T                                        mapped_type;
+//     typedef pair<const key_type, mapped_type>        value_type;
+//     typedef Compare                                  key_compare;
+//     typedef Allocator                                allocator_type;
+//     typedef typename allocator_type::reference       reference;
+//     typedef typename allocator_type::const_reference const_reference;
+//     typedef typename allocator_type::pointer         pointer;
+//     typedef typename allocator_type::const_pointer   const_pointer;
+//     typedef typename allocator_type::size_type       size_type;
+//     typedef typename allocator_type::difference_type difference_type;
+//     ...
+// };
+
+#include <map>
+#include <type_traits>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+
+int main(int, char**)
+{
+    {
+    typedef std::map<int, double> C;
+    static_assert((std::is_same<C::key_type, int>::value), "");
+    static_assert((std::is_same<C::mapped_type, double>::value), "");
+    static_assert((std::is_same<C::value_type, std::pair<const int, double> >::value), "");
+    static_assert((std::is_same<C::key_compare, std::less<int> >::value), "");
+    static_assert((std::is_same<C::allocator_type, std::allocator<std::pair<const int, double> > >::value), "");
+    static_assert((std::is_same<C::reference, std::pair<const int, double>&>::value), "");
+    static_assert((std::is_same<C::const_reference, const std::pair<const int, double>&>::value), "");
+    static_assert((std::is_same<C::pointer, std::pair<const int, double>*>::value), "");
+    static_assert((std::is_same<C::const_pointer, const std::pair<const int, double>*>::value), "");
+    static_assert((std::is_same<C::size_type, std::size_t>::value), "");
+    static_assert((std::is_same<C::difference_type, std::ptrdiff_t>::value), "");
+    }
+#if TEST_STD_VER >= 11
+    {
+    typedef std::map<int, double, std::less<int>, min_allocator<std::pair<const int, double>>> C;
+    static_assert((std::is_same<C::key_type, int>::value), "");
+    static_assert((std::is_same<C::mapped_type, double>::value), "");
+    static_assert((std::is_same<C::value_type, std::pair<const int, double> >::value), "");
+    static_assert((std::is_same<C::key_compare, std::less<int> >::value), "");
+    static_assert((std::is_same<C::allocator_type, min_allocator<std::pair<const int, double> > >::value), "");
+    static_assert((std::is_same<C::reference, std::pair<const int, double>&>::value), "");
+    static_assert((std::is_same<C::const_reference, const std::pair<const int, double>&>::value), "");
+    static_assert((std::is_same<C::pointer, min_pointer<std::pair<const int, double>>>::value), "");
+    static_assert((std::is_same<C::const_pointer, min_pointer<const std::pair<const int, double>>>::value), "");
+//  min_allocator doesn't have a size_type, so one gets synthesized
+    static_assert((std::is_same<C::size_type, std::make_unsigned<C::difference_type>::type>::value), "");
+    static_assert((std::is_same<C::difference_type, std::ptrdiff_t>::value), "");
+    }
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
### Overview:
Intention of this PR is to add external tests taken from libcxx to support future concurrent map implementation.

### Commit description:
Added mockups in CMakeFiles
Files copied from:
https://github.com/llvm-mirror/libcxx/commit/78d6a7767

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/743)
<!-- Reviewable:end -->
