### PR TITLE
CI: remove redundant CMake param in Windows build

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -126,7 +126,6 @@ jobs:
                     -A "${env:ARCH}"
                     -DCMAKE_TOOLCHAIN_FILE="${env:CMAKE_TOOLCHAIN_FILE}"
                     -DCMAKE_INSTALL_PREFIX="${env:CMAKE_INSTALL_PREFIX}"
-                    -DLIBPMEMOBJ_VERSION="${env:PMDK_VERSION}"
                     -DTESTS_USE_FORCED_PMEM=ON
                     -DTESTS_TBB=ON
                     -DDEVELOPER_MODE=ON


### PR DESCRIPTION
ref. 02c0fecae


we got CMake warning in every GHA Windows build:
```
CMake Warning:
  Manually-specified variables were not used by the project:

    LIBPMEMOBJ_VERSION
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/993)
<!-- Reviewable:end -->
