### PR TITLE
force removal of docs' dir since it might not exist yet

### DIFF
--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -48,7 +48,7 @@ git checkout -B $GH_PAGES_NAME upstream/gh-pages
 git clean -dfx
 
 # Clean old content, since some files might have been deleted
-rm -r ./$VERSION
+rm -rf ./$VERSION
 mkdir -p ./$VERSION/doxygen/
 
 cp -r ../cpp_html/* ./$VERSION/doxygen/


### PR DESCRIPTION
When preparing docs for the first time the dir for the branch might not exist yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/786)
<!-- Reviewable:end -->
