### PR TITLE
docker: make build- and push-image scripts more verbose

### DIFF
--- a/utils/docker/images/build-image.sh
+++ b/utils/docker/images/build-image.sh
@@ -49,20 +49,20 @@ function usage {
 		"current directory."
 }
 
-# Check if the first and second argument is nonempty
-if [[ -z "$1" || -z "$2" ]]; then
+echo "Check if the first and second argument are nonempty: \"${1}\", \"${2}\""
+if [[ -z "${1}" || -z "${2}" ]]; then
 	usage
 	exit 1
 fi
 
-# Check if the file Dockerfile.OS-VER exists
+echo "Check if the file Dockerfile.${1}-${2} exists"
 if [[ ! -f "Dockerfile.$2" ]]; then
 	echo "ERROR: wrong argument."
 	usage
 	exit 1
 fi
 
-# Build a Docker image tagged with ${DOCKERHUB_REPO}:1.6-OS-VER
+echo "Build a Docker image tagged with ${DOCKERHUB_REPO}:1.6-${1}-${2}"
 docker build -t $1:1.6-$2 \
 	--build-arg http_proxy=$http_proxy \
 	--build-arg https_proxy=$https_proxy \

--- a/utils/docker/images/push-image.sh
+++ b/utils/docker/images/push-image.sh
@@ -49,14 +49,15 @@ function usage {
 		"locally."
 }
 
-# Check if the first argument is nonempty
-if [[ -z "$1" ]]; then
+OS__OS_VER=${1}
+echo "Check if the first argument (OS-VER) is nonempty: \"${OS__OS_VER}\""
+if [[ -z "${OS__OS_VER}" ]]; then
 	usage
 	exit 1
 fi
 
-# Check if the image tagged with ${DOCKERHUB_REPO}:1.6-OS-VER exists locally
-if [[ ! $(docker images -a | awk -v pattern="^${DOCKERHUB_REPO}:1.6-$1\$" \
+echo "Check if the image tagged with ${DOCKERHUB_REPO}:1.6-${OS__OS_VER} exists locally"
+if [[ ! $(docker images -a | awk -v pattern="^${DOCKERHUB_REPO}:1.6-${OS__OS_VER}\$" \
 	'$1":"$2 ~ pattern') ]]
 then
 	echo "ERROR: wrong argument."
@@ -64,8 +65,8 @@ then
 	exit 1
 fi
 
-# Log in to the Docker Hub
+echo "Log in to the Docker Hub"
 docker login -u="$DOCKERHUB_USER" -p="$DOCKERHUB_PASSWORD"
 
-# Push the image to the repository
+echo "Push the image to the repository"
 docker push ${DOCKERHUB_REPO}:1.6-$1


### PR DESCRIPTION
Sometimes I didn't even know if push took place ;) Change is going to stable-1.6, since 1.5 will be EOL soon, I guess.

I didn't change `$1` and `$1` in build-image.sh on purpose, because there are some changes with these variables in "upper" branches (to avoid big conflicts 😉 ).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/875)
<!-- Reviewable:end -->
