### PR TITLE
Use GH Container Registry instead of Docker Hub

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,6 +1,5 @@
 
 name: CPP-coverity
-
 on:
   schedule:
     # run this job at 00:00 UTC everyday
@@ -9,7 +8,7 @@ on:
 env:
   REPO:           libpmemobj-cpp
   GITHUB_REPO:    pmem/libpmemobj-cpp
-  DOCKERHUB_REPO: pmem/libpmemobj-cpp
+  CONTAINER_REG:  ghcr.io/pmem/libpmemobj-cpp
 
 jobs:
   linux:

--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -4,15 +4,16 @@ on: [push, pull_request]
 env:
   REPO:           libpmemobj-cpp
   GITHUB_REPO:    pmem/libpmemobj-cpp
-  DOCKERHUB_REPO: pmem/libpmemobj-cpp
 
 jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
     env:
-      DOCKERHUB_USER:          ${{ secrets.DOCKERHUB_USER }}
-      DOCKERHUB_PASSWORD:      ${{ secrets.DOCKERHUB_PASSWORD }}
+      CONTAINER_REG:  ghcr.io/pmem/libpmemobj-cpp
+      # use org's Private Access Token to log in to GitHub Container Registry
+      CONTAINER_REG_USER:   ${{ secrets.GH_CR_USER }}
+      CONTAINER_REG_PASS:   ${{ secrets.GH_CR_PAT }}
       HOST_WORKDIR:   /home/runner/work/libpmemobj-cpp/libpmemobj-cpp
       WORKDIR:        utils/docker
     strategy:

--- a/.github/workflows/other_OSes.yml
+++ b/.github/workflows/other_OSes.yml
@@ -9,7 +9,7 @@ on:
 env:
   REPO:           libpmemobj-cpp
   GITHUB_REPO:    pmem/libpmemobj-cpp
-  DOCKERHUB_REPO: pmem/libpmemobj-cpp
+  CONTAINER_REG:  ghcr.io/pmem/libpmemobj-cpp
 
 jobs:
   linux:

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -35,7 +35,7 @@ if [[ -z "$HOST_WORKDIR" ]]; then
 	exit 1
 fi
 
-imageName=${DOCKERHUB_REPO}:1.12-${OS}-${OS_VER}
+imageName=${CONTAINER_REG}:1.12-${OS}-${OS_VER}
 containerName=libpmemobj-cpp-${OS}-${OS_VER}
 
 if [[ "$command" == "" ]]; then

--- a/utils/docker/images/build-image.sh
+++ b/utils/docker/images/build-image.sh
@@ -29,8 +29,8 @@ if [[ -z "${OS__OS_VER}" ]]; then
 	exit 1
 fi
 
-if [[ -z "${DOCKERHUB_REPO}" ]]; then
-	echo "DOCKERHUB_REPO environment variable is not set"
+if [[ -z "${CONTAINER_REG}" ]]; then
+	echo "CONTAINER_REG environment variable is not set"
 	exit 1
 fi
 
@@ -41,8 +41,8 @@ if [[ ! -f "Dockerfile.${OS__OS_VER}" ]]; then
 	exit 1
 fi
 
-echo "Build a Docker image tagged with ${DOCKERHUB_REPO}:1.12-${OS__OS_VER}"
-docker build -t ${DOCKERHUB_REPO}:1.12-${OS__OS_VER} \
+echo "Build a Docker image tagged with ${CONTAINER_REG}:1.12-${OS__OS_VER}"
+docker build -t ${CONTAINER_REG}:1.12-${OS__OS_VER} \
 	--build-arg http_proxy=$http_proxy \
 	--build-arg https_proxy=$https_proxy \
 	-f Dockerfile.${OS__OS_VER} .

--- a/utils/docker/images/push-image.sh
+++ b/utils/docker/images/push-image.sh
@@ -3,10 +3,10 @@
 # Copyright 2016-2020, Intel Corporation
 
 #
-# push-image.sh - pushes the Docker image tagged with OS-VER to the Docker Hub.
+# push-image.sh - pushes the Docker image tagged with OS-VER to the ${CONTAINER_REG}.
 #
-# The script utilizes $DOCKERHUB_USER and $DOCKERHUB_PASSWORD variables to
-# log in to the Docker Hub. The variables can be set in the CI's configuration
+# The script utilizes ${CONTAINER_REG_USER} and ${DOCKERHUB_PASSWORD} variables to
+# log in to the ${CONTAINER_REG}. The variables can be set in the CI's configuration
 # for automated builds.
 #
 
@@ -22,23 +22,29 @@ if [[ -z "${OS_VER}" ]]; then
 	exit 1
 fi
 
