### PR TITLE
tests: fix sign-conversion warning in helpers_test

### DIFF
--- a/tests/common/helpers_test.cpp
+++ b/tests/common/helpers_test.cpp
@@ -17,7 +17,7 @@ static size_t const concurrency = 4;
 static void
 test()
 {
-	std::atomic<int> counter;
+	std::atomic<size_t> counter;
 	counter = 0;
 
 	parallel_xexec(concurrency,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1072)
<!-- Reviewable:end -->
