### PR TITLE
Add conversion operator to basic_string

### DIFF
--- a/include/libpmemobj++/container/basic_string.hpp
+++ b/include/libpmemobj++/container/basic_string.hpp
@@ -23,6 +23,7 @@
 #include <libpmemobj++/persistent_ptr.hpp>
 #include <libpmemobj++/pext.hpp>
 #include <libpmemobj++/slice.hpp>
+#include <libpmemobj++/string_view.hpp>
 #include <libpmemobj++/transaction.hpp>
 #include <libpmemobj++/utils.hpp>
 
@@ -291,6 +292,8 @@ public:
 		noexcept;
 
 	void swap(basic_string &other);
+
+	operator basic_string_view<CharT, Traits>() const;
 
 	/* Special value. The exact meaning depends on the context. */
 	static const size_type npos = static_cast<size_type>(-1);
@@ -4054,6 +4057,15 @@ basic_string<CharT, Traits>::swap(basic_string &other)
 			*_long = tmp;
 		}
 	});
+}
+
+/**
+ * Return new view from this string object.
+ */
+template <typename CharT, typename Traits>
+basic_string<CharT, Traits>::operator basic_string_view<CharT, Traits>() const
+{
+	return basic_string_view<CharT, Traits>(cdata(), length());
 }
 
 /**

--- a/tests/string_access/string_access.cpp
+++ b/tests/string_access/string_access.cpp
@@ -5,6 +5,7 @@
 
 #include <libpmemobj++/container/string.hpp>
 #include <libpmemobj++/make_persistent.hpp>
+#include <libpmemobj++/string_view.hpp>
 
 namespace nvobj = pmem::obj;
 
@@ -39,6 +40,8 @@ check_access_out_of_tx(S &s)
 		s.crend();
 		s.cfront();
 		s.cback();
+		s.operator pmem::obj::basic_string_view<S::value_type,
+							S::traits_type>();
 
 		static_cast<const S &>(s)[0];
 		static_cast<const S &>(s).at(0);
@@ -49,6 +52,8 @@ check_access_out_of_tx(S &s)
 		static_cast<const S &>(s).rend();
 		static_cast<const S &>(s).front();
 		static_cast<const S &>(s).back();
+		static_cast<const S &>(s).operator pmem::obj::
+			basic_string_view<S::value_type, S::traits_type>();
 	} catch (std::exception &e) {
 		UT_FATALexc(e);
 	}

--- a/tests/string_snapshot/string_snapshot.cpp
+++ b/tests/string_snapshot/string_snapshot.cpp
@@ -58,7 +58,9 @@ test_string_snapshot(pmem::obj::pool<struct root> &pop)
 		pmem::obj::transaction::run(pop, [&] {
 			auto data = r->short_str->data();
 			strcpy(data, short_c_str);
+			pmem::obj::string_view sv(*r->long_str);
 
+			UT_ASSERTeq(sv.compare(*r->long_str), 0);
 			UT_ASSERTeq(T::compare(r->short_str->cdata(),
 					       short_c_str,
 					       r->short_str->size()),


### PR DESCRIPTION
This PR will introduce following:
﻿- Add conversion operator to pmem::obj::string
- Extend tests according to changes in pmem::obj::string

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/865)
<!-- Reviewable:end -->
