### PR TITLE
Ignore more libunwind errors

### DIFF
--- a/tests/memcheck-libunwind.supp
+++ b/tests/memcheck-libunwind.supp
@@ -21,3 +21,9 @@
    obj:*libunwind*
    ...
 }
+{
+   libunwind calls glibc's setcontext on some architectures, e.g. ppc
+   Memcheck:Addr8
+   fun:setcontext*
+   ...
+}


### PR DESCRIPTION
On most architectures, libunwind reuses getcontext and setcontext from
the C standard library.  memcheck report errors from these setcontext
calls.
This has been reproduced on ppc64le.

[1] https://github.com/libunwind/libunwind#libc-requirements

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/837)
<!-- Reviewable:end -->
