### PR TITLE
cmake: get rid of INSTALL_* options and always install all source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,15 +96,6 @@ option(TEST_CONCURRENT_MAP "enable testing of pmem::obj::experimental::concurren
 option(TEST_SELF_RELATIVE_POINTER "enable testing of pmem::obj::experimental::self_relative_ptr" ON)
 option(TEST_RADIX_TREE "enable testing of pmem::obj::experimental::radix_tree" ON)
 
-option(INSTALL_ARRAY "enable installation of pmem::obj::array" ON)
-option(INSTALL_VECTOR "enable installation of pmem::obj::vector" ON)
-option(INSTALL_STRING "enable installation of pmem::obj::string (depends on INSTALL_VECTOR)" ON)
-option(INSTALL_CONCURRENT_HASHMAP "enable installation of pmem::obj::concurrent_hash_map (depends on INSTALL_STRING and INSTALL_SEGMENT_VECTOR)" ON)
-option(INSTALL_SEGMENT_VECTOR "enable installation of pmem::obj::segment_vector" ON)
-option(INSTALL_CONCURRENT_MAP "enable installation of pmem::obj::experimental::concurrent_map (depends on INSTALL_STRING)" ON)
-option(INSTALL_SELF_RELATIVE_POINTER "enable installation of pmem::obj::experimental::self_relative_ptr" ON)
-option(INSTALL_RADIX_TREE "enable installation of pmem::obj::experimental::radix_tree" ON)
-
 ## Setup environment, find packages, set compiler's flags, add additional custom targets
 include(FindPerl)
 include(FindThreads)
@@ -250,70 +241,7 @@ configure_file(${CMAKE_SOURCE_DIR}/cmake/version.hpp.in
 		${CMAKE_SOURCE_DIR}/include/libpmemobj++/version.hpp @ONLY)
 
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-	FILES_MATCHING PATTERN "*.hpp"
-	PATTERN "array.hpp" EXCLUDE
-	PATTERN "vector.hpp" EXCLUDE
-	PATTERN "string.hpp" EXCLUDE
-	PATTERN "basic_string.hpp" EXCLUDE
-	PATTERN "contiguous_iterator.hpp" EXCLUDE
-	PATTERN "slice.hpp" EXCLUDE
-	PATTERN "concurrent_hash_map.hpp" EXCLUDE
-	PATTERN "segment_vector.hpp" EXCLUDE
-	PATTERN "enumerable_thread_specific.hpp" EXCLUDE
-	PATTERN "concurrent_map.hpp" EXCLUDE
-	PATTERN "self_relative_ptr.hpp" EXCLUDE
-	PATTERN "self_relative_ptr_base.hpp" EXCLUDE
-	PATTERN "inline_string.hpp" EXCLUDE
-	PATTERN "bytes_view.hpp" EXCLUDE
-	PATTERN "radix_tree.hpp" EXCLUDE
-	PATTERN "self_relative_ptr_base_impl.hpp" EXCLUDE
-	PATTERN "atomic_self_relative_ptr.hpp" EXCLUDE
-	)
-
-if(INSTALL_ARRAY)
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "array.hpp")
-endif()
-
-if(INSTALL_VECTOR)
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "vector.hpp")
-endif()
-
-if(INSTALL_STRING)
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "basic_string.hpp")
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "string.hpp")
-endif()
-
-if(INSTALL_CONCURRENT_HASHMAP)
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "concurrent_hash_map.hpp")
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "enumerable_thread_specific.hpp")
-endif()
-
-if(INSTALL_ARRAY OR INSTALL_VECTOR OR INSTALL_STRING)
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "contiguous_iterator.hpp")
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "slice.hpp")
-endif()
-
-if(INSTALL_SEGMENT_VECTOR)
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "segment_vector.hpp")
-endif()
-
-if(INSTALL_CONCURRENT_MAP)
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "concurrent_map.hpp")
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "enumerable_thread_specific.hpp")
-endif()
-
-if(INSTALL_SELF_RELATIVE_POINTER)
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "self_relative_ptr.hpp")
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "self_relative_ptr_base.hpp")
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "self_relative_ptr_base_impl.hpp")
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "atomic_self_relative_ptr.hpp")
-endif()
-
-if(INSTALL_RADIX_TREE)
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "bytes_view.hpp")
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "inline_string.hpp")
-	install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "radix_tree.hpp")
-endif()
+	FILES_MATCHING PATTERN "*.hpp")
 
 install(DIRECTORY examples/ DESTINATION ${CMAKE_INSTALL_DOCDIR}/examples
 	FILES_MATCHING PATTERN "*.*pp")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ When developing a persistent container make sure you follow the rules and steps 
 ## Steps
 1. Create container implementation
 2. Create doc_snippet/example
-3. Add TEST_CONTAINER and INSTALL_CONTAINER CMake flags for enabling/disabling the container installation and testing.
+3. Add TEST_CONTAINER CMake option for enabling/disabling container's testing.
 4. Add tests (+ if possible, enable libcxx tests in tests/external/libcxx)
 
 ## Requirements:


### PR DESCRIPTION
It seems redundant to keep these options and it complicates
which files are required by which containers. Installing all source
files should not cause any issue as long as they won't be used.

fixes: #955

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/956)
<!-- Reviewable:end -->
