### PR TITLE
Update ndctl

### DIFF
--- a/utils/docker/images/install-libndctl.sh
+++ b/utils/docker/images/install-libndctl.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2019, Intel Corporation
+# Copyright 2018-2020, Intel Corporation
 
 #
 # install-libndctl.sh - installs libndctl
@@ -13,7 +13,7 @@ OS=$1
 echo "==== clone ndctl repo ===="
 git clone https://github.com/pmem/ndctl.git
 cd ndctl
-git checkout tags/v64.1
+git checkout v69
 
 if [ "$OS" = "fedora" ]; then
 


### PR DESCRIPTION
ndctl causes problems on archlinux docker; new version should work just fine.

// archlinux docker was build correctly with this ndctl, see: https://github.com/pmem/libpmemobj-cpp/runs/931104514

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/826)
<!-- Reviewable:end -->
