### PR TITLE
tests: do not use scheduler-locking in gdb tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ option(TESTS_USE_FORCED_PMEM "run tests with PMEM_IS_PMEM_FORCE=1 - it speeds up
 option(TESTS_USE_VALGRIND "enable tests with valgrind (if found)" ON)
 option(TESTS_PMREORDER "enable tests with pmreorder (if pmreorder found; it requires PMDK ver. >= 1.9)" OFF)
 option(TESTS_CONCURRENT_HASH_MAP_DRD_HELGRIND "enable concurrent_hash_map tests with drd and helgrind (can only be run on PMEM)" OFF)
-option(TESTS_CONCURRENT_GDB "enable concurrent gdb tests - require 'set scheduler-locking on' support (OS dependent)" OFF)
+option(TESTS_CONCURRENT_GDB "enable concurrent gdb tests" OFF)
 option(TESTS_LONG "enable long running tests" OFF)
 option(TESTS_TBB "enable tests which require TBB" OFF)
 option(TESTS_COMPATIBILITY "enable compatibility tests (requires internet connection)" OFF)

--- a/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb.cpp
+++ b/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb.cpp
@@ -27,6 +27,17 @@
 
 namespace nvobj = pmem::obj;
 
+void
+loop_forever()
+{
+	for (int i = 0; i < 1; i++) {
+		/* nop */
+	}
+
+	while (true) {
+	}
+}
+
 namespace
 {
 

--- a/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb_0.gdb
+++ b/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb_0.gdb
@@ -2,7 +2,6 @@ set width 0
 set height 0
 set verbose off
 set confirm off
-set breakpoint pending on
 set pagination off
 set print address off
 
@@ -15,22 +14,24 @@ set print address off
 #    New node should not be visible (neither thread 10 nor 11 completed)
 
 break gdb_sync1
+break loop_forever
 run
 rbreak concurrent_skip_list_impl.hpp:internal_insert_node
 thread 10
 c
-set scheduler-locking on
+jump loop_forever
 thread 11
 break gdb_sync2
 c
-del 3
+del 4
 finish
 set variable loop_sync_1 = 0
 c
+jump loop_forever
 thread 12
 break gdb_sync3
 c
-del 4
+del 5
 finish
 set variable loop_sync_2 = 0
 break gdb_sync_exit thread 12

--- a/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb_1.gdb
+++ b/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb_1.gdb
@@ -14,24 +14,26 @@ set pagination off
 #    New node should now be visible (thread 11 completed)
 
 break gdb_sync1
+break loop_forever
 run
 rbreak concurrent_skip_list_impl.hpp:internal_insert_node
 break concurrent_skip_list_impl.hpp:try_insert_node_finish_marker
 thread 10
 c
-set scheduler-locking on
+jump loop_forever
 thread 11
 break gdb_sync2
 c
-del 4
+del 5
 finish
 set variable loop_sync_1 = 0
 c
 c
+jump loop_forever
 thread 12
 break gdb_sync3
 c
-del 5
+del 6
 finish
 set variable loop_sync_2 = 0
 break gdb_sync_exit thread 12

--- a/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb_2.gdb
+++ b/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb_2.gdb
@@ -14,15 +14,16 @@ set pagination off
 #    New node should now be visible (thread 11 partially completed)
 
 break gdb_sync1
+break loop_forever
 run
 rbreak concurrent_skip_list_impl.hpp:internal_insert_node
 thread 10
 c
-set scheduler-locking on
+jump loop_forever
 thread 11
 break gdb_sync2
 c
-del 3
+del 4
 finish
 set variable loop_sync_1 = 0
 c
@@ -33,11 +34,12 @@ finish
 finish
 n
 n
-del 4
+del 5
+jump loop_forever
 thread 12
 break gdb_sync3
 c
-del 5
+del 6
 finish
 set variable loop_sync_2 = 0
 break gdb_sync_exit thread 12


### PR DESCRIPTION
Because it is not supported on some platforms.

`set scheduler-locking on` was used to allow only one thread to execute.
In concurrent_map_gdb tests we wanted for some threads to hang on some
breakpoint and continue with other threads.

In this patch instead of using scheduler locking we just jump to an
infinite loop before switching to a new thread.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/966)
<!-- Reviewable:end -->