-if [[ -z "${DOCKERHUB_REPO}" ]]; then
-	echo "DOCKERHUB_REPO environment variable is not set"
+if [[ -z "${CONTAINER_REG}" ]]; then
+	echo "CONTAINER_REG environment variable is not set"
+	exit 1
+fi
+
+if [[ -z "${CONTAINER_REG_USER}" || -z "${CONTAINER_REG_PASS}" ]]; then
+	echo "ERROR: variables CONTAINER_REG_USER=\"${CONTAINER_REG_USER}\" and CONTAINER_REG_PASS=\"${CONTAINER_REG_PASS}\"" \
+		"have to be set properly to allow login to the Container Registry."
 	exit 1
 fi
 
 TAG="1.12-${OS}-${OS_VER}"
 
-echo "Check if the image tagged with ${DOCKERHUB_REPO}:${TAG} exists locally"
-if [[ ! $(docker images -a | awk -v pattern="^${DOCKERHUB_REPO}:${TAG}\$" \
+echo "Check if the image tagged with ${CONTAINER_REG}:${TAG} exists locally"
+if [[ ! $(docker images -a | awk -v pattern="^${CONTAINER_REG}:${TAG}\$" \
 	'$1":"$2 ~ pattern') ]]
 then
-	echo "ERROR: Docker image tagged ${DOCKERHUB_REPO}:${TAG} does not exist locally."
+	echo "ERROR: Docker image tagged ${CONTAINER_REG}:${TAG} does not exist locally."
 	exit 1
 fi
 
-echo "Log in to the Docker Hub"
-docker login -u="${DOCKERHUB_USER}" -p="${DOCKERHUB_PASSWORD}"
+echo "Log in to the container registry"
+echo "${CONTAINER_REG_PASS}" | docker login ghcr.io -u="${CONTAINER_REG_USER}" --password-stdin
 
-echo "Push the image to the repository"
-docker push ${DOCKERHUB_REPO}:${TAG}
+echo "Push the image to the container registry"
+docker push ${CONTAINER_REG}:${TAG}

--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -4,20 +4,20 @@
 
 #
 # pull-or-rebuild-image.sh - rebuilds the Docker image used in the
-#                            current Travis build if necessary.
+#                            current build if necessary.
 #
 # The script rebuilds the Docker image if:
 # 1. the Dockerfile for the current OS version (Dockerfile.${OS}-${OS_VER})
 #    or any .sh script in the Dockerfiles directory were modified and committed, or
 # 2. "rebuild" param was passed as a first argument to this script.
 #
-# If the Travis build is not of the "pull_request" type (i.e. in case of
-# merge after pull_request) and it succeed, the Docker image should be pushed
-# to the Docker Hub repository. An empty file is created to signal that to
-# further scripts.
+# If the CI build is not of the "pull_request" type (i.e. in case of
+# a pull request merge or any other "push" event) and it succeeds, the Docker image
+# should be pushed to the ${CONTAINER_REG} repository.
+# An empty file is created to signal that to next scripts.
 #
 # If the Docker image does not have to be rebuilt, it will be pulled from
-# the Docker Hub.
+# the ${CONTAINER_REG}.
 #
 
 set -e
@@ -82,15 +82,12 @@ for file in $files; do
 		# repository's stable-* or master branch, and the CI build is not
 		# of the "pull_request" type). In that case, create the empty
 		# file.
-		if [[ "$CI_REPO_SLUG" == "$GITHUB_REPO" \
-			&& ($CI_BRANCH == stable-* || $CI_BRANCH == master) \
-			&& $CI_EVENT_TYPE != "pull_request" \
-			&& $PUSH_IMAGE == "1" ]]
+		if [[ "$CI_REPO_SLUG" == "$GITHUB_REPO" ]]
 		then
-			echo "The image will be pushed to Docker Hub"
+			echo "The image will be pushed to the Container Registry"
 			touch $CI_FILE_PUSH_IMAGE_TO_REPO
 		else
-			echo "Skip pushing the image to Docker Hub"
+			echo "Skip pushing the image to the Container Registry"
 		fi
 
 		exit 0
@@ -98,5 +95,5 @@ for file in $files; do
 done
 
 # Getting here means rebuilding the Docker image is not required.
-# Pull the image from Docker Hub.
-docker pull ${DOCKERHUB_REPO}:1.12-${OS}-${OS_VER}
+# Pull the image from the Container Registry.
+docker pull ${CONTAINER_REG}:1.12-${OS}-${OS_VER}


### PR DESCRIPTION
- [x] we have to setup the PAT secret in GH settings. `GH_CONTAINER_REG_PAT = <new token with only read & write packages permissions>` (to generate PAT token see [guide](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token#creating-a-token))
- [ ] after we merge this PR and first images are pushed, we have to make them public - see [guide](https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/configuring-access-control-and-visibility-for-container-images#configuring-access-to-container-images-for-an-organization)

@szyr - ^^^ that's your tasks 😉 


Tested on my fork:
- push: https://github.com/lukaszstolarczuk/libpmemobj-cpp/runs/1228163272?check_suite_focus=true
- pull: https://github.com/lukaszstolarczuk/libpmemobj-cpp/runs/1230030339?check_suite_focus=true
- public docker image available in my space: https://github.com/lukaszstolarczuk?tab=packages

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/930)
<!-- Reviewable:end -->
