### PR TITLE
concurrent_hash_map: make double to size_t cast explicit in defragment()

### DIFF
--- a/include/libpmemobj++/container/concurrent_hash_map.hpp
+++ b/include/libpmemobj++/container/concurrent_hash_map.hpp
@@ -2851,8 +2851,14 @@ public:
 		}
 
 		size_t max_index = mask().load(std::memory_order_acquire);
-		size_t start_index = (start_percent * max_index) / 100;
-		size_t end_index = (end_percent * max_index) / 100;
+		size_t start_index =
+			static_cast<size_t>((start_percent * max_index) / 100);
+		size_t end_index =
+			static_cast<size_t>((end_percent * max_index) / 100);
+
+		/* Make sure we do not use too big index, even in case of
+		 * rounding errors. */
+		end_index = (std::min)(end_index, max_index);
 
 #if LIBPMEMOBJ_CPP_VG_HELGRIND_ENABLED
 		ANNOTATE_HAPPENS_AFTER(&(this->my_mask));


### PR DESCRIPTION
and make sure only indexes up to max_index are used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/860)
<!-- Reviewable:end -->
