### PR TITLE
string_view: implement access API and port libcxx tests

### DIFF
--- a/tests/external/CMakeLists.txt
+++ b/tests/external/CMakeLists.txt
@@ -740,6 +740,21 @@ if (TEST_STRING)
 	# XXX: port libcxx test basic_string/string.cons/initializer_list_assignment.pass
 	add_test_expect_failure(string_libcxx_string_view libcxx/basic_string/string.cons/string_view.fail.cpp)
 
+	build_test(string_libcxx_string_view_at libcxx/string.view/string.view.access/at.pass.cpp)
+	add_test_generic(NAME string_libcxx_string_view_at TRACERS none pmemcheck memcheck)
+
+	build_test(string_libcxx_string_view_back libcxx/string.view/string.view.access/back.pass.cpp)
+	add_test_generic(NAME string_libcxx_string_view_back TRACERS none pmemcheck memcheck)
+
+	build_test(string_libcxx_string_view_data libcxx/string.view/string.view.access/data.pass.cpp)
+	add_test_generic(NAME string_libcxx_string_view_data TRACERS none pmemcheck memcheck)
+
+	build_test(string_libcxx_string_view_front libcxx/string.view/string.view.access/front.pass.cpp)
+	add_test_generic(NAME string_libcxx_string_view_front TRACERS none pmemcheck memcheck)
+
+	build_test(string_libcxx_string_view_index libcxx/string.view/string.view.access/index.pass.cpp)
+	add_test_generic(NAME string_libcxx_string_view_index TRACERS none pmemcheck memcheck)
+
 	if(MSVC_VERSION GREATER_EQUAL 1920)
 		build_test(string_libcxx_string_view_opeq_string_view libcxx/string.view/string.view.comparison/opeq.string_view.string_view.pass.cpp)
 		add_test_generic(NAME string_libcxx_string_view_opeq_string_view TRACERS none pmemcheck memcheck)

--- a/tests/external/libcxx/string.view/string.view.access/at.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.access/at.pass.cpp
@@ -5,6 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// Copyright 2020, Intel Corporation
+//
+// Modified to test pmem::obj containers
+//
 
 // NOTE: Older versions of clang have a bug where they fail to evaluate
 // string_view::at as a constant expression.
@@ -14,35 +19,31 @@
 
 // constexpr const _CharT& at(size_type _pos) const;
 
-#include <cassert>
-#include <stdexcept>
-#include <string_view>
+#include "unittest.hpp"
 
-#include "test_macros.h"
+#include <libpmemobj++/string_view.hpp>
 
 template <typename CharT>
 void
 test(const CharT *s, size_t len)
 {
-	std::basic_string_view<CharT> sv(s, len);
-	assert(sv.length() == len);
+	pmem::obj::basic_string_view<CharT> sv(s, len);
+	UT_ASSERT(sv.length() == len);
 	for (size_t i = 0; i < len; ++i) {
-		assert(sv.at(i) == s[i]);
-		assert(&sv.at(i) == s + i);
+		UT_ASSERT(sv.at(i) == s[i]);
+		UT_ASSERT(&sv.at(i) == s + i);
 	}
 
-#ifndef TEST_HAS_NO_EXCEPTIONS
 	try {
 		(void)sv.at(len);
 	} catch (const std::out_of_range &) {
 		return;
 	}
-	assert(false);
-#endif
+	UT_ASSERT(false);
 }
 
-int
-main(int, char **)
+static void
+run()
 {
 	test("ABCDE", 5);
 	test("a", 1);
@@ -50,22 +51,15 @@ main(int, char **)
 	test(L"ABCDE", 5);
 	test(L"a", 1);
 
-#if TEST_STD_VER >= 11
 	test(u"ABCDE", 5);
 	test(u"a", 1);
 
 	test(U"ABCDE", 5);
 	test(U"a", 1);
-#endif
+}
 
