### PR TITLE
windows: do not use U_FORTIFY_SOURCE before D_FORTIFY_SOURCE

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -3,8 +3,10 @@
 
 if(MSVC_VERSION)
 	add_flag(-W2)
+	add_flag("-D_FORTIFY_SOURCE=2" RELEASE)
 else()
 	add_flag(-Wall)
+	add_flag("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2" RELEASE)
 endif()
 add_flag(-Wpointer-arith)
 add_flag(-Wsign-compare)
@@ -16,8 +18,6 @@ add_flag(-Wsign-conversion)
 
 add_flag(-ggdb DEBUG)
 add_flag(-DDEBUG DEBUG)
-
-add_flag("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2" RELEASE)
 
 include_directories(${LIBPMEMOBJ_INCLUDE_DIRS} .)
 link_directories(${LIBPMEMOBJ_LIBRARY_DIRS})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,8 +3,10 @@
 
 if(MSVC_VERSION)
 	add_flag(-W2)
+	add_flag("-D_FORTIFY_SOURCE=2" RELEASE)
 else()
 	add_flag(-Wall)
+	add_flag("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2" RELEASE)
 endif()
 add_flag(-Wpointer-arith)
 add_flag(-Wsign-compare)
@@ -16,8 +18,6 @@ add_flag(-fno-common)
 
 add_flag(-ggdb DEBUG)
 add_flag(-DDEBUG DEBUG)
-
-add_flag("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2" RELEASE)
 
 if(USE_ASAN)
 	add_sanitizer_flag(address)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,8 +32,11 @@ if(MSVC_VERSION)
 
 	# fix C1128 raised for some test binaries
 	add_flag(-bigobj)
+
+	add_flag("-D_FORTIFY_SOURCE=2" RELEASE)
 else()
 	add_flag(-Wall)
+	add_flag("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2" RELEASE)
 endif()
 
 add_flag(-Wpointer-arith)
@@ -47,7 +50,7 @@ add_flag(-fno-common)
 add_flag(-ggdb DEBUG)
 add_flag(-DDEBUG DEBUG)
 
-add_flag("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2" RELEASE)
+
 
 if(USE_ASAN)
        add_sanitizer_flag(address)


### PR DESCRIPTION
windows compiler will override D_FORTIFY_SOURCE with U_FORITY_SOURCE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/894)
<!-- Reviewable:end -->
