### PR TITLE
docker: fix packages' test - unshallow repo for git describe to work

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Clone the git repo
         uses: actions/checkout@v2
         with:
-          fetch-depth: 50
+          fetch-depth: 0
 
       # "pull" or "rebuild" can be passed to a secret FORCE_IMAGE_ACTION to override default action
       - name: Pull the image or rebuild and push it
@@ -104,7 +104,7 @@ jobs:
       - name: Clone the git repo
         uses: actions/checkout@v2
         with:
-          fetch-depth: 50
+          fetch-depth: 0
 
       - name: Install PMDK
         run: |

--- a/.github/workflows/other_OSes.yml
+++ b/.github/workflows/other_OSes.yml
@@ -36,7 +36,8 @@ jobs:
                  "OS=opensuse-tumbleweed OS_VER=latest",
                  "OS=ubuntu OS_VER=18.04",
                  "OS=ubuntu OS_VER=20.10",
-                 "OS=ubuntu OS_VER=rolling"]
+                 "OS=ubuntu OS_VER=rolling",
+                 "TYPE=package OS=ubuntu OS_VER=rolling"]
     steps:
       - name: Clone the git repo
         uses: actions/checkout@v2


### PR DESCRIPTION
it's similar to the tests run in pmemkv (see: https://github.com/pmem/pmemkv/blob/master/utils/docker/run-test-building.sh#L58); without this change I encountered:
https://github.com/pmem/libpmemobj-cpp/runs/1627275113?check_suite_focus=true#step:4:5397

**side note**: should we worry if such situation happen e.g. on maintainer/customer side? they could have shallow clone and make a package - package will be created with the git sha instead of the proper project version...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1004)
<!-- Reviewable:end -->
