### PR TITLE
[TO DISCUSS] bump chars limit in line to 120

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,10 +20,10 @@ BraceWrapping:
   IndentBraces:			false
 BreakBeforeBraces: Custom
 BreakStringLiterals: false
+ColumnLimit: 120
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ContinuationIndentWidth: 8
 FixNamespaceComments: false
-IndentCaseLabels: false
 IndentCaseLabels: true
 IndentWidth: 8
 PointerAlignment: Right

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Details such as OS and PMDK version are always appreciated.
 
 * See `.clang-format` file in the repository for details
 * Indent with tabs (width: 8)
-* Max 90 chars per line
+* Max 120 chars per line
 * Space before '*' and '&' (rather than after)
 
 If you want to check and format your source code properly you can use CMake's `DEVELOPER_MODE`


### PR DESCRIPTION
and remove doubled .clang-format configuration's rule.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/816)
<!-- Reviewable:end -->
