### PR TITLE
Move inline_string and basic_string template helpers out

### DIFF
--- a/include/libpmemobj++/detail/template_helpers.hpp
+++ b/include/libpmemobj++/detail/template_helpers.hpp
@@ -11,9 +11,6 @@
 
 #include <type_traits>
 
-#include <libpmemobj++/container/basic_string.hpp>
-#include <libpmemobj++/experimental/inline_string.hpp>
-
 namespace pmem
 {
 
@@ -46,31 +43,6 @@ using is_transparent = typename Compare::is_transparent;
 
 template <typename Compare>
 using has_is_transparent = detail::supports<Compare, is_transparent>;
-
-/* Check if type is pmem::obj::basic_inline_string */
-template <typename>
-struct is_inline_string : std::false_type {
-};
-
-template <typename CharT, typename Traits>
-struct is_inline_string<obj::experimental::basic_inline_string<CharT, Traits>>
-    : std::true_type {
-};
-
-/* Check if type is pmem::obj::basic_string or
- * pmem::obj::basic_inline_string */
-template <typename>
-struct is_string : std::false_type {
-};
-
-template <typename CharT, typename Traits>
-struct is_string<obj::basic_string<CharT, Traits>> : std::true_type {
-};
-
-template <typename CharT, typename Traits>
-struct is_string<obj::experimental::basic_inline_string<CharT, Traits>>
-    : std::true_type {
-};
 
 } /* namespace detail */
 

--- a/include/libpmemobj++/experimental/inline_string.hpp
+++ b/include/libpmemobj++/experimental/inline_string.hpp
@@ -305,6 +305,20 @@ struct total_sizeof<basic_inline_string<CharT, Traits>> {
 };
 } /* namespace experimental */
 } /* namespace obj */
+
+namespace detail
+{
+/* Check if type is pmem::obj::basic_inline_string */
+template <typename>
+struct is_inline_string : std::false_type {
+};
+
+template <typename CharT, typename Traits>
+struct is_inline_string<obj::experimental::basic_inline_string<CharT, Traits>>
+    : std::true_type {
+};
+} /* namespace detail */
+
 } /* namespace pmem */
 
 #endif /* LIBPMEMOBJ_CPP_INLINE_STRING_HPP */

--- a/include/libpmemobj++/experimental/radix_tree.hpp
+++ b/include/libpmemobj++/experimental/radix_tree.hpp
@@ -3199,6 +3199,21 @@ swap(radix_tree<Key, Value, BytesView> &lhs,
 
 namespace detail
 {
+/* Check if type is pmem::obj::basic_string or
+ * pmem::obj::basic_inline_string */
+template <typename>
+struct is_string : std::false_type {
+};
+
+template <typename CharT, typename Traits>
+struct is_string<obj::basic_string<CharT, Traits>> : std::true_type {
+};
+
+template <typename CharT, typename Traits>
+struct is_string<obj::experimental::basic_inline_string<CharT, Traits>>
+    : std::true_type {
+};
+
 template <typename T>
 struct bytes_view<T, typename std::enable_if<is_string<T>::value>::type> {
 	using CharT = typename T::value_type;


### PR DESCRIPTION
of a template_helpers.hpp. The template_helpers.hpp file should
not have any dependencies on libpmemobj-cpp headers.

Ref: https://github.com/pmem/libpmemobj-cpp/issues/955

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/957)
<!-- Reviewable:end -->
