### PR TITLE
Update doxygen settings

### DIFF
--- a/doc/libpmemobj++.Doxyfile.in
+++ b/doc/libpmemobj++.Doxyfile.in
@@ -23,7 +23,7 @@ PROJECT_NAME = "PMDK C++ bindings"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER = "1.2.0"
+PROJECT_NUMBER = @VERSION@
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doc/libpmemobj++.Doxyfile.in
+++ b/doc/libpmemobj++.Doxyfile.in
@@ -73,7 +73,7 @@ HIDE_UNDOC_CLASSES = YES
 # standard output by doxygen. If QUIET is set to YES this implies that the
 # messages are off.
 
-QUIET = YES
+QUIET = NO
 
 # The COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns
 # in which the alphabetical index list will be split.

--- a/doc/libpmemobj++.Doxyfile.in
+++ b/doc/libpmemobj++.Doxyfile.in
@@ -75,6 +75,11 @@ HIDE_UNDOC_CLASSES = YES
 
 QUIET = YES
 
+# The COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns
+# in which the alphabetical index list will be split.
+
+COLS_IN_ALPHA_INDEX = 1
+
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------


### PR DESCRIPTION
- set proper version of project displayed in doxygen's docs
- fix class index view (only one column)
- `make doc` is verbose now

v1.5 preview, after fixes: https://lukaszstolarczuk.github.io/libpmemobj-cpp/v1.5/doxygen/classes.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/858)
<!-- Reviewable:end -->
