### PR TITLE
Fix TBB cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,9 +164,6 @@ if(BUILD_TESTS OR BUILD_EXAMPLES OR BUILD_BENCHMARKS)
 		find_package(LIBPMEMOBJ REQUIRED ${LIBPMEMOBJ_REQUIRED_VERSION})
 		find_package(LIBPMEM REQUIRED ${LIBPMEM_REQUIRED_VERSION})
 	endif()
-
-	# XXX: required by tests only?
-	include(tbb)
 endif()
 
 add_custom_target(checkers ALL)

--- a/cmake/tbb.cmake
+++ b/cmake/tbb.cmake
@@ -1,23 +1,24 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2017-2019, Intel Corporation
+# Copyright 2017-2020, Intel Corporation
+
+message(STATUS "Checking for module 'tbb'")
 
 if(PKG_CONFIG_FOUND)
-	pkg_check_modules(TBB tbb)
+	pkg_check_modules(TBB QUIET tbb)
 endif()
 
+# Now, if needed, try to find it without pkg-config..
 if(NOT TBB_FOUND)
 	# find_package without unsetting this var is not working correctly
 	unset(TBB_FOUND CACHE)
+
 	find_package(TBB COMPONENTS tbb)
-
 	if(TBB_FOUND)
-		message(STATUS "TBB package found without pkg-config")
+		set(TBB_LIBRARIES ${TBB_IMPORTED_TARGETS})
+		message(STATUS "  Found in: ${TBB_DIR} using CMake's find_package (ver: ${TBB_VERSION})")
+	elseif(TESTS_TBB)
+		message(FATAL_ERROR "TBB tests are enabled by cmake TESTS_TBB option, but Intel TBB library was not found.")
 	endif()
-
-	set(TBB_LIBRARIES ${TBB_IMPORTED_TARGETS})
-endif()
-
-if(NOT TBB_FOUND)
-	message(WARNING "TBB not found. Please set TBB_DIR CMake variable if TBB \
-is installed in a non-standard directory, like: -DTBB_DIR=<path_to_tbb_cmake_dir>")
+else()
+	message(STATUS "  Found in: ${TBB_LIBDIR} using pkg-config (ver: ${TBB_VERSION})")
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,9 @@ include(ctest_helpers.cmake)
 ## Setup
 add_custom_target(tests)
 
+# Try to find it for some tests using TBB
+include(tbb)
+
 # Add checks when DEVELOPER_MODE is ON
 add_cppstyle(tests-common ${CMAKE_CURRENT_SOURCE_DIR}/common/*.*pp
 						  ${CMAKE_CURRENT_SOURCE_DIR}/*.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -562,11 +562,8 @@ if(TEST_CONCURRENT_HASHMAP)
 		message(WARNING "Skipping concurrent_hash_map_rehash_break test because GDB was not found")
 	endif()
 
-	# XXX: move this check to the top of the file, to potentially fail build earlier
 	if(NOT TESTS_TBB)
 		message(WARNING "Skipping concurrent_hash_map_tbb tests - disabled by cmake TESTS_TBB option")
-	elseif(NOT TBB_FOUND)
-		message(FATAL_ERROR "concurrent_hash_map_tbb tests enabled by cmake TESTS_TBB option, but Intel TBB library was not found")
 	else()
 		build_test_tbb(concurrent_hash_map_tbb_insert_lookup concurrent_hash_map_insert_lookup/concurrent_hash_map_tbb_insert_lookup.cpp)
 		add_test_generic(NAME concurrent_hash_map_tbb_insert_lookup TRACERS none


### PR DESCRIPTION
- similarly to https://github.com/pmem/pmemkv/pull/843 fix TBB messaging,
- checking if TESTS_TBB is on, already while looking for tbb package,
- including TBB cmake file only in tests sub-directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/980)
<!-- Reviewable:end -->
