### PR TITLE
concurrent_map: fix windows compilation

### DIFF
--- a/include/libpmemobj++/container/detail/concurrent_skip_list_impl.hpp
+++ b/include/libpmemobj++/container/detail/concurrent_skip_list_impl.hpp
@@ -2010,8 +2010,9 @@ private:
 		obj::p<difference_type> size_diff;
 		obj::p<insert_stage_type> insert_stage;
 
-		char reserved[64 - sizeof(ptr) - sizeof(size_diff) -
-			      sizeof(insert_stage)];
+		char reserved[64 - sizeof(decltype(ptr)) -
+			      sizeof(decltype(size_diff)) -
+			      sizeof(decltype(insert_stage))];
 	};
 	static_assert(sizeof(tls_entry_type) == 64,
 		      "The size of tls_entry_type should be 64 bytes.");


### PR DESCRIPTION
On older MSVC versions sizeof(member) is not allowed in definition
of non-static members. Fix this by adding decltype().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/757)
<!-- Reviewable:end -->
