### PR TITLE
CI: require login to container registry only when pushing image

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -33,9 +33,6 @@ jobs:
         with:
           fetch-depth: 50
 
-      - name: Log in to the container registry
-        run: echo "${CONTAINER_REG_PASS}" | docker login ghcr.io -u="${CONTAINER_REG_USER}" --password-stdin
-
       - name: Pull or rebuild the image
         run: cd $WORKDIR && ${{ matrix.CONFIG }} ./pull-or-rebuild-image.sh
 

--- a/utils/docker/images/push-image.sh
+++ b/utils/docker/images/push-image.sh
@@ -43,5 +43,8 @@ then
 	exit 1
 fi
 
+echo "Log in to the container registry"
+echo "${CONTAINER_REG_PASS}" | docker login ghcr.io -u="${CONTAINER_REG_USER}" --password-stdin
+
 echo "Push the image to the container registry"
 docker push ${CONTAINER_REG}:${TAG}


### PR DESCRIPTION
Packages should be public now, so they don't require login.

basically it should work just fine like it was in https://github.com/pmem/libpmemobj-cpp/pull/930 + commit: da7bdf7c85374e4f9632465d63aeac0872f18331

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/951)
<!-- Reviewable:end -->
