### PR TITLE
tests: add double-create test for pool

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -181,6 +181,7 @@ add_test_generic(NAME pool CASE 7 TRACERS none)
 if (NOT WIN32)
 	add_test_generic(NAME pool CASE 8 TRACERS none)
 endif()
+add_test_generic(NAME pool CASE 9 TRACERS none)
 
 if(WIN32)
 	build_test(pool_win pool/pool_win.cpp)

--- a/tests/pool/pool_9.cmake
+++ b/tests/pool/pool_9.cmake
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2018-2021, Intel Corporation
+
+include(${SRC_DIR}/../helpers.cmake)
+
+setup()
+
+# double create
+execute(${TEST_EXECUTABLE} c ${DIR}/testfile "test" 20 0600)
+check_file_exists(${DIR}/testfile)
+
+execute(${TEST_EXECUTABLE} c ${DIR}/testfile "test" 20 0600)
+
+finish()

--- a/tests/pool/pool_9_none.out.match
+++ b/tests/pool/pool_9_none.out.match
@@ -1,0 +1,2 @@
+$(nW)testfile: file size $(N) mode $(N)
+$(nW)testfile: pool::create: Failed creating pool: $(*)


### PR DESCRIPTION
it should fail with pool_invalid_argument, since it returns EEXIST.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1055)
<!-- Reviewable:end -->
