### PR TITLE
concurrent_map: fix windows compilation

### DIFF
--- a/include/libpmemobj++/container/detail/concurrent_skip_list_impl.hpp
+++ b/include/libpmemobj++/container/detail/concurrent_skip_list_impl.hpp
@@ -328,7 +328,10 @@ public:
 	}
 
 	/** Copy constructor. */
-	skip_list_iterator(const skip_list_iterator &other) = default;
+	skip_list_iterator(const skip_list_iterator &other)
+	    : pool_uuid(other.pool_uuid), node(other.node)
+	{
+	}
 
 	/** Copy constructor for const iterator from non-const iterator */
 	template <typename U = void,


### PR DESCRIPTION
Workaround a bug in MSVC 2015

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/766)
<!-- Reviewable:end -->
