### PR TITLE
Fix SRCVERSION in CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ build/
 *.swp
 ~*
 tags
-include/libpmemobj++/version.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,10 @@ add_check_whitespace(cmake-helpers ${CMAKE_CURRENT_SOURCE_DIR}/cmake/*.cmake)
 
 ## Configure make install/uninstall and packages
 configure_file(${CMAKE_SOURCE_DIR}/cmake/version.hpp.in
-		${CMAKE_SOURCE_DIR}/include/libpmemobj++/version.hpp @ONLY)
+	${CMAKE_CURRENT_BINARY_DIR}/version.hpp @ONLY)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/version.hpp
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libpmemobj++)
 
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 	FILES_MATCHING PATTERN "*.hpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,25 @@ endif()
 if(VERSION_PRERELEASE)
 	set(VERSION ${VERSION}-${VERSION_PRERELEASE})
 endif()
+# XXX: use it in version.hpp and in Doxygen.in
+# Set ${SRCVERSION}
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+	execute_process(COMMAND git describe
+			OUTPUT_VARIABLE SRCVERSION
+			WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+			ERROR_QUIET)
+	if(NOT SRCVERSION)
+		execute_process(COMMAND git log -1 --format=%h
+				OUTPUT_VARIABLE SRCVERSION
+				WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+				OUTPUT_STRIP_TRAILING_WHITESPACE)
+	endif()
+elseif(EXISTS "${CMAKE_SOURCE_DIR}/.version")
+	file(STRINGS ${CMAKE_SOURCE_DIR}/.version SRCVERSION)
+else()
+	set(SRCVERSION ${VERSION})
+endif()
 
 set(LIBPMEMOBJ_REQUIRED_VERSION 1.8)
 set(LIBPMEM_REQUIRED_VERSION 1.7)
@@ -42,24 +61,6 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
-
-# XXX: use it in version.hpp and in Doxygen.in
-# Set ${SRCVERSION}
-if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
-	execute_process(COMMAND git describe
-			OUTPUT_VARIABLE SRCVERSION
-			WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-			OUTPUT_STRIP_TRAILING_WHITESPACE
-			ERROR_QUIET)
-	if(NOT SRCVERSION)
-		execute_process(COMMAND git log -1 --format=%h
-				OUTPUT_VARIABLE SRCVERSION
-				WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-				OUTPUT_STRIP_TRAILING_WHITESPACE)
-	endif()
-else()
-	file(STRINGS ${CMAKE_SOURCE_DIR}/.version SRCVERSION)
-endif()
 
 ## CMake build options
 option(BUILD_EXAMPLES "build examples" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 if(VERSION_PRERELEASE)
 	set(VERSION ${VERSION}-${VERSION_PRERELEASE})
 endif()
-# XXX: use it in version.hpp and in Doxygen.in
+
 # Set ${SRCVERSION}
 if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
 	execute_process(COMMAND git describe

--- a/cmake/libpmemobj++.pc.in
+++ b/cmake/libpmemobj++.pc.in
@@ -3,7 +3,7 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: libpmemobj++
 Description: libpmemobj++ - c++ bindings for libpmemobj library
-Version: @VERSION@
+Version: @SRCVERSION@
 URL: https://github.com/pmem/libpmemobj-cpp
 Requires: libpmemobj >= @LIBPMEMOBJ_REQUIRED_VERSION@
 Cflags: -I${includedir}

--- a/cmake/version.hpp.in
+++ b/cmake/version.hpp.in
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2018, Intel Corporation */
+/* Copyright 2018-2020, Intel Corporation */
 
 /**
  * @file
@@ -14,5 +14,6 @@
 #define LIBPMEMOBJ_CPP_VERSION_PATCH @VERSION_PATCH@
 
 #define LIBPMEMOBJ_CPP_VERSION "@VERSION@"
+#define LIBPMEMOBJ_CPP_SRCVERSION "@SRCVERSION@"
 
 #endif /* LIBPMEMOBJ_CPP_VERSION_HPP */

--- a/doc/libpmemobj++.Doxyfile.in
+++ b/doc/libpmemobj++.Doxyfile.in
@@ -23,7 +23,7 @@ PROJECT_NAME = "PMDK C++ bindings"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER = @VERSION@
+PROJECT_NUMBER = @SRCVERSION@
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a


### PR DESCRIPTION
- fix issue when "${CMAKE_SOURCE_DIR}/.version" file is not available (e.g. when repo cloned from git, but ".git" dir is cleared out),
- SRCVERSION in several situations seems more suitable (instead of hardcoded VERSION),
- make sure out-of-tree build doesn't contain leftover in `include/` directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/971)
<!-- Reviewable:end -->