-#if TEST_STD_VER >= 11
-	{
-		constexpr std::basic_string_view<char> sv("ABC", 2);
-		static_assert(sv.length() == 2, "");
-		static_assert(sv.at(0) == 'A', "");
-		static_assert(sv.at(1) == 'B', "");
-	}
-#endif
-
-	return 0;
+int
+main(int argc, char *argv[])
+{
+	return run_test([&] { run(); });
 }

--- a/tests/external/libcxx/string.view/string.view.access/at.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.access/at.pass.cpp
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// NOTE: Older versions of clang have a bug where they fail to evaluate
+// string_view::at as a constant expression.
+// XFAIL: clang-3.4, clang-3.3
+
+// <string_view>
+
+// constexpr const _CharT& at(size_type _pos) const;
+
+#include <cassert>
+#include <stdexcept>
+#include <string_view>
+
+#include "test_macros.h"
+
+template <typename CharT>
+void
+test(const CharT *s, size_t len)
+{
+	std::basic_string_view<CharT> sv(s, len);
+	assert(sv.length() == len);
+	for (size_t i = 0; i < len; ++i) {
+		assert(sv.at(i) == s[i]);
+		assert(&sv.at(i) == s + i);
+	}
+
+#ifndef TEST_HAS_NO_EXCEPTIONS
+	try {
+		(void)sv.at(len);
+	} catch (const std::out_of_range &) {
+		return;
+	}
+	assert(false);
+#endif
+}
+
+int
+main(int, char **)
+{
+	test("ABCDE", 5);
+	test("a", 1);
+
+	test(L"ABCDE", 5);
+	test(L"a", 1);
+
+#if TEST_STD_VER >= 11
+	test(u"ABCDE", 5);
+	test(u"a", 1);
+
+	test(U"ABCDE", 5);
+	test(U"a", 1);
+#endif
+
+#if TEST_STD_VER >= 11
+	{
+		constexpr std::basic_string_view<char> sv("ABC", 2);
+		static_assert(sv.length() == 2, "");
+		static_assert(sv.at(0) == 'A', "");
+		static_assert(sv.at(1) == 'B', "");
+	}
+#endif
+
+	return 0;
+}

--- a/tests/external/libcxx/string.view/string.view.access/back.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.access/back.pass.cpp
@@ -5,53 +5,60 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// Copyright 2020, Intel Corporation
+//
+// Modified to test pmem::obj containers
+//
 
 // <string_view>
 
 // constexpr const _CharT& front();
 
-#include <cassert>
-#include <string_view>
+#include "unittest.hpp"
 
-#include "test_macros.h"
+#include <libpmemobj++/string_view.hpp>
 
 template <typename CharT>
 bool
 test(const CharT *s, size_t len)
 {
-	typedef std::basic_string_view<CharT> SV;
+	typedef pmem::obj::basic_string_view<CharT> SV;
 	SV sv(s, len);
-	ASSERT_SAME_TYPE(decltype(sv.back()), typename SV::const_reference);
-	LIBCPP_ASSERT_NOEXCEPT(sv.back());
-	assert(sv.length() == len);
-	assert(sv.back() == s[len - 1]);
+
+	static_assert(std::is_same<decltype(sv.back()),
+				   typename SV::const_reference>::value,
+		      "must be const_reference");
+	static_assert(noexcept(sv.back()), "Operation must be noexcept");
+	UT_ASSERT(sv.length() == len);
+	UT_ASSERT(sv.back() == s[len - 1]);
 	return &sv.back() == s + len - 1;
 }
 
