### PR TITLE
tests: enable map.ops tests which require generic std::less

### DIFF
--- a/tests/external/CMakeLists.txt
+++ b/tests/external/CMakeLists.txt
@@ -1136,6 +1136,12 @@ if (TEST_CONCURRENT_MAP)
 	build_test(map_libcxx_count libcxx/map/map.ops/count.pass.cpp)
 	add_test_generic(NAME map_libcxx_count TRACERS none pmemcheck memcheck)
 
+	# Test map with std::less<void> avaialable from C++14. Rest of the tests use custom implementation based on std::less.
+	if (CXX_STANDARD GREATER 11)
+		build_test_ext(NAME map_libcxx_count_std_less SRC_FILES libcxx/map/map.ops/count.pass.cpp BUILD_OPTIONS -DLIBPMEMOBJ_CPP_TESTS_USE_STD_LESS)
+		add_test_generic(NAME map_libcxx_count_std_less TRACERS none pmemcheck memcheck)
+	endif()
+
 	build_test(map_libcxx_count0 libcxx/map/map.ops/count0.pass.cpp)
 	add_test_generic(NAME map_libcxx_count0 TRACERS none pmemcheck memcheck)
 

--- a/tests/external/libcxx/map/map.ops/count.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/count.pass.cpp
@@ -30,17 +30,19 @@
 namespace nvobj = pmem::obj;
 namespace nvobjex = pmem::obj::experimental;
 
-using C = nvobjex::concurrent_map<int, double>;
-#ifdef XXX // Implement generic std::less
-using C2 = nvobjex::concurrent_map<int, double, std::less<>>;
-using C3 = nvobjex::concurrent_map<PrivateConstructor, double, std::less<>>;
+#ifdef LIBPMEMOBJ_CPP_TESTS_USE_STD_LESS
+using less_type = std::less<>;
+#else
+using less_type = transparent_less;
 #endif
+
+using C = nvobjex::concurrent_map<int, double>;
+using C2 = nvobjex::concurrent_map<int, double, less_type>;
+using C3 = nvobjex::concurrent_map<PrivateConstructor, double, less_type>;
 struct root {
 	nvobj::persistent_ptr<C> s;
-#ifdef XXX // Implement generic std::less
 	nvobj::persistent_ptr<C2> s2;
 	nvobj::persistent_ptr<C3> s3;
-#endif
 };
 
 int
@@ -121,7 +123,6 @@ run(pmem::obj::pool<root> &pop)
 		}
 	}
 #endif
-#ifdef XXX // Implement generic std::less
 	{
 		auto robj = pop.root();
 
@@ -217,7 +218,6 @@ run(pmem::obj::pool<root> &pop)
 		pmem::obj::transaction::run(
 			pop, [&] { nvobj::delete_persistent<C3>(robj->s3); });
 	}
-#endif
 	return 0;
 }
 

--- a/tests/external/libcxx/map/map.ops/equal_range.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/equal_range.pass.cpp
@@ -33,16 +33,13 @@ namespace nvobj = pmem::obj;
 namespace nvobjex = pmem::obj::experimental;
 
 using C = nvobjex::concurrent_map<int, double>;
-#ifdef XXX // Implement generic std::less
-using C1 = nvobjex::concurrent_map<int, double, std::less<>>;
-using C2 = nvobjex::concurrent_map<PrivateConstructor, double, std::less<>>;
-#endif
+using C1 = nvobjex::concurrent_map<int, double, transparent_less>;
+using C2 =
+	nvobjex::concurrent_map<PrivateConstructor, double, transparent_less>;
 struct root {
 	nvobj::persistent_ptr<C> s;
-#ifdef XXX // Implement generic std::less
 	nvobj::persistent_ptr<C1> s1;
 	nvobj::persistent_ptr<C2> s2;
-#endif
 };
 
 int
@@ -304,7 +301,6 @@ run(pmem::obj::pool<root> &pop)
 		}
 	}
 #endif
-#ifdef XXX // Implement generic std::less
 	{
 		auto robj = pop.root();
 		typedef std::pair<const int, double> V;
@@ -497,8 +493,6 @@ run(pmem::obj::pool<root> &pop)
 		pmem::obj::transaction::run(
 			pop, [&] { nvobj::delete_persistent<M>(robj->s2); });
 	}
-#endif
-
 	return 0;
 }
 

--- a/tests/external/libcxx/map/map.ops/find.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/find.pass.cpp
@@ -34,16 +34,13 @@ namespace nvobj = pmem::obj;
 namespace nvobjex = pmem::obj::experimental;
 
 using C = nvobjex::concurrent_map<int, double>;
