### PR TITLE
docker: fix auto docs generating - force clean dir

### DIFF
--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -58,7 +58,7 @@ git checkout -B ${GH_PAGES_NAME} upstream/gh-pages
 git clean -dfx
 
 # Clean old content, since some files might have been deleted
-rm -r ./${VERSION}
+rm -rf ./${VERSION}
 mkdir -p ./${VERSION}/doxygen/
 
 cp -fr ${ARTIFACTS_DIR}/cpp_html/* ./${VERSION}/doxygen/


### PR DESCRIPTION
it's required for new branches, where target directory does not exist yet.

// yes, yet another fix for docs... I hope it's the last one 😉

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/924)
<!-- Reviewable:end -->
