### PR TITLE
[readme] fix wrong argument for make

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ You will need the following packages for compilation:
 ```
 $ mkdir build
 $ cd build
-$ cmake ..
-$ make [-DCMAKE_INSTALL_PREFIX=<path_to_installation_dir>]
+$ cmake .. [-DCMAKE_INSTALL_PREFIX=<path_to_installation_dir>]
+$ make
 # make install
 ```
 


### PR DESCRIPTION
Arguments starting from '-D' are typically CMake options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1035)
<!-- Reviewable:end -->
