### PR TITLE
string_view: add missing licence for capacity libcxx test

### DIFF
--- a/tests/external/libcxx/string.view/string.view.capacity/capacity.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.capacity/capacity.pass.cpp
@@ -5,6 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// Copyright 2020, Intel Corporation
+//
+// Modified to test pmem::obj containers
+//
 
 // <string_view>
 


### PR DESCRIPTION
- add missing Intel licence

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/947)
<!-- Reviewable:end -->
