### PR TITLE
radix_tree: fix use after free

### DIFF
--- a/include/libpmemobj++/experimental/radix_tree.hpp
+++ b/include/libpmemobj++/experimental/radix_tree.hpp
@@ -1802,6 +1802,10 @@ radix_tree<Key, Value, BytesView>::erase(const_iterator pos)
 		auto *leaf = pos.leaf_;
 		auto parent = leaf->parent;
 
+		/* there are more elements in the container */
+		if (parent)
+			++pos;
+
 		delete_persistent<radix_tree::leaf>(
 			persistent_ptr<radix_tree::leaf>(leaf));
 
@@ -1813,8 +1817,6 @@ radix_tree<Key, Value, BytesView>::erase(const_iterator pos)
 			pos = begin();
 			return;
 		}
-
-		++pos;
 
 		/* It's safe to cast because we're inside non-const method. */
 		const_cast<tagged_node_ptr &>(*parent->find_child(leaf)) =

--- a/tests/radix/radix_basic.cpp
+++ b/tests/radix/radix_basic.cpp
@@ -847,6 +847,55 @@ test_inline_string_u8t_key(nvobj::pool<root> &pop)
 	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
 }
 
+void
+test_remove_inserted(nvobj::pool<root> &pop)
+{
+	const size_t NUM_ITER = 100;
+
+	auto r = pop.root();
+
+	nvobj::transaction::run(pop, [&] {
+		r->radix_str = nvobj::make_persistent<container_string>();
+	});
+
+	/* remove element which was just inserted */
+	nvobj::transaction::run(pop, [&] {
+		for (size_t i = 0; i < NUM_ITER; i++) {
+			UT_ASSERT(r->radix_str
+					  ->emplace(std::to_string(i),
+						    std::to_string(i))
+					  .second);
+			UT_ASSERT(r->radix_str->erase(std::to_string(i)));
+		}
+	});
+
+	/* insert some initial elements */
+	nvobj::transaction::run(pop, [&] {
+		for (size_t i = 0; i < 5; i++)
+			UT_ASSERT(r->radix_str
+					  ->emplace("init" + std::to_string(i),
+						    std::to_string(i))
+					  .second);
+	});
+
+	/* remove element which was just inserted */
+	nvobj::transaction::run(pop, [&] {
+		for (size_t i = 0; i < NUM_ITER; i++) {
+			UT_ASSERT(r->radix_str
+					  ->emplace(std::to_string(i),
+						    std::to_string(i))
+					  .second);
+			UT_ASSERT(r->radix_str->erase(std::to_string(i)));
+		}
+	});
+
+	nvobj::transaction::run(pop, [&] {
+		nvobj::delete_persistent<container_string>(r->radix_str);
+	});
+
+	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+}
+
 static void
 test(int argc, char *argv[])
 {
@@ -880,6 +929,7 @@ test(int argc, char *argv[])
 	test_compression(pop);
 	test_inline_string_u8t_key(pop);
 
+	test_remove_inserted(pop);
 	pop.close();
 }
 


### PR DESCRIPTION
Iterator inside erase() cannot be incremented after calling delete_persistent.
Incrementing checks the value of leaf_->parent which means reading from free'd memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/984)
<!-- Reviewable:end -->
