### PR TITLE
cmake: prioritize TBB_DIR to find TBB module

### DIFF
--- a/cmake/tbb.cmake
+++ b/cmake/tbb.cmake
@@ -1,24 +1,51 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2017-2020, Intel Corporation
+# Copyright 2017-2021, Intel Corporation
 
 message(STATUS "Checking for module 'tbb'")
 
-if(PKG_CONFIG_FOUND)
-	pkg_check_modules(TBB QUIET tbb)
-endif()
+# TBB was found without pkg-config:
+# print status message and set global variable with tbb libs.
+function(handle_tbb_found_no_pkgconf)
+	set(TBB_LIBRARIES ${TBB_IMPORTED_TARGETS} PARENT_SCOPE)
+	message(STATUS "  Found in dir '${TBB_DIR}' using CMake's find_package (ver: ${TBB_VERSION})")
+endfunction()
 
-# Now, if needed, try to find it without pkg-config..
-if(NOT TBB_FOUND)
-	# find_package without unsetting this var is not working correctly
+# Fail cmake build if TBB not found and TBB tests are enabled.
+function(fail_tbb_not_found)
+	message(FATAL_ERROR "TBB tests are enabled by cmake TESTS_TBB option, but Intel TBB library was not found.")
+endfunction()
+
+# CMake param TBB_DIR is priortized. This is the best to use
+# while developing/testing pmemkv with custom TBB installation.
+if(TBB_DIR)
+	message(STATUS "  CMake param TBB_DIR is set, look ONLY in there (${TBB_DIR})!")
+	find_package(TBB QUIET COMPONENTS tbb NO_DEFAULT_PATH)
+	if(TBB_FOUND)
+		handle_tbb_found_no_pkgconf()
+	else()
+		message(WARNING "TBB_DIR is set, but does not contain a path to TBB. "
+			"Either set this var to a dir with TBBConfig.cmake (or tbb-config.cmake), "
+			"or unset it and let CMake find TBB in the system (using e.g. pkg-config).")
+		if(TESTS_TBB)
+			fail_tbb_not_found()
+		endif()
+	endif()
+else()
+	if(PKG_CONFIG_FOUND)
+		pkg_check_modules(TBB QUIET tbb)
+		if(TBB_FOUND)
+			message(STATUS "  Found in dir '${TBB_LIBDIR}' using pkg-config (ver: ${TBB_VERSION})")
+			return()
+		endif()
+	endif()
+
+	# find_package (run after pkg-config) without unsetting this var is not working correctly
 	unset(TBB_FOUND CACHE)
 
 	find_package(TBB COMPONENTS tbb)
 	if(TBB_FOUND)
-		set(TBB_LIBRARIES ${TBB_IMPORTED_TARGETS})
-		message(STATUS "  Found in: ${TBB_DIR} using CMake's find_package (ver: ${TBB_VERSION})")
+		handle_tbb_found_no_pkgconf()
 	elseif(TESTS_TBB)
-		message(FATAL_ERROR "TBB tests are enabled by cmake TESTS_TBB option, but Intel TBB library was not found.")
+		fail_tbb_not_found()
 	endif()
-else()
-	message(STATUS "  Found in: ${TBB_LIBDIR} using pkg-config (ver: ${TBB_VERSION})")
 endif()


### PR DESCRIPTION
if TBB_DIR is set, disregard any way of finding TBB in the system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1039)
<!-- Reviewable:end -->
