### PR TITLE
Bump required version of libpmemobj

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -75,7 +75,7 @@ jobs:
       VCPKG_DEFAULT_TRIPLET: x64-windows
       GENERATOR: "Visual Studio 16 2019"
       ARCH:      "x64"
-      PMDK_VERSION: "1.8"
+      PMDK_VERSION: "1.9"
       CMAKE_TOOLCHAIN_FILE: "C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake"
       CMAKE_INSTALL_PREFIX: "C:\\install\\libpmemobj-cpp"
       WORKDIR:  "D:\\a\\libpmemobj-cpp\\libpmemobj-cpp\\"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ else()
 	set(SRCVERSION ${VERSION})
 endif()
 
-set(LIBPMEMOBJ_REQUIRED_VERSION 1.8)
+set(LIBPMEMOBJ_REQUIRED_VERSION 1.9)
 set(LIBPMEM_REQUIRED_VERSION 1.7)
 # Only pmreorder in ver. >= 1.9 guarantees reliable output
 set(PMREORDER_REQUIRED_VERSION 1.9)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To install **libpmemobj-cpp** on Fedora or RedHat execute:
 You will need the following packages for compilation:
 
 - **cmake** >= 3.3
-- **libpmemobj-dev(el)** >= 1.8 (https://pmem.io/pmdk/)
+- **libpmemobj-dev(el)** >= 1.9 (https://pmem.io/pmdk/)
 - compiler with C++11 support
 	- **gcc** >= 4.8.1<sup> 1</sup>
 	- **clang** >= 3.3


### PR DESCRIPTION
Since introducing flat_transactions, 1.9 is needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/998)
<!-- Reviewable:end -->
