### PR TITLE
Fix doxygen docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Up-to-date support/maintenance status of branches/releases is available on [pmem
 ## Compatibility note
 In libpmemobj 1.12 we introduced a new transaction handler type: [pmem::obj::flat_transaction](https://pmem.io/libpmemobj-cpp/master/doxygen/classpmem_1_1obj_1_1flat__transaction.html).
 By defining LIBPMEMOBJ_CPP_USE_FLAT_TRANSACTION you can make pmem::obj::transaction to be an alias to pmem::obj::flat_transaction.
-In 1.12 we have also changed the default behavior of containers' transactional methods. Now, in  case of any failure within such method,
+In 1.12 we have also changed the default behavior of containers' transactional methods. Now, in case of any failure within such method,
 the outer transaction (if any) will not be immediately aborted. Instead, an exception will be thrown, which will lead to transaction abort
 only if it's not caught before the outer tx scope ends. To change the behavior to the old one, you can set LIBPMEMOBJ_CPP_FLAT_TX_USE_FAILURE_RETURN macro to 0.
 Be aware that the old behavior can lead to segfaults in some cases (see tx_nested_struct_example in this [file](examples/transaction/transaction.cpp)).

--- a/examples/concurrent_hash_map/concurrent_hash_map.cpp
+++ b/examples/concurrent_hash_map/concurrent_hash_map.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2019-2020, Intel Corporation */
+/* Copyright 2019-2021, Intel Corporation */
 
 /*
  * concurrent_hash_map.cpp -- C++ documentation snippets.
@@ -15,15 +15,15 @@
 
 using namespace pmem::obj;
 
-/* In this example we will be using concurrent_hash_map with p<int> type for
- * both keys and values */
+/* In this example we use concurrent_hash_map with p<int> type as
+ * both key and value. */
 using hashmap_type = concurrent_hash_map<p<int>, p<int>>;
 
 const int THREADS_NUM = 30;
 
 /* This is basic example and we only need to use concurrent_hash_map. Hence we
- * will correlate memory pool root object with single instance of persistent
- * pointer to hasmap_type */
+ * correlate memory pool root object with a single instance of persistent
+ * pointer to hashmap_type. */
 struct root {
 	persistent_ptr<hashmap_type> pptr;
 };
@@ -73,7 +73,7 @@ main(int argc, char *argv[])
 
 			r->runtime_initialize();
 
-			/* defragment the whole pool at the beginning */
+			/* Defragment the whole pool at the beginning. */
 			try {
 				r->defragment();
 			} catch (const pmem::defrag_error &e) {
@@ -89,8 +89,8 @@ main(int argc, char *argv[])
 		std::vector<std::thread> threads;
 		threads.reserve(static_cast<size_t>(THREADS_NUM));
 
-		/* Insert THREADS_NUM / 3 key-value pairs to the hashmap. This
-		 * operation is thread-safe. */
+		/* Start THREADS_NUM/3 threads to insert key-value pairs
+		 * to the hashmap. This operation is thread-safe. */
 		for (int i = 0; i < THREADS_NUM / 3; ++i) {
 			threads.emplace_back([&]() {
 				for (int i = 0; i < 10 * THREADS_NUM; ++i) {
@@ -100,8 +100,8 @@ main(int argc, char *argv[])
 			});
 		}
 
-		/* Erase THREADS_NUM /3 key-value pairs from the hashmap. This
-		 * operation is thread-safe. */
+		/* Start THREADS_NUM/3 threads to erase key-value pairs
+		 * from the hashmap. This operation is thread-safe. */
 		for (int i = 0; i < THREADS_NUM / 3; ++i) {
 			threads.emplace_back([&]() {
 				for (int i = 0; i < 10 * THREADS_NUM; ++i) {
@@ -110,8 +110,9 @@ main(int argc, char *argv[])
 			});
 		}
 
-		/* Check if given key is in the hashmap. For the time of an
-		 * accessor life, the read-write lock is taken on the item. */
+		/* Start THREADS_NUM/3 threads to check if given key is
+		 * in the hashmap. For the time of an accessor life,
+		 * the read-write lock is taken on the item. */
 		for (int i = 0; i < THREADS_NUM / 3; ++i) {
 			threads.emplace_back([&]() {
 				for (int i = 0; i < 10 * THREADS_NUM; ++i) {
@@ -132,7 +133,7 @@ main(int argc, char *argv[])
 			t.join();
 		}
 		try {
-			/* defragment the whole pool at the end */
+			/* Defragment the whole pool at the end. */
 			map.defragment();
 		} catch (const pmem::defrag_error &e) {
 			std::cerr << "Defragmentation exception: " << e.what()
@@ -176,8 +177,7 @@ main(int argc, char *argv[])
 			map.free_data();
 
 			/* map.clear() // WRONG
-			 * After free_data() concurrent hash map cannot be used
-			 * anymore! */
+			 * After free_data() hash map cannot be used anymore! */
 
 			transaction::run(pop, [&] {
 				delete_persistent<hashmap_type>(r);

--- a/include/libpmemobj++/README.md
+++ b/include/libpmemobj++/README.md
@@ -3,6 +3,19 @@ libpmemobj-cpp	{#mainpage}
 
 This is the C++ API for libpmemobj extended with persistent containers.
 
+If you want to read more about PMDK (and libpmemobj C API in specific) see:
+https://pmem.io/pmdk
+
+Main libpmemobj-cpp documentation website is:
+https://pmem.io/libpmemobj-cpp
+It also contains links to blog articles which you might find helpful.
+
+If you find any issues or have suggestion about these bindings please file an
+issue in https://github.com/pmem/libpmemobj-cpp/issues. The GitHub website
+is also the main code repository location and it contains full usage examples.
+
+### Introduction
+
 During the development of libpmemobj, many difficulties were encountered and
 compromises were made to make the C API as much user-friendly as possible. This
 is mostly due to the semantics of the C language. Since C++ is a more expressive
@@ -34,14 +47,8 @@ Please remember to take extra care when using _static class members_. They are
 not stored in persistent memory, therefore their value will _not_ always be
 consistent across subsequent executions or compilations of user applications.
 
-If you find any issues or have suggestion about these bindings please file an
-issue in https://github.com/pmem/libpmemobj-cpp/issues. There are also blog articles in
-https://pmem.io/blog/ which you might find helpful.
+### Compiler notice
 
-Have fun!
-The PMDK team
-
-### Compiler notice ###
 The C++ bindings require a C++11 compliant compiler, therefore the minimal
 versions of GCC and Clang are 4.8.1 and 3.3 respectively. However the
 pmem::obj::transaction::automatic class requires C++17, so
@@ -50,7 +57,8 @@ It is recommended to use these or newer versions of GCC or Clang.
 A usage of the libpmemobj-cpp containers requires GCC >= 4.9.0 (see explanation
 in the main README.md file).
 
-### Standard notice ###
+### C++ standard notice
+
 Please note that the C++11 standard, section 3.8, states that a valid
 non-trivially default constructible object (in other words, not plain old data)
 must be properly constructed in the lifetime of the application.
@@ -69,7 +77,20 @@ practically speaking implementation defined. The only exception to this rule is
 the use of polymorphic types, which are notably forbidden when using C++
 bindings.
 
-### Important classes/functions ###
+### Compatibility notice
+
+In libpmemobj 1.12 we introduced a new transaction handler type: pmem::obj::flat_transaction.
+By defining LIBPMEMOBJ_CPP_USE_FLAT_TRANSACTION you can make pmem::obj::transaction to be
+an alias to pmem::obj::flat_transaction. In 1.12 we have also changed the default behavior
+of containers' transactional methods. Now, in case of any failure within such method,
+the outer transaction (if any) will not be immediately aborted. Instead, an exception
+will be thrown, which will lead to transaction abort only if it's not caught before the outer tx scope ends.
+To change the behavior to the old one, you can set LIBPMEMOBJ_CPP_FLAT_TX_USE_FAILURE_RETURN macro to 0.
+Be aware that the old behavior can lead to segfaults in some cases
+(see tx_nested_struct_example in this
+[example](https://github.com/pmem/libpmemobj-cpp/blob/master/examples/transaction/transaction.cpp)).
+
+### Important classes/functions
 
  * Transactional allocations - make_persistent.hpp
  * Transactional array allocations - make_persistent_array.hpp
@@ -82,7 +103,7 @@ bindings.
  * Persistent memory pool - [pool](@ref pmem::obj::pool)
  * Defrag class - [defrag](@ref pmem::obj::defrag)
 
-## Persistent containers ##
+## Persistent containers
 
 The C++ standard library containers collection is something that persistent
 memory programmers may want to use. Containers manage the lifetime of held
@@ -92,8 +113,10 @@ Template Library) containers has two main downsides:
 
 Implementation details:
  - STL containers do not use algorithms optimal from persistent memory programming point of view.
- - Persistent memory containers should have durability and consistency properties, while not every STL method guarantees strong exception safety.
- - Persistent memory containers should be designed with an awareness of fragmentation limitations.
+ - Persistent memory containers should have durability and consistency properties,
+    while not every STL method guarantees strong exception safety.
+ - Persistent memory containers should be designed with an awareness of
+    fragmentation limitations.
 
 Memory layout:
  - The STL does not guarantee that the container layout will remain unchanged in new library versions.
@@ -105,11 +128,14 @@ These methods guarantee atomicity, consistency and durability. Besides specific
 internal implementation details, libpmemobj-cpp persistent memory containers
 have the well-known STL-like interface and they work with STL algorithms.
 
-### Available containers ###
+### Available containers
 
  * array with STL-like interface - [pmem::obj::array](@ref pmem::obj::array)
  * string with STL-like interface - [pmem::obj::string](@ref pmem::obj::basic_string)
  * vector with STL-like interface - [pmem::obj::vector](@ref pmem::obj::vector)
- * segment_vector with std::vector-like interface (no STL counterpart) - [pmem::obj::segment_vector](@ref pmem::obj::segment_vector)
- * concurrent_hash_map (no STL counterpart) - [pmem::obj::concurrent_hash_map](@ref pmem::obj::concurrent_hash_map)
- * radix_tree (partially compatible with std::map) - [pmem::obj::experimental::radix_tree](@ref pmem::obj::experimental::radix_tree)
+ * segment_vector with std::vector-like interface (no STL counterpart) -
+    [pmem::obj::segment_vector](@ref pmem::obj::segment_vector)
+ * concurrent_hash_map (no STL counterpart) -
+    [pmem::obj::concurrent_hash_map](@ref pmem::obj::concurrent_hash_map)
+ * radix_tree (partially compatible with std::map) -
+    [pmem::obj::experimental::radix_tree](@ref pmem::obj::experimental::radix_tree)

--- a/include/libpmemobj++/container/concurrent_hash_map.hpp
+++ b/include/libpmemobj++/container/concurrent_hash_map.hpp
@@ -333,7 +333,7 @@ struct hash_map_node {
 
 /**
  * The class provides the way to access certain properties of segments
- * used by hash map
+ * used by hash map.
  */
 template <typename Bucket>
 class segment_traits {
@@ -1319,7 +1319,7 @@ public:
 
 	/**
 	 * Swap hash_map_base
-	 * @throws std::transaction_error in case of PMDK transaction failed
+	 * @throw std::transaction_error in case of PMDK transaction failed
 	 */
 	void
 	internal_swap(hash_map_base<Key, T, mutex_t, scoped_t> &table)
@@ -1575,7 +1575,7 @@ operator!=(const hash_map_iterator<Container, M> &i,
  * Persistent memory aware implementation of Intel TBB concurrent_hash_map.
  * The implementation is based on a concurrent hash table algorithm
  * (https://arxiv.org/ftp/arxiv/papers/1509/1509.02235.pdf) where elements
- * assigned to buckets based on a hash code are calculated from a key.
+ * are assigned to buckets based on a hash code calculated from a key.
  * In addition to concurrent find, insert, and erase operations, the algorithm
  * employs resizing and on-demand per-bucket rehashing. The hash table consists
  * of an array of buckets, and each bucket consists of a list of nodes and a
@@ -2273,7 +2273,7 @@ public:
 	 * Clear hash map content
 	 * Not thread safe.
 	 *
-	 * @throws pmem::transaction_error in case of PMDK transaction failure
+	 * @throw pmem::transaction_error in case of PMDK transaction failure
 	 */
 	void clear();
 
@@ -2800,7 +2800,7 @@ public:
 	 * Remove element with corresponding key
 	 *
 	 * @return true if element was deleted by this call
-	 * @throws pmem::transaction_free_error in case of PMDK unable to free
+	 * @throw pmem::transaction_free_error in case of PMDK unable to free
 	 * the memory
 	 * @throw pmem::transaction_scope_error if called inside transaction
 	 */
@@ -2889,7 +2889,7 @@ public:
 	 * this function without constructing an instance of Key
 	 *
 	 * @return true if element was deleted by this call
-	 * @throws pmem::transaction_free_error in case of PMDK unable to free
+	 * @throw pmem::transaction_free_error in case of PMDK unable to free
 	 * the memory
 	 * @throw pmem::transaction_scope_error if called inside transaction
 	 */

--- a/include/libpmemobj++/pool.hpp
+++ b/include/libpmemobj++/pool.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2016-2020, Intel Corporation */
+/* Copyright 2016-2021, Intel Corporation */
 
 /**
  * @file
@@ -451,7 +451,10 @@ protected:
  *
  * This class is the pmemobj pool handler. It provides basic primitives
  * for operations on pmemobj pools. The template parameter defines the
- * type of the root object within the pool. The typical usage example would be:
+ * type of the root object within the pool. This pool class inherits also
+ * some methods from the base class: pmem::obj::pool_base.
+ *
+ * The typical usage example would be:
  * @snippet pool/pool.cpp pool_example
  *
  * This API should not be mixed with C API. For example explicitly calling


### PR DESCRIPTION
Beside minor cleanups in doxygen readme and hashmap comments, a small sentence to inform about pool_base inherited members (not described in docs, due to doxygen issue, ref. #1010).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1011)
<!-- Reviewable:end -->
