### PR TITLE
CI: use special environment var in GHA for Windows' PATH

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -69,8 +69,7 @@ jobs:
         CONFIG: [Debug, Release]
     steps:
        - name: Update PATH
-         run: |
-           echo "::add-path::$Env:MSBUILD"
+         run: echo "${env:MSBUILD}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
        - name: Cache vcpkg packages
          uses: actions/cache@v1


### PR DESCRIPTION
The old 'addPath' is depreciated now. For more details see:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

mea culpa, this is a merge back from #975 - this should have been based on the oldest branch with GHA enabled, from the beginning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/981)
<!-- Reviewable:end -->
