### PR TITLE
docker: remove hub package from Fedora Rawhide

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-rawhide
+++ b/utils/docker/images/Dockerfile.fedora-rawhide
@@ -44,7 +44,6 @@ RUN dnf update -y \
 	gcc-c++ \
 	gdb \
 	git \
-	hub \
 	json-c-devel \
 	kmod-devel \
 	libtool \

--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2020, Intel Corporation
+# Copyright 2018-2021, Intel Corporation
 
 #
 # run-doc-update.sh - is called inside a Docker container,
@@ -85,6 +85,9 @@ echo "Add and push changes:"
 git add -A
 git commit -m "doc: automatic gh-pages docs update" && true
 git push -f ${ORIGIN} ${GH_PAGES_NAME}
+
+echo "Make sure hub command is available:"
+hub --version
 
 echo "Make or update pull request:"
 # When there is already an open PR or there are no changes an error is thrown, which we ignore.


### PR DESCRIPTION
it's required by run-doc-update.sh which is not executed on this OS
and apparently this package is not available in repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/977)
<!-- Reviewable:end -->
