### PR TITLE
tests: move num_allocs to common

### DIFF
--- a/tests/common/unittest.hpp
+++ b/tests/common/unittest.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2018-2020, Intel Corporation */
+/* Copyright 2018-2021, Intel Corporation */
 
 #ifndef LIBPMEMOBJ_CPP_UNITTEST_HPP
 #define LIBPMEMOBJ_CPP_UNITTEST_HPP
@@ -18,6 +18,9 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <type_traits>
+
+#include <libpmemobj++/pool.hpp>
+#include <libpmemobj/iterator_base.h>
 
 #ifndef _WIN32
 #define os_stat_t struct stat
@@ -190,6 +193,20 @@ run_test(std::function<void()> test)
 	}
 
 	return 0;
+}
+
+static inline int
+num_allocs(pmem::obj::pool_base &pop)
+{
+	auto oid = pmemobj_first(pop.handle());
+	int num = 0;
+
+	while (!OID_IS_NULL(oid)) {
+		num++;
+		oid = pmemobj_next(oid);
+	}
+
+	return num;
 }
 
 #endif /* LIBPMEMOBJ_CPP_UNITTEST_HPP */

--- a/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb.cpp
+++ b/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * concurrent_map.cpp -- pmem::obj::concurrent_map test
@@ -20,8 +20,6 @@
 
 #include <libpmemobj++/container/string.hpp>
 #include <libpmemobj++/experimental/concurrent_map.hpp>
-
-#include <libpmemobj.h>
 
 #define LAYOUT "concurrent_map"
 
@@ -82,20 +80,6 @@ gdb_sync_exit()
 
 static int loop_sync_1 = 1;
 static int loop_sync_2 = 1;
-
-int
-num_allocs(nvobj::pool<root> &pop)
-{
-	auto oid = pmemobj_first(pop.handle());
-	int num = 0;
-
-	while (!OID_IS_NULL(oid)) {
-		num++;
-		oid = pmemobj_next(oid);
-	}
-
-	return num;
-}
 
 struct test_case {
 	virtual void

--- a/tests/external/libcxx/basic_string/string.cons/copy.pass.cpp
+++ b/tests/external/libcxx/basic_string/string.cons/copy.pass.cpp
@@ -130,7 +130,7 @@ run(pmem::obj::pool<root> &pop)
 	} catch (std::exception &e) {
 		UT_FATALexc(e);
 	}
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 void

--- a/tests/radix_tree/radix_basic.cpp
+++ b/tests/radix_tree/radix_basic.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 #include "radix.hpp"
 
@@ -118,7 +118,7 @@ test_iterators(nvobj::pool<root> &pop)
 		nvobj::delete_persistent<container_int>(r->radix_int);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 void
@@ -261,7 +261,7 @@ test_find(nvobj::pool<root> &pop)
 				r->radix_str);
 		});
 
-		UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+		UT_ASSERTeq(num_allocs(pop), 0);
 	}
 
 	{
@@ -297,7 +297,7 @@ test_find(nvobj::pool<root> &pop)
 				r->radix_str);
 		});
 
-		UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+		UT_ASSERTeq(num_allocs(pop), 0);
 	}
 
 	{
@@ -397,7 +397,7 @@ test_find(nvobj::pool<root> &pop)
 				r->radix_str);
 		});
 
-		UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+		UT_ASSERTeq(num_allocs(pop), 0);
 	}
 }
 
@@ -531,7 +531,7 @@ test_compression(nvobj::pool<root> &pop)
 		nvobj::delete_persistent<container_string>(r->radix_str);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 /* Tests some corner cases (not covered by libcxx erase tests). */
