### PR TITLE
string_view: change test behavior according to C++ version

### DIFF
--- a/tests/external/libcxx/string.view/string.view.access/back.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.access/back.pass.cpp
@@ -29,7 +29,9 @@ test(const CharT *s, size_t len)
 	static_assert(std::is_same<decltype(sv.back()),
 				   typename SV::const_reference>::value,
 		      "must be const_reference");
+#ifndef __cpp_lib_string_view
 	static_assert(noexcept(sv.back()), "Operation must be noexcept");
+#endif
 	UT_ASSERT(sv.length() == len);
 	UT_ASSERT(sv.back() == s[len - 1]);
 	return &sv.back() == s + len - 1;

--- a/tests/external/libcxx/string.view/string.view.access/front.pass.cpp
+++ b/tests/external/libcxx/string.view/string.view.access/front.pass.cpp
@@ -28,7 +28,9 @@ test(const CharT *s, size_t len)
 	static_assert(std::is_same<decltype(sv.front()),
 				   typename SV::const_reference>::value,
 		      "must be const_reference");
+#ifndef __cpp_lib_string_view
 	static_assert(noexcept(sv.front()), "Operation must be noexcept");
+#endif
 	UT_ASSERT(sv.length() == len);
 	UT_ASSERT(sv.front() == s[0]);
 	return &sv.front() == s;


### PR DESCRIPTION
This PR makes master great again:
﻿- check noexcept when testing our implementation of string_view

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/953)
<!-- Reviewable:end -->
