### PR TITLE
docker: fix packages deps

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-32
+++ b/utils/docker/images/Dockerfile.fedora-32
@@ -85,7 +85,6 @@ RUN dnf update -y \
 	${EXAMPLES_DEPS} \
 	${DOC_DEPS} \
 	${TESTS_DEPS} \
-	${COVERITY_DEPS} \
 	${MISC_DEPS} \
  && dnf clean all
 

--- a/utils/docker/images/Dockerfile.fedora-32
+++ b/utils/docker/images/Dockerfile.fedora-32
@@ -42,6 +42,7 @@ ARG PMDK_DEPS="\
 	man \
 	ndctl-devel \
 	pandoc \
+	python3 \
 	rpm-build \
 	rpm-build-libs \
 	rpmdevtools \

--- a/utils/docker/images/Dockerfile.fedora-33
+++ b/utils/docker/images/Dockerfile.fedora-33
@@ -85,7 +85,6 @@ RUN dnf update -y \
 	${EXAMPLES_DEPS} \
 	${DOC_DEPS} \
 	${TESTS_DEPS} \
-	${COVERITY_DEPS} \
 	${MISC_DEPS} \
  && dnf clean all
 

--- a/utils/docker/images/Dockerfile.fedora-33
+++ b/utils/docker/images/Dockerfile.fedora-33
@@ -42,6 +42,7 @@ ARG PMDK_DEPS="\
 	man \
 	ndctl-devel \
 	pandoc \
+	python3 \
 	rpm-build \
 	rpm-build-libs \
 	rpmdevtools \

--- a/utils/docker/images/Dockerfile.fedora-rawhide
+++ b/utils/docker/images/Dockerfile.fedora-rawhide
@@ -35,11 +35,6 @@ ARG LIBPMEMOBJ_CPP_DEPS="\
 	libpmemobj-devel \
 	tbb-devel"
 
-# pmem's Valgrind (optional; valgrind-devel may be used instead)
-ARG VALGRIND_DEPS="\
-	autoconf \
-	automake"
-
 # Examples (optional)
 ARG EXAMPLES_DEPS="\
 	ncurses-devel \
@@ -50,11 +45,14 @@ ARG DOC_DEPS="\
 	doxygen"
 
 # Tests (optional)
+# XXX: Valgrind is installed from upstream package, because of:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1903527
 ARG TESTS_DEPS="\
 	gdb \
 	libpmem-devel \
 	libunwind-devel \
-	pmempool"
+	pmempool \
+	valgrind-devel"
 
 # Misc for our builds/CI (optional)
 ARG MISC_DEPS="\

--- a/utils/docker/images/Dockerfile.ubuntu-18.04
+++ b/utils/docker/images/Dockerfile.ubuntu-18.04
@@ -51,7 +51,8 @@ ARG PMDK_DEPS="\
 	debhelper \
 	devscripts \
 	gdb \
-	pandoc"
+	pandoc \
+	python3"
 
 # pmem's Valgrind (optional; valgrind-devel may be used instead)
 ARG VALGRIND_DEPS="\

--- a/utils/docker/images/Dockerfile.ubuntu-20.04
+++ b/utils/docker/images/Dockerfile.ubuntu-20.04
@@ -41,7 +41,8 @@ ARG PMDK_DEPS="\
 	gdb \
 	libdaxctl-dev \
 	libndctl-dev \
-	pandoc"
+	pandoc \
+	python3"
 
 # pmem's Valgrind (optional; valgrind-devel may be used instead)
 ARG VALGRIND_DEPS="\

--- a/utils/docker/images/Dockerfile.ubuntu-20.04
+++ b/utils/docker/images/Dockerfile.ubuntu-20.04
@@ -98,6 +98,7 @@ RUN apt-get update \
 	${DOC_DEPS} \
 	${TESTS_DEPS} \
 	${CODECOV_DEPS} \
+	${COVERITY_DEPS} \
 	${MISC_DEPS} \
  && rm -rf /var/lib/apt/lists/*
 

--- a/utils/docker/images/Dockerfile.ubuntu-20.10
+++ b/utils/docker/images/Dockerfile.ubuntu-20.10
@@ -41,7 +41,8 @@ ARG PMDK_DEPS="\
 	gdb \
 	libdaxctl-dev \
 	libndctl-dev \
-	pandoc"
+	pandoc \
+	python3"
 
 # pmem's Valgrind (optional; valgrind-devel may be used instead)
 ARG VALGRIND_DEPS="\

--- a/utils/docker/images/Dockerfile.ubuntu-devel
+++ b/utils/docker/images/Dockerfile.ubuntu-devel
@@ -40,7 +40,8 @@ ARG PMDK_DEPS="\
 	gdb \
 	libdaxctl-dev \
 	libndctl-dev \
-	pandoc"
+	pandoc \
+	python3"
 
 # pmem's Valgrind (optional; valgrind-devel may be used instead)
 ARG VALGRIND_DEPS="\


### PR DESCRIPTION
mainly it's required because I've misplaced installation of Coverity Deps - they should be on Ubuntu 20.04

BTW:
- I propose to quickly fix (for now) Fedora Rawhide image using valgrind package from upstream
- it's required by pmreorder to have python3, and it's probably by accident we have it already in the image

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1050)
<!-- Reviewable:end -->
