### PR TITLE
Do not run concurrent gdb tests under clang

### DIFF
--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -89,8 +89,7 @@ function tests_clang_debug_cpp17_no_valgrind() {
 		-DTESTS_PMREORDER=${TESTS_PMREORDER} \
 		-DTEST_DIR=/mnt/pmem \
 		-DTESTS_USE_FORCED_PMEM=1 \
-		-DTESTS_COMPATIBILITY=1 \
-		-DTESTS_CONCURRENT_GDB=1
+		-DTESTS_COMPATIBILITY=1
 
 	make -j$(nproc)
 	ctest --output-on-failure -E "_pmreorder" --timeout 590


### PR DESCRIPTION
On some versions of clang and gdb rbreak does not work correctly
for template function. More precisely, breakpoint at internal_insert_node
is never hit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/967)
<!-- Reviewable:end -->
