### PR TITLE
string_view: implement capacity API and port libcxx tests

### DIFF
--- a/include/libpmemobj++/string_view.hpp
+++ b/include/libpmemobj++/string_view.hpp
@@ -10,7 +10,7 @@
 #define LIBPMEMOBJ_CPP_STRING_VIEW
 
 #include <algorithm>
-#include <cassert>
+#include <limits>
 #include <stdexcept>
 #include <string>
 
@@ -38,8 +38,8 @@ using u32string_view = std::basic_string_view<char32_t>;
 /**
  * Our partial std::string_view implementation.
  *
- * If C++17's std::string_view implementation is not available, this one is
- * used to avoid unnecessary string copying.
+ * If C++17's std::string_view implementation is not available, this one
+ * is used to avoid unnecessary string copying.
  */
 template <typename CharT, typename Traits = std::char_traits<CharT>>
 class basic_string_view {
@@ -67,6 +67,8 @@ public:
 	constexpr const CharT *data() const noexcept;
 	constexpr size_type size() const noexcept;
 	constexpr size_type length() const noexcept;
+	constexpr bool empty() const noexcept;
+	constexpr size_type max_size() const noexcept;
 
 	const CharT &at(size_type pos) const;
 	constexpr const CharT &operator[](size_type pos) const noexcept;
@@ -135,8 +137,8 @@ constexpr inline basic_string_view<CharT, Traits>::basic_string_view(
 }
 
 /**
- * Returns pointer to data stored in this pmem::obj::string_view. It may not
- * contain the terminating null character.
+ * Returns pointer to data stored in this pmem::obj::string_view. It may
+ *not contain the terminating null character.
  *
  * @return pointer to C-like string (char *), it may not end with null
  *	character.
@@ -149,7 +151,8 @@ basic_string_view<CharT, Traits>::data() const noexcept
 }
 
 /**
- * Returns count of characters stored in this pmem::obj::string_view data.
+ * Returns count of characters stored in this pmem::obj::string_view
+ * data.
  *
  * @return the number of CharT elements in the view.
  */
@@ -158,6 +161,31 @@ constexpr inline typename basic_string_view<CharT, Traits>::size_type
 basic_string_view<CharT, Traits>::size() const noexcept
 {
 	return size_;
+}
+
+/**
+ * Returns that view is empty or not.
+ *
+ * @return true when size() == 0.
+ */
+template <typename CharT, typename Traits>
+constexpr inline bool
+basic_string_view<CharT, Traits>::empty() const noexcept
+{
+	return size() == 0;
+}
+
+/**
+ * Returns the largest possible number of char-like objects that can be
+ * referred to by a basic_string_view.
+ *
+ * @return maximum number of characters.
+ */
+template <typename CharT, typename Traits>
+constexpr inline typename basic_string_view<CharT, Traits>::size_type
+basic_string_view<CharT, Traits>::max_size() const noexcept
+{
+	return (std::numeric_limits<size_type>::max)();
 }
 
 /**

--- a/tests/external/CMakeLists.txt
+++ b/tests/external/CMakeLists.txt
@@ -755,6 +755,9 @@ if (TEST_STRING)
 	build_test(string_libcxx_string_view_index libcxx/string.view/string.view.access/index.pass.cpp)
 	add_test_generic(NAME string_libcxx_string_view_index TRACERS none pmemcheck memcheck)
 
+	build_test(string_libcxx_string_view_capacity libcxx/string.view/string.view.capacity/capacity.pass.cpp)
+	add_test_generic(NAME string_libcxx_string_view_capacity TRACERS none pmemcheck memcheck)
+
 	if(MSVC_VERSION GREATER_EQUAL 1920)
 		build_test(string_libcxx_string_view_opeq_string_view libcxx/string.view/string.view.comparison/opeq.string_view.string_view.pass.cpp)
 		add_test_generic(NAME string_libcxx_string_view_opeq_string_view TRACERS none pmemcheck memcheck)

--- a/tests/external/libcxx/string.view/string.view.capacity/capacity.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.capacity/capacity.pass.cpp
@@ -1,0 +1,104 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+
+// <string_view>
+
+// [string.view.capacity], capacity
+// constexpr size_type size()     const noexcept;
+// constexpr size_type length()   const noexcept;
+// constexpr size_type max_size() const noexcept;
+// constexpr bool empty()         const noexcept;
+
+#include <string_view>
+#include <cassert>
+
+#include "test_macros.h"
+
+template<typename SV>
+void test1 () {
+#if TEST_STD_VER > 11
+    {
+    constexpr SV sv1;
+    static_assert ( sv1.size() == 0, "" );
+    static_assert ( sv1.empty(), "");
+    static_assert ( sv1.size() == sv1.length(), "" );
+    static_assert ( sv1.max_size() > sv1.size(), "");
+    }
+#endif
+
+    {
+    SV sv1;
+    ASSERT_NOEXCEPT(sv1.size());
+    ASSERT_NOEXCEPT(sv1.empty());
+    ASSERT_NOEXCEPT(sv1.max_size());
+    ASSERT_NOEXCEPT(sv1.length());
+    assert ( sv1.size() == 0 );
+    assert ( sv1.empty());
+    assert ( sv1.size() == sv1.length());
+    assert ( sv1.max_size() > sv1.size());
+    }
+}
+
+template<typename CharT>
+void test2 ( const CharT *s, size_t len ) {
+    {
+    std::basic_string_view<CharT> sv1 ( s );
+    assert ( sv1.size() == len );
+    assert ( sv1.data() == s );
+    assert ( sv1.empty() == (len == 0));
+    assert ( sv1.size() == sv1.length());
+    assert ( sv1.max_size() > sv1.size());
+#if TEST_STD_VER > 14
+//  make sure we pick up std::size, too!
+    assert ( sv1.size() == std::size(sv1));
+    assert ( sv1.empty() == std::empty(sv1));
+#endif
+    }
+}
+
+int main(int, char**) {
+    test1<std::string_view> ();
+#if defined(__cpp_lib_char8_t) && __cpp_lib_char8_t >= 201811L
+    test1<std::u8string_view> ();
+#endif
+    test1<std::u16string_view> ();
+    test1<std::u32string_view> ();
+    test1<std::wstring_view> ();
+
+    test2 ( "ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE", 105 );
+    test2 ( "ABCDE", 5 );
+    test2 ( "a", 1 );
+    test2 ( "", 0 );
+
+    test2 ( L"ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE", 105 );
+    test2 ( L"ABCDE", 5 );
+    test2 ( L"a", 1 );
+    test2 ( L"", 0 );
+
+#if defined(__cpp_lib_char8_t) && __cpp_lib_char8_t >= 201811L
+    test2 ( u8"ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE", 105 );
+    test2 ( u8"ABCDE", 5 );
+    test2 ( u8"a", 1 );
+    test2 ( u8"", 0 );
+#endif
+
+#if TEST_STD_VER >= 11
+    test2 ( u"ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE", 105 );
+    test2 ( u"ABCDE", 5 );
+    test2 ( u"a", 1 );
+    test2 ( u"", 0 );
+
+    test2 ( U"ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE", 105 );
+    test2 ( U"ABCDE", 5 );
+    test2 ( U"a", 1 );
+    test2 ( U"", 0 );
+#endif
+
+  return 0;
+}

--- a/tests/external/libcxx/string.view/string.view.capacity/capacity.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.capacity/capacity.pass.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 // <string_view>
 
 // [string.view.capacity], capacity
@@ -15,90 +14,88 @@
 // constexpr size_type max_size() const noexcept;
 // constexpr bool empty()         const noexcept;
 
-#include <string_view>
-#include <cassert>
+#include "unittest.hpp"
 
-#include "test_macros.h"
+#include <libpmemobj++/string_view.hpp>
 
-template<typename SV>
-void test1 () {
-#if TEST_STD_VER > 11
-    {
-    constexpr SV sv1;
-    static_assert ( sv1.size() == 0, "" );
-    static_assert ( sv1.empty(), "");
-    static_assert ( sv1.size() == sv1.length(), "" );
-    static_assert ( sv1.max_size() > sv1.size(), "");
-    }
-#endif
+template <typename SV>
+void
+test1()
+{
+	{
+		constexpr SV sv1;
+		static_assert(sv1.size() == 0, "");
+		static_assert(sv1.empty(), "");
+		static_assert(sv1.size() == sv1.length(), "");
+		static_assert(sv1.max_size() > sv1.size(), "");
+	}
 
-    {
-    SV sv1;
-    ASSERT_NOEXCEPT(sv1.size());
-    ASSERT_NOEXCEPT(sv1.empty());
-    ASSERT_NOEXCEPT(sv1.max_size());
-    ASSERT_NOEXCEPT(sv1.length());
-    assert ( sv1.size() == 0 );
-    assert ( sv1.empty());
-    assert ( sv1.size() == sv1.length());
-    assert ( sv1.max_size() > sv1.size());
-    }
+	{
+		SV sv1;
+		static_assert(noexcept(sv1.size()),
+			      "Operation must be noexcept");
+		static_assert(noexcept(sv1.empty()),
+			      "Operation must be noexcept");
+		static_assert(noexcept(sv1.max_size()),
+			      "Operation must be noexcept");
+		static_assert(noexcept(sv1.length()),
+			      "Operation must be noexcept");
+		UT_ASSERT(sv1.size() == 0);
+		UT_ASSERT(sv1.empty());
+		UT_ASSERT(sv1.size() == sv1.length());
+		UT_ASSERT(sv1.max_size() > sv1.size());
+	}
 }
 
-template<typename CharT>
-void test2 ( const CharT *s, size_t len ) {
-    {
-    std::basic_string_view<CharT> sv1 ( s );
-    assert ( sv1.size() == len );
-    assert ( sv1.data() == s );
-    assert ( sv1.empty() == (len == 0));
-    assert ( sv1.size() == sv1.length());
-    assert ( sv1.max_size() > sv1.size());
-#if TEST_STD_VER > 14
-//  make sure we pick up std::size, too!
-    assert ( sv1.size() == std::size(sv1));
-    assert ( sv1.empty() == std::empty(sv1));
-#endif
-    }
+template <typename CharT>
+void
+test2(const CharT *s, size_t len)
+{
+	{
+		pmem::obj::basic_string_view<CharT> sv1(s);
+		UT_ASSERT(sv1.size() == len);
+		UT_ASSERT(sv1.data() == s);
+		UT_ASSERT(sv1.empty() == (len == 0));
+		UT_ASSERT(sv1.size() == sv1.length());
+		UT_ASSERT(sv1.max_size() > sv1.size());
+	}
 }
 
-int main(int, char**) {
-    test1<std::string_view> ();
-#if defined(__cpp_lib_char8_t) && __cpp_lib_char8_t >= 201811L
-    test1<std::u8string_view> ();
-#endif
-    test1<std::u16string_view> ();
-    test1<std::u32string_view> ();
-    test1<std::wstring_view> ();
+static void
+run()
+{
+	test1<pmem::obj::string_view>();
+	test1<pmem::obj::u16string_view>();
+	test1<pmem::obj::u32string_view>();
+	test1<pmem::obj::wstring_view>();
 
-    test2 ( "ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE", 105 );
-    test2 ( "ABCDE", 5 );
-    test2 ( "a", 1 );
-    test2 ( "", 0 );
+	test2("ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE",
+	      105);
+	test2("ABCDE", 5);
+	test2("a", 1);
+	test2("", 0);
 
-    test2 ( L"ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE", 105 );
-    test2 ( L"ABCDE", 5 );
-    test2 ( L"a", 1 );
-    test2 ( L"", 0 );
+	test2(L"ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE",
+	      105);
+	test2(L"ABCDE", 5);
+	test2(L"a", 1);
+	test2(L"", 0);
 
-#if defined(__cpp_lib_char8_t) && __cpp_lib_char8_t >= 201811L
-    test2 ( u8"ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE", 105 );
-    test2 ( u8"ABCDE", 5 );
-    test2 ( u8"a", 1 );
-    test2 ( u8"", 0 );
-#endif
+	test2(u"ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE",
+	      105);
+	test2(u"ABCDE", 5);
+	test2(u"a", 1);
+	test2(u"", 0);
 
-#if TEST_STD_VER >= 11
-    test2 ( u"ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE", 105 );
-    test2 ( u"ABCDE", 5 );
-    test2 ( u"a", 1 );
-    test2 ( u"", 0 );
+	test2(U"ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE",
+	      105);
+	test2(U"ABCDE", 5);
+	test2(U"a", 1);
+	test2(U"", 0);
+}
 
-    test2 ( U"ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE", 105 );
-    test2 ( U"ABCDE", 5 );
-    test2 ( U"a", 1 );
-    test2 ( U"", 0 );
-#endif
-
-  return 0;
+int
+main(int argc, char *argv[])
+{
+	return run_test([&] { run(); });
 }


### PR DESCRIPTION
This PR contains:
- string_view: add capacity related methods for string_view
- string_view: add string_view capacity API libcxx tests
- string_view: port LIBCXX capacity test to use pmem::obj::string_view

PR depends on #938.
Please merge it after #938.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/940)
<!-- Reviewable:end -->
