### PR TITLE
radix_tree: fix upper_bound implementation

### DIFF
--- a/include/libpmemobj++/experimental/radix_tree.hpp
+++ b/include/libpmemobj++/experimental/radix_tree.hpp
@@ -2010,6 +2010,10 @@ radix_tree<Key, Value, BytesView>::internal_bound(const K &k) const
 		return const_iterator(leaf, &root);
 	}
 
+	if (slot == &root) {
+		return const_iterator(nullptr, &root);
+	}
+
 	/* Since looked-for key is larger than *slot, the target node must be
 	 * within subtree of a right sibling of *slot. */
 	leaf = next_leaf<node::direction::Forward>(

--- a/include/libpmemobj++/experimental/radix_tree.hpp
+++ b/include/libpmemobj++/experimental/radix_tree.hpp
@@ -314,7 +314,7 @@ private:
 	template <typename K1, typename K2>
 	static byten_t prefix_diff(const K1 &lhs, const K2 &rhs,
 				   byten_t offset = 0);
-	leaf *any_lower_leaf(tagged_node_ptr n, size_type min_depth) const;
+	leaf *any_leftmost_leaf(tagged_node_ptr n, size_type min_depth) const;
 	template <typename K1, typename K2>
 	static bitn_t bit_diff(const K1 &leaf_key, const K2 &key, byten_t diff);
 	template <typename K>
@@ -942,14 +942,14 @@ radix_tree<Key, Value, BytesView>::parent_ref(tagged_node_ptr n)
 }
 
 /*
- * Find a leaf in a subtree of @param n.
+ * Find a leftmost leaf in a subtree of @param n.
  *
  * @param min_depth specifies minimum depth of the leaf. If the
  * tree is shorter than min_depth, a bottom leaf is returned.
  */
 template <typename Key, typename Value, typename BytesView>
 typename radix_tree<Key, Value, BytesView>::leaf *
-radix_tree<Key, Value, BytesView>::any_lower_leaf(
+radix_tree<Key, Value, BytesView>::any_leftmost_leaf(
 	typename radix_tree<Key, Value, BytesView>::tagged_node_ptr n,
 	size_type min_depth) const
 {
@@ -987,7 +987,7 @@ radix_tree<Key, Value, BytesView>::common_prefix_leaf(const K &key) const
 		if (nn)
 			n = nn;
 		else {
-			n = any_lower_leaf(n, key.size());
+			n = any_leftmost_leaf(n, key.size());
 			break;
 		}
 	}
@@ -995,7 +995,7 @@ radix_tree<Key, Value, BytesView>::common_prefix_leaf(const K &key) const
 	/* This can happen when key is a prefix of some leaf or when the node at
 	 * which the keys diverge isn't a leaf */
 	if (!n.is_leaf())
-		n = any_lower_leaf(n, key.size());
+		n = any_leftmost_leaf(n, key.size());
 
 	return n.get_leaf();
 }


### PR DESCRIPTION
If a key was not present in a radix tree and a slot variable was
set to &root, next_leaf function lead to accessing uninitialzied memory
(we tried to increment slot, as if it was a pointer to an element in array).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/906)
<!-- Reviewable:end -->
