### PR TITLE
docker: cron workflows are no longer for coverity jobs only

### DIFF
--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -30,13 +30,6 @@ if [[ "$CI_EVENT_TYPE" != "cron" && "$CI_BRANCH" != "coverity_scan" \
 	exit 0
 fi
 
-if [[ ( "$CI_EVENT_TYPE" == "cron" || "$CI_BRANCH" == "coverity_scan" )\
-	&& "$TYPE" != "coverity" ]]; then
-	echo "INFO: Skip regular jobs if build is triggered either by 'cron'" \
-		" or by a push to 'coverity_scan' branch"
-	exit 0
-fi
-
 if [[ -z "$OS" || -z "$OS_VER" ]]; then
 	echo "ERROR: The variables OS and OS_VER have to be set " \
 		"(eg. OS=fedora, OS_VER=31)."

--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -32,13 +32,6 @@ if [[ "$CI_EVENT_TYPE" != "cron" && "$CI_BRANCH" != "coverity_scan" \
 	exit 0
 fi
 
-if [[ ( "$CI_EVENT_TYPE" == "cron" || "$CI_BRANCH" == "coverity_scan" )\
-	&& "$TYPE" != "coverity" ]]; then
-	echo "INFO: Skip regular jobs if build is triggered either by 'cron'" \
-		" or by a push to 'coverity_scan' branch"
-	exit 0
-fi
-
 if [[ -z "$OS" || -z "$OS_VER" ]]; then
 	echo "ERROR: The variables OS and OS_VER have to be set properly " \
              "(eg. OS=fedora, OS_VER=31)."


### PR DESCRIPTION
without this fix it skips our cron jobs, see e.g.:
https://github.com/pmem/libpmemobj-cpp/actions/runs/275798439

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/901)
<!-- Reviewable:end -->
