### PR TITLE
align issues' labels to recent update

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Did you find a bug in libpmemobj-cpp? Please let us know.
-labels: "bug"
+labels: "Type: Bug"
 ---
 <!--
 Before creating new issue, ensure that similar issue wasn't already created

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,7 +1,7 @@
 ---
 name: Feature
 about: Feature your request
-labels: "enhancement"
+labels: "Type: Feature"
 ---
 # FEAT: <!-- fill the title of feature -->
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,7 @@
 ---
 name: Question
 about: Do you have question regarding libpmemobj-cpp? Don't hesitate to ask.
-labels: "question"
+labels: "Type: Question"
 ---
 # QUESTION: <!-- fill the title of question -->
 


### PR DESCRIPTION
I've cleaned up labels for issues and aligned them between projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/799)
<!-- Reviewable:end -->
