### PR TITLE
Implement defer free for radix_tree

### DIFF
--- a/include/libpmemobj++/detail/life.hpp
+++ b/include/libpmemobj++/detail/life.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2016-2020, Intel Corporation */
+/* Copyright 2016-2021, Intel Corporation */
 
 /**
  * @file
@@ -10,6 +10,7 @@
 #define LIBPMEMOBJ_CPP_DESTROYER_HPP
 
 #include <cstddef>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -969,6 +969,9 @@ if(TEST_RADIX_TREE)
 	build_test_ext(NAME radix_concurrent SRC_FILES radix_tree/radix_concurrent.cpp)
 	add_test_generic(NAME radix_concurrent TRACERS none memcheck pmemcheck drd helgrind)
 
+	build_test_ext(NAME radix_concurrent_overwrite SRC_FILES radix_tree/radix_concurrent_overwrite.cpp)
+	add_test_generic(NAME radix_concurrent_overwrite TRACERS none memcheck pmemcheck drd helgrind)
+
 	build_test_ext(NAME radix_ctor_exceptions_nopmem SRC_FILES map/map_ctor_exception_nopmem.cpp BUILD_OPTIONS -DLIBPMEMOBJ_CPP_TESTS_RADIX)
 	add_test_generic(NAME radix_ctor_exceptions_nopmem TRACERS none memcheck pmemcheck)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -975,6 +975,9 @@ if(TEST_RADIX_TREE)
 	build_test_ext(NAME radix_ctor_exceptions_notx SRC_FILES map/map_ctor_exception_notx.cpp BUILD_OPTIONS -DLIBPMEMOBJ_CPP_TESTS_RADIX)
 	add_test_generic(NAME radix_ctor_exceptions_notx TRACERS none memcheck)
 
+	build_test_ext(NAME radix_garbage_collection SRC_FILES radix_tree/radix_garbage_collection.cpp)
+	add_test_generic(NAME radix_garbage_collection TRACERS none memcheck)
+
 	build_test_ext(NAME radix_txabort SRC_FILES map/map_txabort.cpp BUILD_OPTIONS -DLIBPMEMOBJ_CPP_TESTS_RADIX)
 	add_test_generic(NAME radix_txabort TRACERS none memcheck pmemcheck)
 

--- a/tests/common/unittest.hpp
+++ b/tests/common/unittest.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2018-2020, Intel Corporation */
+/* Copyright 2018-2021, Intel Corporation */
 
 #ifndef LIBPMEMOBJ_CPP_UNITTEST_HPP
 #define LIBPMEMOBJ_CPP_UNITTEST_HPP
@@ -18,6 +18,9 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <type_traits>
+
+#include <libpmemobj++/pool.hpp>
+#include <libpmemobj/iterator_base.h>
 
 #ifndef _WIN32
 #define os_stat_t struct stat
@@ -190,6 +193,21 @@ run_test(std::function<void()> test)
 	}
 
 	return 0;
+}
+
+/* Returns number of objects allocated via pmemobj */
+static inline int
+num_allocs(pmem::obj::pool_base &pop)
+{
+	auto oid = pmemobj_first(pop.handle());
+	int num = 0;
+
+	while (!OID_IS_NULL(oid)) {
+		num++;
+		oid = pmemobj_next(oid);
+	}
+
+	return num;
 }
 
 #endif /* LIBPMEMOBJ_CPP_UNITTEST_HPP */

--- a/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb.cpp
+++ b/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * concurrent_map.cpp -- pmem::obj::concurrent_map test
@@ -20,8 +20,6 @@
 
 #include <libpmemobj++/container/string.hpp>
 #include <libpmemobj++/experimental/concurrent_map.hpp>
-
-#include <libpmemobj.h>
 
 #define LAYOUT "concurrent_map"
 
@@ -82,20 +80,6 @@ gdb_sync_exit()
 
 static int loop_sync_1 = 1;
 static int loop_sync_2 = 1;
-
-int
-num_allocs(nvobj::pool<root> &pop)
-{
-	auto oid = pmemobj_first(pop.handle());
-	int num = 0;
-
-	while (!OID_IS_NULL(oid)) {
-		num++;
-		oid = pmemobj_next(oid);
-	}
-
-	return num;
-}
 
 struct test_case {
 	virtual void

--- a/tests/external/libcxx/basic_string/string.cons/copy.pass.cpp
+++ b/tests/external/libcxx/basic_string/string.cons/copy.pass.cpp
@@ -130,7 +130,7 @@ run(pmem::obj::pool<root> &pop)
 	} catch (std::exception &e) {
 		UT_FATALexc(e);
 	}
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 void