-int
-main(int, char **)
+static void
+run()
 {
-	assert(test("ABCDE", 5));
-	assert(test("a", 1));
+	UT_ASSERT(test("ABCDE", 5));
+	UT_ASSERT(test("a", 1));
 
-	assert(test(L"ABCDE", 5));
-	assert(test(L"a", 1));
+	UT_ASSERT(test(L"ABCDE", 5));
+	UT_ASSERT(test(L"a", 1));
 
-#if TEST_STD_VER >= 11
-	assert(test(u"ABCDE", 5));
-	assert(test(u"a", 1));
+	UT_ASSERT(test(u"ABCDE", 5));
+	UT_ASSERT(test(u"a", 1));
 
-	assert(test(U"ABCDE", 5));
-	assert(test(U"a", 1));
-#endif
+	UT_ASSERT(test(U"ABCDE", 5));
+	UT_ASSERT(test(U"a", 1));
 
-#if TEST_STD_VER >= 11
 	{
-		constexpr std::basic_string_view<char> sv("ABC", 2);
+		constexpr pmem::obj::basic_string_view<char> sv("ABC", 2);
 		static_assert(sv.length() == 2, "");
 		static_assert(sv.back() == 'B', "");
 	}
-#endif
+}
 
-	return 0;
+int
+main(int argc, char *argv[])
+{
+	return run_test([&] { run(); });
 }

--- a/tests/external/libcxx/string.view/string.view.access/back.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.access/back.pass.cpp
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <string_view>
+
+// constexpr const _CharT& front();
+
+#include <cassert>
+#include <string_view>
+
+#include "test_macros.h"
+
+template <typename CharT>
+bool
+test(const CharT *s, size_t len)
+{
+	typedef std::basic_string_view<CharT> SV;
+	SV sv(s, len);
+	ASSERT_SAME_TYPE(decltype(sv.back()), typename SV::const_reference);
+	LIBCPP_ASSERT_NOEXCEPT(sv.back());
+	assert(sv.length() == len);
+	assert(sv.back() == s[len - 1]);
+	return &sv.back() == s + len - 1;
+}
+
+int
+main(int, char **)
+{
+	assert(test("ABCDE", 5));
+	assert(test("a", 1));
+
+	assert(test(L"ABCDE", 5));
+	assert(test(L"a", 1));
+
+#if TEST_STD_VER >= 11
+	assert(test(u"ABCDE", 5));
+	assert(test(u"a", 1));
+
+	assert(test(U"ABCDE", 5));
+	assert(test(U"a", 1));
+#endif
+
+#if TEST_STD_VER >= 11
+	{
+		constexpr std::basic_string_view<char> sv("ABC", 2);
+		static_assert(sv.length() == 2, "");
+		static_assert(sv.back() == 'B', "");
+	}
+#endif
+
+	return 0;
+}

--- a/tests/external/libcxx/string.view/string.view.access/data.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.access/data.pass.cpp
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <string_view>
+
+// constexpr const _CharT* data() const noexcept;
+
+#include <cassert>
+#include <string_view>
+
+#include "test_macros.h"
+
+template <typename CharT>
+void
+test(const CharT *s, size_t len)
+{
+	std::basic_string_view<CharT> sv(s, len);
+	assert(sv.length() == len);
+	assert(sv.data() == s);
+#if TEST_STD_VER > 14
+	//  make sure we pick up std::data, too!
+	assert(sv.data() == std::data(sv));
+#endif
+}
+
+int
+main(int, char **)
+{
+	test("ABCDE", 5);
+	test("a", 1);
+
+	test(L"ABCDE", 5);
+	test(L"a", 1);
+
+#if TEST_STD_VER >= 11
+	test(u"ABCDE", 5);
+	test(u"a", 1);
+
+	test(U"ABCDE", 5);
+	test(U"a", 1);
+#endif
+
+#if TEST_STD_VER > 11
+	{
+		constexpr const char *s = "ABC";
+		constexpr std::basic_string_view<char> sv(s, 2);
+		static_assert(sv.length() == 2, "");
+		static_assert(sv.data() == s, "");
+	}
+#endif
+
+	return 0;
+}

