### PR TITLE
doc: add examples/ to EXAMPLE_PATH in doxyfile

### DIFF
--- a/doc/libpmemobj++.Doxyfile.in
+++ b/doc/libpmemobj++.Doxyfile.in
@@ -128,6 +128,7 @@ EXCLUDE =
 # command).
 
 EXAMPLE_PATH = @CMAKE_SOURCE_DIR@/examples/doc_snippets
+EXAMPLE_PATH += @CMAKE_SOURCE_DIR@/examples
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and


### PR DESCRIPTION
Without this, doxygen cannot find doc snippets from examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/819)
<!-- Reviewable:end -->
