### PR TITLE
cmake: replace, not add Ob flag in WIN32

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -19,23 +19,58 @@ function(prepend var prefix)
 	set(${var} "${listVar}" PARENT_SCOPE)
 endfunction()
 
-# Checks whether flag is supported by current C++ compiler and appends
-# it to the relevant cmake variable.
-# 1st argument is a flag
-# 2nd (optional) argument is a build type (debug, release)
-macro(add_flag flag)
+# Checks whether flag is supported by current C++ compiler
+macro(check_flag flag OUT_NAME)
 	string(REPLACE - _ flag2 ${flag})
 	string(REPLACE " " _ flag2 ${flag2})
 	string(REPLACE = "_" flag2 ${flag2})
 	set(check_name "CXX_HAS_${flag2}")
 
 	check_cxx_compiler_flag(${flag} ${check_name})
+	set(${OUT_NAME} "${check_name}")
+endmacro()
+
+# Checks flag and appends it to the relevant cmake variable, parameters:
+# 1st: a flag
+# 2nd: (optional) a build type (DEBUG, RELEASE, ...), by default appends to common variable
+macro(add_flag flag)
+	check_flag("${flag}" check_name)
 
 	if (${${check_name}})
 		if (${ARGC} EQUAL 1)
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
 		else()
-			set(CMAKE_CXX_FLAGS_${ARGV1} "${CMAKE_CXX_FLAGS_${ARGV1}} ${flag}")
+			string(TOUPPER "${ARGV1}" BUILD)
+			set(CMAKE_CXX_FLAGS_${BUILD} "${CMAKE_CXX_FLAGS_${BUILD}} ${flag}")
+		endif()
+	endif()
+endmacro()
+
+# Checks flag and tries to replace found regex with the flag. If regex wasn't found,
+# it adds it. In both cases, only if the flag is supported by compiler.
+# Useful in Windows builds, where doubled flag produces warning. Parameters:
+# 1st: a flag
+# 2nd: a regex to be replaced, by the flag - NOTE: be precise, partial match is undiserable!
+# 3rd: (optional) a build type (DEBUG, RELEASE, ...), by default replaces/adds in common variable
+macro(replace_or_add_flag flag regex)
+	check_flag("${flag}" check_name)
+
+	if (${${check_name}})
+		if (${ARGC} EQUAL 2)
+			string(REGEX MATCHALL "${regex}" MATCHES "${CMAKE_CXX_FLAGS}")
+			if(MATCHES)
+				string(REGEX REPLACE "${regex}" "${flag}" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+			else()
+				add_flag(${flag})
+			endif()
+		else()
+			string(TOUPPER "${ARGV2}" BUILD)
+			string(REGEX MATCHALL "${regex}" MATCHES "${CMAKE_CXX_FLAGS_${BUILD}}")
+			if(MATCHES)
+				string(REGEX REPLACE "${regex}" "${flag}" CMAKE_CXX_FLAGS_${BUILD} "${CMAKE_CXX_FLAGS_${BUILD}}")
+			else()
+				add_flag(${flag} ${BUILD})
+			endif()
 		endif()
 	endif()
 endmacro()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,7 +46,10 @@ if(MSVC_VERSION)
 
 	# omit function name ambiguity under MSVC++ compiler
 	if(MSVC_VERSION GREATER 1919)
-		add_flag(-Ob3)
+		# Each CXX_FLAGS_* variable has its own /Ob setting. By default CMake
+		# may set it up with some value, so we replace it (or add, if not found)
+		# in the current build to avoid warning D9025.
+		replace_or_add_flag("/Ob3" "/Ob[0-9]" ${CMAKE_BUILD_TYPE})
 	endif()
 else()
 	add_flag(-Wall)


### PR DESCRIPTION
without this change we got build warning (D9025).
With this change comes a small refactor of the 'add_flag' macro,
to allow easily add 'replace_flag' macro.

//
Log with the debug prints confirm that the flag was replaced (also, warnings disappeared):
https://github.com/lukaszstolarczuk/libpmemobj-cpp/runs/1838651067?check_suite_focus=true#step:8:87

Solution based on:
https://gitlab.kitware.com/cmake/cmake/-/issues/19084#lack-of-proper-solution

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1030)
<!-- Reviewable:end -->
