### PR TITLE
examples: update min cmake version to 3.4

### DIFF
--- a/examples/array/CMakeLists.txt
+++ b/examples/array/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2019, Intel Corporation
+# Copyright 2018-2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(array CXX)
 
 set(CXX_STANDARD_REQUIRED ON)

--- a/examples/concurrent_hash_map/CMakeLists.txt
+++ b/examples/concurrent_hash_map/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(concurrent_hash_map CXX)
 
 set(CXX_STANDARD_REQUIRED ON)

--- a/examples/defrag/CMakeLists.txt
+++ b/examples/defrag/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(defrag CXX)
 
 set(CXX_STANDARD_REQUIRED ON)

--- a/examples/make_persistent/CMakeLists.txt
+++ b/examples/make_persistent/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(make_persistent CXX)
 
 set(CXX_STANDARD_REQUIRED ON)

--- a/examples/map_cli/CMakeLists.txt
+++ b/examples/map_cli/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2019, Intel Corporation
+# Copyright 2018-2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(map_cli CXX)
 
 set(CXX_STANDARD_REQUIRED ON)

--- a/examples/mutex/CMakeLists.txt
+++ b/examples/mutex/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(mutex CXX)
 
 set(CXX_STANDARD_REQUIRED ON)

--- a/examples/panaconda/CMakeLists.txt
+++ b/examples/panaconda/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2019, Intel Corporation
+# Copyright 2018-2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(panaconda CXX)
 
 set(CXX_STANDARD_REQUIRED ON)

--- a/examples/persistent/CMakeLists.txt
+++ b/examples/persistent/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(persistent CXX)
 
 set(CXX_STANDARD_REQUIRED ON)

--- a/examples/pman/CMakeLists.txt
+++ b/examples/pman/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2019, Intel Corporation
+# Copyright 2018-2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(pman CXX)
 
 set(CXX_STANDARD_REQUIRED ON)

--- a/examples/pmpong/CMakeLists.txt
+++ b/examples/pmpong/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2019, Intel Corporation
+# Copyright 2018-2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(pmpong CXX)
 
 set(CXX_STANDARD_REQUIRED ON)

--- a/examples/pool/CMakeLists.txt
+++ b/examples/pool/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(pool CXX)
 
 set(CXX_STANDARD_REQUIRED ON)

--- a/examples/queue/CMakeLists.txt
+++ b/examples/queue/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2019, Intel Corporation
+# Copyright 2018-2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(queue CXX)
 
 set(CXX_STANDARD_REQUIRED ON)

--- a/examples/segment_vector/CMakeLists.txt
+++ b/examples/segment_vector/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(segment_vector CXX)
 
 set(CXX_STANDARD_REQUIRED ON)

--- a/examples/slab/CMakeLists.txt
+++ b/examples/slab/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(slab CXX)
 
 set(CXX_STANDARD_REQUIRED ON)

--- a/examples/string/CMakeLists.txt
+++ b/examples/string/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(string CXX)
 
 set(CXX_STANDARD_REQUIRED ON)

--- a/examples/transaction/CMakeLists.txt
+++ b/examples/transaction/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(transaction CXX)
 
 set(CXX_STANDARD_REQUIRED ON)

--- a/examples/v/CMakeLists.txt
+++ b/examples/v/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.4)
 project(v CXX)
 
 set(CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
in examples using 'include' command - it also uses 'CheckIncludeFile'
which (in CMake <=3.3) worked only with set project language (CXX in this case),
and some included files are supposed to be checked with C lang, too.

With help of: https://github.com/nlohmann/cmake_min_version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/922)
<!-- Reviewable:end -->