--- a/tests/external/libcxx/string.view/string.view.access/data.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.access/data.pass.cpp
@@ -5,31 +5,31 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// Copyright 2020, Intel Corporation
+//
+// Modified to test pmem::obj containers
+//
 
 // <string_view>
 
 // constexpr const _CharT* data() const noexcept;
 
-#include <cassert>
-#include <string_view>
+#include "unittest.hpp"
 
-#include "test_macros.h"
+#include <libpmemobj++/string_view.hpp>
 
 template <typename CharT>
 void
 test(const CharT *s, size_t len)
 {
-	std::basic_string_view<CharT> sv(s, len);
-	assert(sv.length() == len);
-	assert(sv.data() == s);
-#if TEST_STD_VER > 14
-	//  make sure we pick up std::data, too!
-	assert(sv.data() == std::data(sv));
-#endif
+	pmem::obj::basic_string_view<CharT> sv(s, len);
+	UT_ASSERT(sv.length() == len);
+	UT_ASSERT(sv.data() == s);
 }
 
-int
-main(int, char **)
+static void
+run()
 {
 	test("ABCDE", 5);
 	test("a", 1);
@@ -37,22 +37,22 @@ main(int, char **)
 	test(L"ABCDE", 5);
 	test(L"a", 1);
 
-#if TEST_STD_VER >= 11
 	test(u"ABCDE", 5);
 	test(u"a", 1);
 
 	test(U"ABCDE", 5);
 	test(U"a", 1);
-#endif
 
-#if TEST_STD_VER > 11
 	{
 		constexpr const char *s = "ABC";
-		constexpr std::basic_string_view<char> sv(s, 2);
+		constexpr pmem::obj::basic_string_view<char> sv(s, 2);
 		static_assert(sv.length() == 2, "");
 		static_assert(sv.data() == s, "");
 	}
-#endif
+}
 
-	return 0;
+int
+main(int argc, char *argv[])
+{
+	return run_test([&] { run(); });
 }

--- a/tests/external/libcxx/string.view/string.view.access/front.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.access/front.pass.cpp
@@ -5,53 +5,59 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// Copyright 2020, Intel Corporation
+//
+// Modified to test pmem::obj containers
+//
 
 // <string_view>
 
 // constexpr const _CharT& back();
 
-#include <cassert>
-#include <string_view>
+#include "unittest.hpp"
 
-#include "test_macros.h"
+#include <libpmemobj++/string_view.hpp>
 
 template <typename CharT>
 bool
 test(const CharT *s, size_t len)
 {
-	typedef std::basic_string_view<CharT> SV;
+	typedef pmem::obj::basic_string_view<CharT> SV;
 	SV sv(s, len);
-	ASSERT_SAME_TYPE(decltype(sv.front()), typename SV::const_reference);
-	LIBCPP_ASSERT_NOEXCEPT(sv.front());
-	assert(sv.length() == len);
-	assert(sv.front() == s[0]);
+	static_assert(std::is_same<decltype(sv.front()),
+				   typename SV::const_reference>::value,
+		      "must be const_reference");
+	static_assert(noexcept(sv.front()), "Operation must be noexcept");
+	UT_ASSERT(sv.length() == len);
+	UT_ASSERT(sv.front() == s[0]);
 	return &sv.front() == s;
 }
 
-int
-main(int, char **)
+static void
+run()
 {
-	assert(test("ABCDE", 5));
-	assert(test("a", 1));
+	UT_ASSERT(test("ABCDE", 5));
+	UT_ASSERT(test("a", 1));
 
-	assert(test(L"ABCDE", 5));
-	assert(test(L"a", 1));
+	UT_ASSERT(test(L"ABCDE", 5));
+	UT_ASSERT(test(L"a", 1));
 
-#if TEST_STD_VER >= 11
-	assert(test(u"ABCDE", 5));
-	assert(test(u"a", 1));
+	UT_ASSERT(test(u"ABCDE", 5));
+	UT_ASSERT(test(u"a", 1));
 
-	assert(test(U"ABCDE", 5));
-	assert(test(U"a", 1));
-#endif
+	UT_ASSERT(test(U"ABCDE", 5));
+	UT_ASSERT(test(U"a", 1));
 
-#if TEST_STD_VER >= 11
 	{
-		constexpr std::basic_string_view<char> sv("ABC", 2);
+		constexpr pmem::obj::basic_string_view<char> sv("ABC", 2);
 		static_assert(sv.length() == 2, "");
 		static_assert(sv.front() == 'A', "");
 	}
-#endif
+}
 