-#ifdef XXX // Implement generic std::less
-using C1 = nvobjex::concurrent_map<int, double, std::less<>>;
-using C2 = nvobjex::concurrent_map<PrivateConstructor, double, std::less<>>;
-#endif
+using C1 = nvobjex::concurrent_map<int, double, transparent_less>;
+using C2 =
+	nvobjex::concurrent_map<PrivateConstructor, double, transparent_less>;
 struct root {
 	nvobj::persistent_ptr<C> s;
-#ifdef XXX // Implement generic std::less
 	nvobj::persistent_ptr<C1> s1;
 	nvobj::persistent_ptr<C2> s2;
-#endif
 };
 
 int
@@ -171,7 +168,6 @@ run(pmem::obj::pool<root> &pop)
 		}
 	}
 #endif
-#ifdef XXX // Implement generic std::less
 	{
 		typedef std::pair<const int, double> V;
 		typedef C1 M;
@@ -258,7 +254,6 @@ run(pmem::obj::pool<root> &pop)
 		pmem::obj::transaction::run(
 			pop, [&] { nvobj::delete_persistent<M>(robj->s2); });
 	}
-#endif
 	return 0;
 }
 

--- a/tests/external/libcxx/map/map.ops/lower_bound.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/lower_bound.pass.cpp
@@ -33,16 +33,13 @@ namespace nvobj = pmem::obj;
 namespace nvobjex = pmem::obj::experimental;
 
 using C = nvobjex::concurrent_map<int, double>;
-#ifdef XXX // Implement generic std::less
-using C2 = nvobjex::concurrent_map<int, double, std::less<>>;
-using C3 = nvobjex::concurrent_map<PrivateConstructor, double, std::less<>>;
-#endif
+using C2 = nvobjex::concurrent_map<int, double, transparent_less>;
+using C3 =
+	nvobjex::concurrent_map<PrivateConstructor, double, transparent_less>;
 struct root {
 	nvobj::persistent_ptr<C> s;
-#ifdef XXX // Implement generic std::less
 	nvobj::persistent_ptr<C2> s2;
 	nvobj::persistent_ptr<C3> s3;
-#endif
 };
 
 int
@@ -234,7 +231,6 @@ run(pmem::obj::pool<root> &pop)
 		}
 	}
 #endif
-#ifdef XXX // Implement generic std::less
 	{
 		typedef std::pair<const int, double> V;
 		typedef C2 M;
@@ -373,7 +369,6 @@ run(pmem::obj::pool<root> &pop)
 		pmem::obj::transaction::run(
 			pop, [&] { nvobj::delete_persistent<M>(robj->s3); });
 	}
-#endif
 	return 0;
 }
 

--- a/tests/external/libcxx/map/map.ops/upper_bound.pass.cpp
+++ b/tests/external/libcxx/map/map.ops/upper_bound.pass.cpp
@@ -26,22 +26,20 @@
 #include <libpmemobj++/pool.hpp>
 #include <libpmemobj++/transaction.hpp>
 
+#include "../is_transparent.h"
 #include "../private_constructor.h"
 
 namespace nvobj = pmem::obj;
 namespace nvobjex = pmem::obj::experimental;
 
 using C = nvobjex::concurrent_map<int, double>;
-#ifdef XXX // Implement generic std::less
-using C2 = nvobjex::concurrent_map<int, double, std::less<>>;
-using C3 = nvobjex::concurrent_map<PrivateConstructor, double, std::less<>>;
-#endif
+using C2 = nvobjex::concurrent_map<int, double, transparent_less>;
+using C3 =
+	nvobjex::concurrent_map<PrivateConstructor, double, transparent_less>;
 struct root {
 	nvobj::persistent_ptr<C> s;
-#ifdef XXX // Implement generic std::less
 	nvobj::persistent_ptr<C2> s2;
 	nvobj::persistent_ptr<C3> s3;
-#endif
 };
 
 int
@@ -233,7 +231,6 @@ run(pmem::obj::pool<root> &pop)
 		}
 	}
 #endif
-#ifdef XXX // Implement generic std::less
 	{
 		typedef std::pair<const int, double> V;
 		typedef C2 M;
@@ -336,7 +333,6 @@ run(pmem::obj::pool<root> &pop)
 		pmem::obj::transaction::run(
 			pop, [&] { nvobj::delete_persistent<M>(robj->s3); });
 	}
-#endif
 	return 0;
 }
 


### PR DESCRIPTION
Intead of std::less<void> which is available from C++14 use
transaprent less which has the same implementation.

Leave just one test with std::less<> as sanity check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/798)
<!-- Reviewable:end -->
