### PR TITLE
add "rebuild" param to utils' script, to force dockers rebuilding

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -20,7 +20,7 @@ before_install:
   - export GITHUB_REPO=pmem/libpmemobj-cpp
   - export DOCKERHUB_REPO=pmem/libpmemobj-cpp
   - cd utils/docker
-  - ./pull-or-rebuild-image.sh
+  - ./pull-or-rebuild-image.sh rebuild
   - if [[ -f push_image_to_repo_flag ]]; then PUSH_THE_IMAGE=1; fi
   - if [[ -f skip_build_package_check ]]; then export SKIP_CHECK=1; fi
   - rm -f push_image_to_repo_flag skip_build_package_check


### PR DESCRIPTION
it makes more sense to rebuild dockers all the time on stable branches,
because we don't have to count on DockerHub's policy to keep our
docker images on their servers.

this change is based on commit on master: 0c5bf91852cf64a067af9ac0caf23ccc008f77b8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/929)
<!-- Reviewable:end -->
