### PR TITLE
Add missing constructor to concurrent map

### DIFF
--- a/include/libpmemobj++/experimental/concurrent_map.hpp
+++ b/include/libpmemobj++/experimental/concurrent_map.hpp
@@ -87,6 +87,15 @@ public:
 	}
 
 	/**
+	 * Construct the empty map
+	 */
+	explicit concurrent_map(const key_compare &comp,
+				const allocator_type &alloc = allocator_type())
+	    : base_type(comp, alloc)
+	{
+	}
+
+	/**
 	 * Constructs the map with the contents of the range [first, last).
 	 */
 	template <class InputIt>

--- a/tests/external/CMakeLists.txt
+++ b/tests/external/CMakeLists.txt
@@ -1064,8 +1064,8 @@ if (TEST_CONCURRENT_MAP)
 	# build_test_ext(NAME map_libcxx_compare_alloc SRC_FILES libcxx/map/map.cons/compare_alloc.pass.cpp BUILD_OPTIONS -DLIBPMEMOBJ_CPP_TESTS_CONCURRENT_MAP)
 	# add_test_generic(NAME map_libcxx_compare_alloc TRACERS none pmemcheck memcheck)
 
-	# build_test_ext(NAME map_libcxx_compare SRC_FILES libcxx/map/map.cons/compare.pass.cpp BUILD_OPTIONS -DLIBPMEMOBJ_CPP_TESTS_CONCURRENT_MAP)
-	# add_test_generic(NAME map_libcxx_compare TRACERS none pmemcheck memcheck)
+	build_test_ext(NAME map_libcxx_compare SRC_FILES libcxx/map/map.cons/compare.pass.cpp BUILD_OPTIONS -DLIBPMEMOBJ_CPP_TESTS_CONCURRENT_MAP)
+	add_test_generic(NAME map_libcxx_compare TRACERS none pmemcheck memcheck)
 
 	# build_test_ext(NAME map_libcxx_copy_alloc SRC_FILES libcxx/map/map.cons/copy_alloc.pass.cpp BUILD_OPTIONS -DLIBPMEMOBJ_CPP_TESTS_CONCURRENT_MAP)
 	# add_test_generic(NAME map_libcxx_copy_alloc TRACERS none pmemcheck memcheck)

--- a/tests/external/libcxx/map/map.cons/compare.pass.cpp
+++ b/tests/external/libcxx/map/map.cons/compare.pass.cpp
@@ -77,7 +77,6 @@ struct root {
 int
 run(pmem::obj::pool<root> &pop)
 {
-#ifdef XXX // XXX: Probably missing constructor
 	auto robj = pop.root();
 	{
 		pmem::obj::transaction::run(pop, [&] {
@@ -90,7 +89,6 @@ run(pmem::obj::pool<root> &pop)
 		pmem::obj::transaction::run(
 			pop, [&] { nvobj::delete_persistent<CM>(robj->s); });
 	}
-#endif
 #ifdef XXX // XXX: implement min_allocator
 	{
 		typedef test_compare<std::less<int>> C;


### PR DESCRIPTION
It depends on: #782 
I will rebase after merge.

Description:
- Add missing constructor to concurrent map

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/812)
<!-- Reviewable:end -->
