### PR TITLE
[TO DISCUSS] set image-version parameter in CI definition's file

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -24,6 +24,7 @@ jobs:
       DOCKERHUB_PASSWORD:      ${{ secrets.DOCKERHUB_PASSWORD }}
       HOST_WORKDIR:   /home/runner/work/libpmemobj-cpp/libpmemobj-cpp
       WORKDIR:        utils/docker
+      IMAGE_VER:      1.11
     strategy:
       matrix:
         CONFIG: ["N=1 OS=ubuntu OS_VER=19.10 TYPE=debug PUSH_IMAGE=1",

--- a/travis.yml
+++ b/travis.yml
@@ -11,6 +11,7 @@ env:
   global:
     - GITHUB_REPO=pmem/libpmemobj-cpp
     - DOCKERHUB_REPO=pmem/libpmemobj-cpp
+    - IMAGE_VER=1.11
   matrix:
     - OS=ubuntu OS_VER=19.10 TYPE=debug PUSH_IMAGE=1
     - OS=fedora OS_VER=31    TYPE=debug PUSH_IMAGE=1
@@ -24,7 +25,6 @@ env:
     - OS=ubuntu OS_VER=19.10 TYPE=coverity
 
 before_install:
-  - echo $TRAVIS_COMMIT_RANGE
   - export HOST_WORKDIR=`pwd`
   - cd utils/docker
   - ./pull-or-rebuild-image.sh

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -41,13 +41,19 @@ if [[ -z "$OS" || -z "$OS_VER" ]]; then
 	exit 1
 fi
 
+if [[ -z "$IMAGE_VER" ]]; then
+	echo "IMAGE_VER environment variable is not set - a version of docker image, usually related to project's release tag"
+	exit 1
+fi
+
 if [[ -z "$HOST_WORKDIR" ]]; then
 	echo "ERROR: The variable HOST_WORKDIR has to contain a path to " \
 		"the root of this project on the host machine"
 	exit 1
 fi
 
-imageName=${DOCKERHUB_REPO}:1.10-${OS}-${OS_VER}
+TAG=${IMAGE_VER}-${OS}-${OS_VER}
+imageName=${DOCKERHUB_REPO}:${TAG}
 containerName=libpmemobj-cpp-${OS}-${OS_VER}
 
 if [[ "$command" == "" ]]; then

--- a/utils/docker/images/build-image.sh
+++ b/utils/docker/images/build-image.sh
@@ -3,9 +3,9 @@
 # Copyright 2016-2020, Intel Corporation
 
 #
-# build-image.sh <OS-VER> - prepares a Docker image with <OS>-based
+# build-image.sh <OS-OS_VER> - prepares a Docker image with <OS>-based
 #                           environment for testing libpmemobj-cpp, according
-#                           to the Dockerfile.<OS-VER> file located
+#                           to the Dockerfile.<OS-OS_VER> file located
 #                           in the same directory.
 #
 # The script can be run locally.
@@ -13,12 +13,18 @@
 
 set -e
 
-OS_VER=$1
+if [[ -z "$IMAGE_VER" ]]; then
+	echo "WARN: IMAGE_VER environment variable is not set - a version of docker's image, " \
+		 "usually related to project's release tag. It's used to tag the built docker image."
+fi
+
+OS__OS_VER=$1
+TAG=${IMAGE_VER}-${OS__OS_VER}
 
 function usage {
 	echo "Usage:"
-	echo "    build-image.sh <OS-VER>"
-	echo "where <OS-VER>, for example, can be 'fedora-31', provided " \
+	echo "    build-image.sh <OS-OS_VER>"
+	echo "where <OS-OS_VER>, for example, can be 'fedora-31', provided " \
 		"a Dockerfile named 'Dockerfile.fedora-31' exists in the " \
 		"current directory."
 }
@@ -29,16 +35,16 @@ if [[ -z "$1" ]]; then
 	exit 1
 fi
 
-# Check if the file Dockerfile.OS-VER exists
-if [[ ! -f "Dockerfile.$OS_VER" ]]; then
-	echo "Error: Dockerfile.$OS_VER does not exist."
+# Check if the file Dockerfile.OS-OS_VER exists
+if [[ ! -f "Dockerfile.$OS__OS_VER" ]]; then
+	echo "Error: Dockerfile.$OS__OS_VER does not exist in current dir."
 	echo
 	usage
 	exit 1
 fi
 
-# Build a Docker image tagged with ${DOCKERHUB_REPO}:1.10-OS-VER
-docker build -t ${DOCKERHUB_REPO}:1.10-${OS_VER} \
+# Build a Docker image tagged with ${DOCKERHUB_REPO}:${TAG}
+docker build -t ${DOCKERHUB_REPO}:${TAG} \
 	--build-arg http_proxy=$http_proxy \
 	--build-arg https_proxy=$https_proxy \
-	-f Dockerfile.${OS_VER} .
+	-f Dockerfile.${OS__OS_VER} .

--- a/utils/docker/images/push-image.sh
+++ b/utils/docker/images/push-image.sh
@@ -3,7 +3,7 @@
 # Copyright 2016-2020, Intel Corporation
 
 #
-# push-image.sh - pushes the Docker image tagged with OS-VER to the Docker Hub.
+# push-image.sh - pushes the Docker image tagged with IMAGE_VER-OS-OS_VER to the Docker Hub.
 #
 # The script utilizes $DOCKERHUB_USER and $DOCKERHUB_PASSWORD variables to
 # log in to the Docker Hub. The variables can be set in the CI's configuration
@@ -12,13 +12,18 @@
 
 set -e
 
+if [[ -z "$IMAGE_VER" ]]; then
+	echo "IMAGE_VER environment variable is not set - a version of docker image, usually related to project's release tag"
+	exit 1
+fi
+
 if [[ -z "$OS" ]]; then
-	echo "OS environment variable is not set"
+	echo "OS environment variable is not set - OS name, e.g. Fedora"
 	exit 1
 fi
 
 if [[ -z "$OS_VER" ]]; then
-	echo "OS_VER environment variable is not set"
+	echo "OS_VER environment variable is not set - OS's version, e.g. 31"
 	exit 1
 fi
 
@@ -27,9 +32,9 @@ if [[ -z "${DOCKERHUB_REPO}" ]]; then
 	exit 1
 fi
 
-TAG="1.10-${OS}-${OS_VER}"
+TAG="${IMAGE_VER}-${OS}-${OS_VER}"
 
-# Check if the image tagged with ${DOCKERHUB_REPO}:1.10-OS-VER exists locally
+# Check if the image tagged with ${DOCKERHUB_REPO}:${TAG} exists locally
 if [[ ! $(docker images -a | awk -v pattern="^${DOCKERHUB_REPO}:${TAG}\$" \
 	'$1":"$2 ~ pattern') ]]
 then

--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -44,11 +44,18 @@ if [[ -z "$OS" || -z "$OS_VER" ]]; then
 	exit 1
 fi
 
+if [[ -z "$IMAGE_VER" ]]; then
+	echo "IMAGE_VER environment variable is not set - a version of docker image, usually related to project's release tag"
+	exit 1
+fi
+
 if [[ -z "$HOST_WORKDIR" ]]; then
 	echo "ERROR: The variable HOST_WORKDIR has to contain a path to " \
 		"the root of this project on the host machine"
 	exit 1
 fi
+
+TAG=${IMAGE_VER}-${OS}-${OS_VER}
 
 # Find all the commits for the current build
 if [ -n "$CI_COMMIT_RANGE" ]; then
@@ -104,4 +111,4 @@ done
 
 # Getting here means rebuilding the Docker image is not required.
 # Pull the image from Docker Hub.
-docker pull ${DOCKERHUB_REPO}:1.10-${OS}-${OS_VER}
+docker pull ${DOCKERHUB_REPO}:${TAG}


### PR DESCRIPTION
instead of multiple tag's definitions in several scripts in docker directory.
Additionally, minor cleanups in scripts' files.

I'm going to test this on my fork (work in progress: https://github.com/lukaszstolarczuk/libpmemobj-cpp/actions/runs/123651502).

I'm a bit worried, if we shouldn't update our "build-image" policy - with current implementation, it won't rebuild if we update only the new variable (IMAGE_VER) in `.travis` or `.gha/workflows`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/774)
<!-- Reviewable:end -->
