### PR TITLE
string_view: add modifiers API and related libcxx tests

### DIFF
--- a/include/libpmemobj++/string_view.hpp
+++ b/include/libpmemobj++/string_view.hpp
@@ -13,6 +13,7 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #if __cpp_lib_string_view
 #include <string_view>
@@ -87,6 +88,10 @@ public:
 	constexpr const CharT &operator[](size_type pos) const noexcept;
 	constexpr const_reference front() const noexcept;
 	constexpr const_reference back() const noexcept;
+
+	void remove_prefix(size_type n);
+	void remove_suffix(size_type n);
+	void swap(basic_string_view &v) noexcept;
 
 	int compare(const basic_string_view &other) const noexcept;
 
@@ -318,6 +323,47 @@ constexpr inline const CharT &
 basic_string_view<CharT, Traits>::front() const noexcept
 {
 	return operator[](0);
+}
+
+/**
+ * Moves the start of the view forward by n characters.
+ * The behavior is undefined if n > size().
+ *
+ * @param[in] n number of characters to remove from the start of the view
+ */
+template <typename CharT, typename Traits>
+void
+basic_string_view<CharT, Traits>::remove_prefix(size_type n)
+{
+	data_ += n;
+	size_ -= n;
+}
+
+/**
+ * Moves the end of the view back by n characters.
+ * The behavior is undefined if n > size().
+ *
+ * @param[in] n number of characters to remove from the end of the view
+ */
+template <typename CharT, typename Traits>
+void
+basic_string_view<CharT, Traits>::remove_suffix(size_type n)
+{
+	size_ -= n;
+}
+
+/**
+ * Exchanges the view with that of v.
+ *
+ * @param[in] v view to swap with
+ */
+template <typename CharT, typename Traits>
+void
+basic_string_view<CharT, Traits>::swap(
+	basic_string_view<CharT, Traits> &v) noexcept
+{
+	std::swap(data_, v.data_);
+	std::swap(size_, v.size_);
 }
 
 /**

--- a/tests/external/CMakeLists.txt
+++ b/tests/external/CMakeLists.txt
@@ -764,6 +764,15 @@ if (TEST_STRING)
 	build_test(string_libcxx_string_view_end libcxx/string.view/string.view.iterators/end.pass.cpp)
 	add_test_generic(NAME string_libcxx_string_view_end TRACERS none pmemcheck memcheck)
 
+	build_test(string_libcxx_string_view_swap libcxx/string.view/string.view.modifiers/swap.pass.cpp)
+	add_test_generic(NAME string_libcxx_string_view_swap TRACERS none pmemcheck memcheck)
+
+	build_test(string_libcxx_string_view_remove_prefix libcxx/string.view/string.view.modifiers/remove_prefix.pass.cpp)
+	add_test_generic(NAME string_libcxx_string_view_remove_prefix TRACERS none pmemcheck memcheck)
+
+	build_test(string_libcxx_string_view_remove_suffix libcxx/string.view/string.view.modifiers/remove_suffix.pass.cpp)
+	add_test_generic(NAME string_libcxx_string_view_remove_suffix TRACERS none pmemcheck memcheck)
+
 	if(MSVC_VERSION GREATER_EQUAL 1920)
 		build_test(string_libcxx_string_view_opeq_string_view libcxx/string.view/string.view.comparison/opeq.string_view.string_view.pass.cpp)
 		add_test_generic(NAME string_libcxx_string_view_opeq_string_view TRACERS none pmemcheck memcheck)

--- a/tests/external/libcxx/string.view/string.view.modifiers/remove_prefix.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.modifiers/remove_prefix.pass.cpp
@@ -1,0 +1,83 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <string_view>
+
+// void remove_prefix(size_type _n)
+
+#include <cassert>
+#include <string_view>
+
+#include "test_macros.h"
+
+template <typename CharT>
+void
+test(const CharT *s, size_t len)
+{
+	typedef std::basic_string_view<CharT> SV;
+	{
+		SV sv1(s);
+		assert(sv1.size() == len);
+		assert(sv1.data() == s);
+
+		if (len > 0) {
+			sv1.remove_prefix(1);
+			assert(sv1.size() == (len - 1));
+			assert(sv1.data() == (s + 1));
+			sv1.remove_prefix(len - 1);
+		}
+
+		assert(sv1.size() == 0);
+		sv1.remove_prefix(0);
+		assert(sv1.size() == 0);
+	}
+}
+
+#if TEST_STD_VER > 11
+constexpr size_t
+test_ce(size_t n, size_t k)
+{
+	typedef std::basic_string_view<char> SV;
+	SV sv1{"ABCDEFGHIJKL", n};
+	sv1.remove_prefix(k);
+	return sv1.size();
+}
+#endif
+
+int
+main(int, char **)
+{
+	test("ABCDE", 5);
+	test("a", 1);
+	test("", 0);
+
+	test(L"ABCDE", 5);
+	test(L"a", 1);
+	test(L"", 0);
+
+#if TEST_STD_VER >= 11
+	test(u"ABCDE", 5);
+	test(u"a", 1);
+	test(u"", 0);
+
+	test(U"ABCDE", 5);
+	test(U"a", 1);
+	test(U"", 0);
+#endif
+
+#if TEST_STD_VER > 11
+	{
+		static_assert(test_ce(5, 0) == 5, "");
+		static_assert(test_ce(5, 1) == 4, "");
+		static_assert(test_ce(5, 5) == 0, "");
+		static_assert(test_ce(9, 3) == 6, "");
+	}
+#endif
+
+	return 0;
+}

--- a/tests/external/libcxx/string.view/string.view.modifiers/remove_prefix.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.modifiers/remove_prefix.pass.cpp
@@ -5,52 +5,45 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// Copyright 2020, Intel Corporation
+//
+// Modified to test pmem::obj containers
+//
 
 // <string_view>
 
 // void remove_prefix(size_type _n)
 
-#include <cassert>
-#include <string_view>
+#include "unittest.hpp"
 
-#include "test_macros.h"
+#include <libpmemobj++/string_view.hpp>
 
 template <typename CharT>
 void
 test(const CharT *s, size_t len)
 {
-	typedef std::basic_string_view<CharT> SV;
+	typedef pmem::obj::basic_string_view<CharT> SV;
 	{
 		SV sv1(s);
-		assert(sv1.size() == len);
-		assert(sv1.data() == s);
+		UT_ASSERT(sv1.size() == len);
+		UT_ASSERT(sv1.data() == s);
 
 		if (len > 0) {
 			sv1.remove_prefix(1);
-			assert(sv1.size() == (len - 1));
-			assert(sv1.data() == (s + 1));
+			UT_ASSERT(sv1.size() == (len - 1));
+			UT_ASSERT(sv1.data() == (s + 1));
 			sv1.remove_prefix(len - 1);
 		}
 
-		assert(sv1.size() == 0);
+		UT_ASSERT(sv1.size() == 0);
 		sv1.remove_prefix(0);
-		assert(sv1.size() == 0);
+		UT_ASSERT(sv1.size() == 0);
 	}
 }
 
-#if TEST_STD_VER > 11
-constexpr size_t
-test_ce(size_t n, size_t k)
-{
-	typedef std::basic_string_view<char> SV;
-	SV sv1{"ABCDEFGHIJKL", n};
-	sv1.remove_prefix(k);
-	return sv1.size();
-}
-#endif
-
-int
-main(int, char **)
+static void
+run()
 {
 	test("ABCDE", 5);
 	test("a", 1);
@@ -60,7 +53,6 @@ main(int, char **)
 	test(L"a", 1);
 	test(L"", 0);
 
-#if TEST_STD_VER >= 11
 	test(u"ABCDE", 5);
 	test(u"a", 1);
 	test(u"", 0);
@@ -68,16 +60,10 @@ main(int, char **)
 	test(U"ABCDE", 5);
 	test(U"a", 1);
 	test(U"", 0);
-#endif
+}
 
-#if TEST_STD_VER > 11
-	{
-		static_assert(test_ce(5, 0) == 5, "");
-		static_assert(test_ce(5, 1) == 4, "");
-		static_assert(test_ce(5, 5) == 0, "");
-		static_assert(test_ce(9, 3) == 6, "");
-	}
-#endif
-
-	return 0;
+int
+main(int argc, char *argv[])
+{
+	return run_test([&] { run(); });
 }

--- a/tests/external/libcxx/string.view/string.view.modifiers/remove_suffix.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.modifiers/remove_suffix.pass.cpp
@@ -5,52 +5,45 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// Copyright 2020, Intel Corporation
+//
+// Modified to test pmem::obj containers
+//
 
 // <string_view>
 
 // void remove_suffix(size_type _n)
 
-#include <cassert>
-#include <string_view>
+#include "unittest.hpp"
 
-#include "test_macros.h"
+#include <libpmemobj++/string_view.hpp>
 
 template <typename CharT>
 void
 test(const CharT *s, size_t len)
 {
-	typedef std::basic_string_view<CharT> SV;
+	typedef pmem::obj::basic_string_view<CharT> SV;
 	{
 		SV sv1(s);
-		assert(sv1.size() == len);
-		assert(sv1.data() == s);
+		UT_ASSERT(sv1.size() == len);
+		UT_ASSERT(sv1.data() == s);
 
 		if (len > 0) {
 			sv1.remove_suffix(1);
-			assert(sv1.size() == (len - 1));
-			assert(sv1.data() == s);
+			UT_ASSERT(sv1.size() == (len - 1));
+			UT_ASSERT(sv1.data() == s);
 			sv1.remove_suffix(len - 1);
 		}
 
-		assert(sv1.size() == 0);
+		UT_ASSERT(sv1.size() == 0);
 		sv1.remove_suffix(0);
-		assert(sv1.size() == 0);
+		UT_ASSERT(sv1.size() == 0);
 	}
 }
 
-#if TEST_STD_VER > 11
-constexpr size_t
-test_ce(size_t n, size_t k)
-{
-	typedef std::basic_string_view<char> SV;
-	SV sv1{"ABCDEFGHIJKL", n};
-	sv1.remove_suffix(k);
-	return sv1.size();
-}
-#endif
-
-int
-main(int, char **)
+static void
+run()
 {
 	test("ABCDE", 5);
 	test("a", 1);
@@ -60,7 +53,6 @@ main(int, char **)
 	test(L"a", 1);
 	test(L"", 0);
 
-#if TEST_STD_VER >= 11
 	test(u"ABCDE", 5);
 	test(u"a", 1);
 	test(u"", 0);
@@ -68,16 +60,10 @@ main(int, char **)
 	test(U"ABCDE", 5);
 	test(U"a", 1);
 	test(U"", 0);
-#endif
+}
 
-#if TEST_STD_VER > 11
-	{
-		static_assert(test_ce(5, 0) == 5, "");
-		static_assert(test_ce(5, 1) == 4, "");
-		static_assert(test_ce(5, 5) == 0, "");
-		static_assert(test_ce(9, 3) == 6, "");
-	}
-#endif
-
-	return 0;
+int
+main(int argc, char *argv[])
+{
+	return run_test([&] { run(); });
 }

--- a/tests/external/libcxx/string.view/string.view.modifiers/remove_suffix.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.modifiers/remove_suffix.pass.cpp
@@ -1,0 +1,83 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <string_view>
+
+// void remove_suffix(size_type _n)
+
+#include <cassert>
+#include <string_view>
+
+#include "test_macros.h"
+
+template <typename CharT>
+void
+test(const CharT *s, size_t len)
+{
+	typedef std::basic_string_view<CharT> SV;
+	{
+		SV sv1(s);
+		assert(sv1.size() == len);
+		assert(sv1.data() == s);
+
+		if (len > 0) {
+			sv1.remove_suffix(1);
+			assert(sv1.size() == (len - 1));
+			assert(sv1.data() == s);
+			sv1.remove_suffix(len - 1);
+		}
+
+		assert(sv1.size() == 0);
+		sv1.remove_suffix(0);
+		assert(sv1.size() == 0);
+	}
+}
+
+#if TEST_STD_VER > 11
+constexpr size_t
+test_ce(size_t n, size_t k)
+{
+	typedef std::basic_string_view<char> SV;
+	SV sv1{"ABCDEFGHIJKL", n};
+	sv1.remove_suffix(k);
+	return sv1.size();
+}
+#endif
+
+int
+main(int, char **)
+{
+	test("ABCDE", 5);
+	test("a", 1);
+	test("", 0);
+
+	test(L"ABCDE", 5);
+	test(L"a", 1);
+	test(L"", 0);
+
+#if TEST_STD_VER >= 11
+	test(u"ABCDE", 5);
+	test(u"a", 1);
+	test(u"", 0);
+
+	test(U"ABCDE", 5);
+	test(U"a", 1);
+	test(U"", 0);
+#endif
+
+#if TEST_STD_VER > 11
+	{
+		static_assert(test_ce(5, 0) == 5, "");
+		static_assert(test_ce(5, 1) == 4, "");
+		static_assert(test_ce(5, 5) == 0, "");
+		static_assert(test_ce(9, 3) == 6, "");
+	}
+#endif
+
+	return 0;
+}

--- a/tests/external/libcxx/string.view/string.view.modifiers/swap.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.modifiers/swap.pass.cpp
@@ -5,50 +5,42 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// Copyright 2020, Intel Corporation
+//
+// Modified to test pmem::obj containers
+//
 
 // <string_view>
 
 // void swap(basic_string_view& _other) noexcept
 
-#include <cassert>
-#include <string_view>
+#include "unittest.hpp"
 
-#include "test_macros.h"
+#include <libpmemobj++/string_view.hpp>
 
 template <typename CharT>
 void
 test(const CharT *s, size_t len)
 {
-	typedef std::basic_string_view<CharT> SV;
+	typedef pmem::obj::basic_string_view<CharT> SV;
 	{
 		SV sv1(s);
 		SV sv2;
 
-		assert(sv1.size() == len);
-		assert(sv1.data() == s);
-		assert(sv2.size() == 0);
+		UT_ASSERT(sv1.size() == len);
+		UT_ASSERT(sv1.data() == s);
+		UT_ASSERT(sv2.size() == 0);
 
 		sv1.swap(sv2);
-		assert(sv1.size() == 0);
-		assert(sv2.size() == len);
-		assert(sv2.data() == s);
+		UT_ASSERT(sv1.size() == 0);
+		UT_ASSERT(sv2.size() == len);
+		UT_ASSERT(sv2.data() == s);
 	}
 }
 
-#if TEST_STD_VER > 11
-constexpr size_t
-test_ce(size_t n, size_t k)
-{
-	typedef std::basic_string_view<char> SV;
-	SV sv1{"ABCDEFGHIJKL", n};
-	SV sv2{sv1.data(), k};
-	sv1.swap(sv2);
-	return sv1.size();
-}
-#endif
-
-int
-main(int, char **)
+static void
+run()
 {
 	test("ABCDE", 5);
 	test("a", 1);
@@ -58,7 +50,6 @@ main(int, char **)
 	test(L"a", 1);
 	test(L"", 0);
 
-#if TEST_STD_VER >= 11
 	test(u"ABCDE", 5);
 	test(u"a", 1);
 	test(u"", 0);
@@ -66,15 +57,10 @@ main(int, char **)
 	test(U"ABCDE", 5);
 	test(U"a", 1);
 	test(U"", 0);
-#endif
+}
 
-#if TEST_STD_VER > 11
-	{
-		static_assert(test_ce(2, 3) == 3, "");
-		static_assert(test_ce(5, 3) == 3, "");
-		static_assert(test_ce(0, 1) == 1, "");
-	}
-#endif
-
-	return 0;
+int
+main(int argc, char *argv[])
+{
+	return run_test([&] { run(); });
 }

--- a/tests/external/libcxx/string.view/string.view.modifiers/swap.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.modifiers/swap.pass.cpp
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <string_view>
+
+// void swap(basic_string_view& _other) noexcept
+
+#include <cassert>
+#include <string_view>
+
+#include "test_macros.h"
+
+template <typename CharT>
+void
+test(const CharT *s, size_t len)
+{
+	typedef std::basic_string_view<CharT> SV;
+	{
+		SV sv1(s);
+		SV sv2;
+
+		assert(sv1.size() == len);
+		assert(sv1.data() == s);
+		assert(sv2.size() == 0);
+
+		sv1.swap(sv2);
+		assert(sv1.size() == 0);
+		assert(sv2.size() == len);
+		assert(sv2.data() == s);
+	}
+}
+
+#if TEST_STD_VER > 11
+constexpr size_t
+test_ce(size_t n, size_t k)
+{
+	typedef std::basic_string_view<char> SV;
+	SV sv1{"ABCDEFGHIJKL", n};
+	SV sv2{sv1.data(), k};
+	sv1.swap(sv2);
+	return sv1.size();
+}
+#endif
+
+int
+main(int, char **)
+{
+	test("ABCDE", 5);
+	test("a", 1);
+	test("", 0);
+
+	test(L"ABCDE", 5);
+	test(L"a", 1);
+	test(L"", 0);
+
+#if TEST_STD_VER >= 11
+	test(u"ABCDE", 5);
+	test(u"a", 1);
+	test(u"", 0);
+
+	test(U"ABCDE", 5);
+	test(U"a", 1);
+	test(U"", 0);
+#endif
+
+#if TEST_STD_VER > 11
+	{
+		static_assert(test_ce(2, 3) == 3, "");
+		static_assert(test_ce(5, 3) == 3, "");
+		static_assert(test_ce(0, 1) == 1, "");
+	}
+#endif
+
+	return 0;
+}


### PR DESCRIPTION
This PR contains:

- string_view: add string_view capacity API libcxx tests
- string_view: implement modifiers API for string_view
- string_view: port modifiers libcxx tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/946)
<!-- Reviewable:end -->