-	return 0;
+int
+main(int argc, char *argv[])
+{
+	return run_test([&] { run(); });
 }

--- a/tests/external/libcxx/string.view/string.view.access/front.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.access/front.pass.cpp
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <string_view>
+
+// constexpr const _CharT& back();
+
+#include <cassert>
+#include <string_view>
+
+#include "test_macros.h"
+
+template <typename CharT>
+bool
+test(const CharT *s, size_t len)
+{
+	typedef std::basic_string_view<CharT> SV;
+	SV sv(s, len);
+	ASSERT_SAME_TYPE(decltype(sv.front()), typename SV::const_reference);
+	LIBCPP_ASSERT_NOEXCEPT(sv.front());
+	assert(sv.length() == len);
+	assert(sv.front() == s[0]);
+	return &sv.front() == s;
+}
+
+int
+main(int, char **)
+{
+	assert(test("ABCDE", 5));
+	assert(test("a", 1));
+
+	assert(test(L"ABCDE", 5));
+	assert(test(L"a", 1));
+
+#if TEST_STD_VER >= 11
+	assert(test(u"ABCDE", 5));
+	assert(test(u"a", 1));
+
+	assert(test(U"ABCDE", 5));
+	assert(test(U"a", 1));
+#endif
+
+#if TEST_STD_VER >= 11
+	{
+		constexpr std::basic_string_view<char> sv("ABC", 2);
+		static_assert(sv.length() == 2, "");
+		static_assert(sv.front() == 'A', "");
+	}
+#endif
+
+	return 0;
+}

--- a/tests/external/libcxx/string.view/string.view.access/index.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.access/index.pass.cpp
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <string_view>
+
+// constexpr const _CharT& operator[](size_type _pos) const;
+
+#include <cassert>
+#include <string_view>
+
+#include "test_macros.h"
+
+template <typename CharT>
+void
+test(const CharT *s, size_t len)
+{
+	typedef std::basic_string_view<CharT> SV;
+	SV sv(s, len);
+	ASSERT_SAME_TYPE(decltype(sv[0]), typename SV::const_reference);
+	LIBCPP_ASSERT_NOEXCEPT(sv[0]);
+	assert(sv.length() == len);
+	for (size_t i = 0; i < len; ++i) {
+		assert(sv[i] == s[i]);
+		assert(&sv[i] == s + i);
+	}
+}
+
+int
+main(int, char **)
+{
+	test("ABCDE", 5);
+	test("a", 1);
+
+	test(L"ABCDE", 5);
+	test(L"a", 1);
+
+#if TEST_STD_VER >= 11
+	test(u"ABCDE", 5);
+	test(u"a", 1);
+
+	test(U"ABCDE", 5);
+	test(U"a", 1);
+#endif
+
+#if TEST_STD_VER > 11
+	{
+		constexpr std::basic_string_view<char> sv("ABC", 2);
+		static_assert(sv.length() == 2, "");
+		static_assert(sv[0] == 'A', "");
+		static_assert(sv[1] == 'B', "");
+	}
+#endif
+
+	return 0;
+}


### PR DESCRIPTION
- string_view: add string_view access API libcxx tests
- string_view: implement access API
- string_view: port LIBCXX access tests to use pmem::obj::string_view

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/938)
<!-- Reviewable:end -->