--- a/tests/radix_tree/radix_basic.cpp
+++ b/tests/radix_tree/radix_basic.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 #include "radix.hpp"
 
@@ -118,7 +118,7 @@ test_iterators(nvobj::pool<root> &pop)
 		nvobj::delete_persistent<container_int>(r->radix_int);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 void
@@ -261,7 +261,7 @@ test_find(nvobj::pool<root> &pop)
 				r->radix_str);
 		});
 
-		UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+		UT_ASSERTeq(num_allocs(pop), 0);
 	}
 
 	{
@@ -297,7 +297,7 @@ test_find(nvobj::pool<root> &pop)
 				r->radix_str);
 		});
 
-		UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+		UT_ASSERTeq(num_allocs(pop), 0);
 	}
 
 	{
@@ -397,7 +397,7 @@ test_find(nvobj::pool<root> &pop)
 				r->radix_str);
 		});
 
-		UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+		UT_ASSERTeq(num_allocs(pop), 0);
 	}
 }
 
@@ -531,7 +531,7 @@ test_compression(nvobj::pool<root> &pop)
 		nvobj::delete_persistent<container_string>(r->radix_str);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 /* Tests some corner cases (not covered by libcxx erase tests). */
@@ -587,7 +587,7 @@ test_erase(nvobj::pool<root> &pop)
 		nvobj::delete_persistent<container_string>(r->radix_str);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 /* This test inserts elements in range [0:2:2 * numeric_limits<uint16_t>::max()]
@@ -647,7 +647,7 @@ test_binary_keys(nvobj::pool<root> &pop)
 
 	its = {};
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 
 	nvobj::transaction::run(pop, [&] {
 		r->radix_int_int = nvobj::make_persistent<container_int_int>();
@@ -687,7 +687,7 @@ test_binary_keys(nvobj::pool<root> &pop)
 		nvobj::delete_persistent<container_int_int>(r->radix_int_int);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 void
@@ -763,7 +763,7 @@ test_pre_post_fixes(nvobj::pool<root> &pop)
 		nvobj::delete_persistent<container_string>(r->radix_str);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 void
@@ -791,7 +791,7 @@ test_assign_inline_string(nvobj::pool<root> &pop)
 		nvobj::delete_persistent<container_string>(r->radix_str);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 void
@@ -844,7 +844,7 @@ test_inline_string_u8t_key(nvobj::pool<root> &pop)
 			r->radix_inline_s_u8t);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 void
@@ -932,7 +932,7 @@ test_remove_inserted(nvobj::pool<root> &pop)
 		nvobj::delete_persistent<container_string>(r->radix_str);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 static void

--- a/tests/radix_tree/radix_concurrent_overwrite.cpp
+++ b/tests/radix_tree/radix_concurrent_overwrite.cpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2021, Intel Corporation */
+
+#include "radix.hpp"
+
+/*
+ * radix_concurrent_overwrite -- test concurrent overwrite operations on the
+ * radix_tree.
+ */
+
+static size_t INITIAL_ELEMENTS = 256;
+
+static void
+test_overwrite_bigger_size_find(
+	nvobj::pool<root> &pop,
+	nvobj::persistent_ptr<container_int_string> &ptr)
+{
+	size_t threads = 16;
+	if (On_drd)
+		threads = 2;
+
+	init_container(pop, ptr, INITIAL_ELEMENTS);
+	ptr->runtime_initialize_mt();
+
+	/* Overwrites initial elements with string(i, 100) */
+	auto writer = [&]() {
+		for (size_t i = 0; i < INITIAL_ELEMENTS * 2; ++i) {
+			auto k = i % INITIAL_ELEMENTS;
+			ptr->insert_or_assign(
+				key<container_int_string>(k),
+				value<container_int_string>(i, 100));
+		}
+	};
+
+	auto readers = std::vector<std::function<void()>>{
+		[&]() {
+			for (size_t i = 0; i < INITIAL_ELEMENTS * 2; ++i) {
+				auto k = i % INITIAL_ELEMENTS;
+				auto res =
+					ptr->find(key<container_int_string>(k));
+				UT_ASSERT(res != ptr->end());
+				UT_ASSERT(res->value() ==
+						  value<container_int_string>(
+							  k) ||
+					  res->value() ==
+						  value<container_int_string>(
+							  k, 100) ||
+					  res->value() ==
+						  value<container_int_string>(
+							  k + INITIAL_ELEMENTS,
+							  100));
+			}
+		},
+	};
+
+	parallel_write_read(writer, readers, threads);
+
+	nvobj::transaction::run(pop, [&] {
+		nvobj::delete_persistent<container_int_string>(ptr);
+	});
+
+	UT_ASSERTeq(num_allocs(pop), 0);
+}
+
+static void
+test(int argc, char *argv[])
+{
+	if (argc != 2)
+		UT_FATAL("usage: %s file-name", argv[0]);
+
+	const char *path = argv[1];
+
+	nvobj::pool<root> pop;
+
+	try {
+		pop = nvobj::pool<struct root>::create(path, "radix_concurrent",
+						       10 * PMEMOBJ_MIN_POOL,
+						       S_IWUSR | S_IRUSR);
+	} catch (pmem::pool_error &pe) {
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
+	}
+
+	test_overwrite_bigger_size_find(pop, pop.root()->radix_int_str);
+
+	pop.close();
+}
+
+int
+main(int argc, char *argv[])
+{
+	return run_test([&] { test(argc, argv); });
+}

