### PR TITLE
get rid of old WA for vcpkg and use latest release instead

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -91,12 +91,6 @@ jobs:
          with:
             fetch-depth: 50
 
-       - name: Use old vcpkg for pmdk to build properly
-         working-directory: C:/vcpkg
-         run: |
-            git fetch --unshallow --tags
-            git checkout 6709d3d7d0cba96508ba3606f810ab562ea32556
-
        - name: Install PMDK
          run: |
             vcpkg install pmdk:x64-windows


### PR DESCRIPTION
ref. #785 - it's also required on stable-1.9 and -1.10

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/787)
<!-- Reviewable:end -->