@@ -587,7 +587,7 @@ test_erase(nvobj::pool<root> &pop)
 		nvobj::delete_persistent<container_string>(r->radix_str);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 /* This test inserts elements in range [0:2:2 * numeric_limits<uint16_t>::max()]
@@ -647,7 +647,7 @@ test_binary_keys(nvobj::pool<root> &pop)
 
 	its = {};
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 
 	nvobj::transaction::run(pop, [&] {
 		r->radix_int_int = nvobj::make_persistent<container_int_int>();
@@ -687,7 +687,7 @@ test_binary_keys(nvobj::pool<root> &pop)
 		nvobj::delete_persistent<container_int_int>(r->radix_int_int);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 void
@@ -763,7 +763,7 @@ test_pre_post_fixes(nvobj::pool<root> &pop)
 		nvobj::delete_persistent<container_string>(r->radix_str);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 void
@@ -791,7 +791,7 @@ test_assign_inline_string(nvobj::pool<root> &pop)
 		nvobj::delete_persistent<container_string>(r->radix_str);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 void
@@ -844,7 +844,7 @@ test_inline_string_u8t_key(nvobj::pool<root> &pop)
 			r->radix_inline_s_u8t);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 void
@@ -932,7 +932,7 @@ test_remove_inserted(nvobj::pool<root> &pop)
 		nvobj::delete_persistent<container_string>(r->radix_str);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 static void

--- a/tests/radix_tree/radix_large.cpp
+++ b/tests/radix_tree/radix_large.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 #include "unittest.hpp"
 
@@ -59,7 +59,7 @@ test_long_string(nvobj::pool<root> &pop)
 		nvobj::delete_persistent<nvobj::string>(r->str);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 static void

--- a/tests/radix_tree/radix_tx_abort.cpp
+++ b/tests/radix_tree/radix_tx_abort.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 #include "radix.hpp"
 
@@ -43,7 +43,7 @@ test_emplace(nvobj::pool<root> &pop, nvobj::persistent_ptr<Container> &ptr)
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 template <typename Container, int ValueRepeats>
@@ -87,7 +87,7 @@ test_try_emplace(nvobj::pool<root> &pop, nvobj::persistent_ptr<Container> &ptr)
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 template <typename Container, int ValueRepeats>
@@ -152,7 +152,7 @@ test_insert_or_assign(nvobj::pool<root> &pop,
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 template <typename Container, int ValueRepeats>
@@ -199,7 +199,7 @@ test_insert(nvobj::pool<root> &pop, nvobj::persistent_ptr<Container> &ptr)
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 template <typename Container, int ValueRepeats>
@@ -266,7 +266,7 @@ test_assign(nvobj::pool<root> &pop, nvobj::persistent_ptr<Container> &ptr)
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 template <typename Container, int ValueRepeats>
@@ -334,7 +334,7 @@ test_assign_internal_leaf(nvobj::pool<root> &pop,
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 template <typename Container, int ValueRepeats>
@@ -377,7 +377,7 @@ test_assign_root(nvobj::pool<root> &pop, nvobj::persistent_ptr<Container> &ptr)
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 template <typename Container, int ValueRepeats>
@@ -422,7 +422,7 @@ test_erase(nvobj::pool<root> &pop, nvobj::persistent_ptr<Container> &ptr)
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 template <typename Container, int ValueRepeats>
@@ -463,7 +463,7 @@ test_erase_internal(nvobj::pool<root> &pop,
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 }
 

--- a/tests/string/string_modifiers.cpp
+++ b/tests/string/string_modifiers.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2019-2020, Intel Corporation */
+/* Copyright 2019-2021, Intel Corporation */
 
 #include "unittest.hpp"
 
@@ -429,7 +429,7 @@ check_tx_abort(pmem::obj::pool<struct root> &pop, const char *str,
 		nvobj::delete_persistent<S>(r->str);
 		nvobj::delete_persistent<S>(r->str2);
 	});
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 static void
@@ -462,7 +462,7 @@ test(int argc, char *argv[])
 		       "0123456789012345678901234567890123456789"
 		       "0123456789",
 		       true);
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 	pop.close();
 }
 


### PR DESCRIPTION
The reason for this change is that num_alloc method is quite useful and I plan to use it in defer_free tests for radix_tree.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1064)
<!-- Reviewable:end -->
