### PR TITLE
basic_string: remove workaround to compile under VC++2015

### DIFF
--- a/tests/external/libcxx/basic_string/string.cons/T_size_size.pass.cpp
+++ b/tests/external/libcxx/basic_string/string.cons/T_size_size.pass.cpp
@@ -6,6 +6,11 @@
 // Source Licenses. See LICENSE.TXT for details.
 //
 //===----------------------------------------------------------------------===//
+//
+// Copyright 2020, Intel Corporation
+//
+// Modified to test pmem::obj containers
+//
 
 // <string>
 
@@ -207,8 +212,7 @@ run(pmem::obj::pool<root> &pop)
 			auto s3 = nvobj::make_persistent<S>(
 				sv, static_cast<S::size_type>(0),
 				std::string::npos); // calls ctor(T, pos, npos)
-			UT_ASSERT(static_cast<pmem::obj::string_view>(*s3) ==
-				  sv);
+			UT_ASSERT(*s3 == sv);
 			nvobj::delete_persistent<S>(s3);
 		});
 


### PR DESCRIPTION
After added conversion operators there is no need
to manually cast string to string_view. Casting in this case
produces VC++2015 errors due to operator==() ambiguity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/982)
<!-- Reviewable:end -->
