### PR TITLE
remove doubled clang-format configuration's rule

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,7 +23,6 @@ BreakStringLiterals: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ContinuationIndentWidth: 8
 FixNamespaceComments: false
-IndentCaseLabels: false
 IndentCaseLabels: true
 IndentWidth: 8
 PointerAlignment: Right


### PR DESCRIPTION
this rule is for indenting cases of a switch clause (seems about right to has it on "true")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/856)
<!-- Reviewable:end -->