--- a/tests/radix_tree/radix_garbage_collection.cpp
+++ b/tests/radix_tree/radix_garbage_collection.cpp
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2021, Intel Corporation */
+
+/* Tests memory reclamation in concurrent mode (with runtime_initialize_mt
+ * called) for radix tree */
+
+#include "radix.hpp"
+
+static const unsigned N_ELEMS = 300;
+
+template <typename Container>
+std::vector<typename Container::iterator>
+init(nvobj::pool<root> &pop, nvobj::persistent_ptr<Container> &ptr)
+{
+	std::vector<typename Container::iterator> its;
+
+	nvobj::transaction::run(pop, [&] {
+		ptr = nvobj::make_persistent<Container>();
+		for (unsigned i = 0; i < N_ELEMS; i++) {
+			auto ret = ptr->try_emplace(key<Container>(i),
+						    value<Container>(i));
+			its.push_back(ret.first);
+
+			ptr->runtime_initialize_mt();
+		}
+
+		ptr->runtime_initialize_mt();
+	});
+
+	return its;
+}
+
+template <typename Container>
+void
+test_memory_reclamation_erase(nvobj::pool<root> &pop,
+			      nvobj::persistent_ptr<Container> &ptr)
+{
+	auto its = init(pop, ptr);
+
+	for (auto it = ptr->begin(); it != ptr->end();)
+		it = ptr->erase(it);
+
+	for (size_t i = 0; i < its.size(); i++) {
+		UT_ASSERT(its[i]->key() == key<Container>(i));
+		UT_ASSERT(its[i]->value() == value<Container>(i));
+	}
+
+	UT_ASSERT(num_allocs(pop) > 2);
+
+	ptr->garbage_collect();
+
+	/* radix_tree and garbage vector */
+	UT_ASSERTeq(num_allocs(pop), 2);
+
+	nvobj::transaction::run(
+		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
+
+	UT_ASSERTeq(num_allocs(pop), 0);
+}
+
+template <typename Container>
+void
+test_memory_reclamation_assign(nvobj::pool<root> &pop,
+			       nvobj::persistent_ptr<Container> &ptr)
+{
+	auto its = init(pop, ptr);
+
+	for (unsigned i = 0; i < its.size(); i++) {
+		auto ret = ptr->insert_or_assign(key<Container>(i),
+						 value<Container>(1 + i));
+		UT_ASSERT(!ret.second);
+	}
+
+	for (unsigned i = 0; i < its.size(); i++) {
+		UT_ASSERT(its[i]->key() == key<Container>(i));
+		UT_ASSERT(its[i]->value() == value<Container>(i));
+	}
+
+	auto alocs = num_allocs(pop);
+
+	ptr->garbage_collect();
+
+	UT_ASSERT(num_allocs(pop) < alocs);
+
+	for (unsigned i = 0; i < its.size(); i++) {
+		auto it = ptr->find(key<Container>(i));
+
+		UT_ASSERT(it->key() == key<Container>(i));
+		UT_ASSERT(it->value() == value<Container>(i + 1));
+	}
+
+	nvobj::transaction::run(
+		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
+
+	UT_ASSERTeq(num_allocs(pop), 0);
+}
+
+template <typename Container>
+void
+test_memory_reclamation_dtor(nvobj::pool<root> &pop,
+			     nvobj::persistent_ptr<Container> &ptr)
+{
+	init(pop, ptr);
+
+	for (auto it = ptr->begin(); it != ptr->end();)
+		it = ptr->erase(it);
+
+	nvobj::transaction::run(
+		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
+
+	UT_ASSERTeq(num_allocs(pop), 0);
+}
+
+static void
+test(int argc, char *argv[])
+{
+	if (argc != 2)
+		UT_FATAL("usage: %s file-name", argv[0]);
+
+	const char *path = argv[1];
+
+	nvobj::pool<root> pop;
+
+	try {
+		pop = nvobj::pool<struct root>::create(path, "radix_basic",
+						       10 * PMEMOBJ_MIN_POOL,
+						       S_IWUSR | S_IRUSR);
+	} catch (pmem::pool_error &pe) {
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
+	}
+
+	test_memory_reclamation_erase(pop, pop.root()->radix_str);
+	test_memory_reclamation_erase(pop, pop.root()->radix_int_int);
+
+	test_memory_reclamation_assign(pop, pop.root()->radix_str);
+	test_memory_reclamation_assign(pop, pop.root()->radix_int_int);
+
+	test_memory_reclamation_dtor(pop, pop.root()->radix_str);
+	test_memory_reclamation_dtor(pop, pop.root()->radix_int_int);
+
+	pop.close();
+}
+
+int
+main(int argc, char *argv[])
+{
+	return run_test([&] { test(argc, argv); });
+}

--- a/tests/radix_tree/radix_large.cpp
+++ b/tests/radix_tree/radix_large.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 #include "unittest.hpp"
 
@@ -59,7 +59,7 @@ test_long_string(nvobj::pool<root> &pop)
 		nvobj::delete_persistent<nvobj::string>(r->str);
 	});
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 static void

--- a/tests/radix_tree/radix_tx_abort.cpp
+++ b/tests/radix_tree/radix_tx_abort.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 #include "radix.hpp"
 
@@ -43,7 +43,7 @@ test_emplace(nvobj::pool<root> &pop, nvobj::persistent_ptr<Container> &ptr)
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 template <typename Container, int ValueRepeats>
@@ -87,7 +87,7 @@ test_try_emplace(nvobj::pool<root> &pop, nvobj::persistent_ptr<Container> &ptr)
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 template <typename Container, int ValueRepeats>
@@ -152,7 +152,7 @@ test_insert_or_assign(nvobj::pool<root> &pop,
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 template <typename Container, int ValueRepeats>
@@ -199,7 +199,7 @@ test_insert(nvobj::pool<root> &pop, nvobj::persistent_ptr<Container> &ptr)
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 template <typename Container, int ValueRepeats>
@@ -266,7 +266,7 @@ test_assign(nvobj::pool<root> &pop, nvobj::persistent_ptr<Container> &ptr)
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 template <typename Container, int ValueRepeats>
@@ -334,7 +334,7 @@ test_assign_internal_leaf(nvobj::pool<root> &pop,
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 template <typename Container, int ValueRepeats>
@@ -377,7 +377,7 @@ test_assign_root(nvobj::pool<root> &pop, nvobj::persistent_ptr<Container> &ptr)
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 template <typename Container, int ValueRepeats>
@@ -422,7 +422,7 @@ test_erase(nvobj::pool<root> &pop, nvobj::persistent_ptr<Container> &ptr)
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 template <typename Container, int ValueRepeats>
@@ -463,7 +463,7 @@ test_erase_internal(nvobj::pool<root> &pop,
 	nvobj::transaction::run(
 		pop, [&] { nvobj::delete_persistent<Container>(ptr); });
 
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 }
 

--- a/tests/string/string_modifiers.cpp
+++ b/tests/string/string_modifiers.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2019-2020, Intel Corporation */
+/* Copyright 2019-2021, Intel Corporation */
 
 #include "unittest.hpp"
 
@@ -429,7 +429,7 @@ check_tx_abort(pmem::obj::pool<struct root> &pop, const char *str,
 		nvobj::delete_persistent<S>(r->str);
 		nvobj::delete_persistent<S>(r->str2);
 	});
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 static void
@@ -462,7 +462,7 @@ test(int argc, char *argv[])
 		       "0123456789012345678901234567890123456789"
 		       "0123456789",
 		       true);
-	UT_ASSERT(OID_IS_NULL(pmemobj_first(pop.handle())));
+	UT_ASSERTeq(num_allocs(pop), 0);
 	pop.close();
 }
 


### PR DESCRIPTION
This is a first step to allow single writer, multi reader support. By not freeing the nodes immediately we can protect readers from reading freed memory.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1065)
<!-- Reviewable:end -->
