### PR TITLE
Fix GH Container Registry log-in

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           fetch-depth: 50
 
+      - name: Log in to the container registry
+        run: echo "${CONTAINER_REG_PASS}" | docker login ghcr.io -u="${CONTAINER_REG_USER}" --password-stdin
+
       - name: Pull or rebuild the image
         run: cd $WORKDIR && ${{ matrix.CONFIG }} ./pull-or-rebuild-image.sh
 

--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -4,13 +4,13 @@ on: [push, pull_request]
 env:
   REPO:           libpmemobj-cpp
   GITHUB_REPO:    pmem/libpmemobj-cpp
+  CONTAINER_REG:  ghcr.io/pmem/libpmemobj-cpp
 
 jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
     env:
-      CONTAINER_REG:  ghcr.io/pmem/libpmemobj-cpp
       # use org's Private Access Token to log in to GitHub Container Registry
       CONTAINER_REG_USER:   ${{ secrets.GH_CR_USER }}
       CONTAINER_REG_PASS:   ${{ secrets.GH_CR_PAT }}

--- a/utils/docker/images/push-image.sh
+++ b/utils/docker/images/push-image.sh
@@ -43,8 +43,5 @@ then
 	exit 1
 fi
 
-echo "Log in to the container registry"
-echo "${CONTAINER_REG_PASS}" | docker login ghcr.io -u="${CONTAINER_REG_USER}" --password-stdin
-
 echo "Push the image to the container registry"
 docker push ${CONTAINER_REG}:${TAG}


### PR DESCRIPTION
by login already at the beginning of the workflow.
BTW fix position of env var in gha.yaml - it's required in docs' job.

This fix is to try if docker login is needed for all docker actions (pull & push). Potentially we'll need to implement in next PR/next fix solution like [this](https://github.community/t/error-response-from-daemon-get-https-ghcr-io-v2-denied/134675/4).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/949)
<!-- Reviewable:end -->
