### PR TITLE
tests: add libunwind suppresion

### DIFF
--- a/tests/memcheck-libunwind.supp
+++ b/tests/memcheck-libunwind.supp
@@ -27,3 +27,11 @@
    fun:setcontext*
    ...
 }
+{
+   libunwind exception suppresion
+   Memcheck:Param
+   write(buf)
+   ...
+   obj:*libunwind*
+   ...
+}


### PR DESCRIPTION
Memcheck reports an error in libunwind exception raising.

Closes https://github.com/pmem/libpmemobj-cpp/issues/831

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/850)
<!-- Reviewable:end -->
