### PR TITLE
Update dockers

### DIFF
--- a/.github/workflows/other_OSes.yml
+++ b/.github/workflows/other_OSes.yml
@@ -32,12 +32,13 @@ jobs:
                  "OS=debian OS_VER=unstable",
                  "OS=debian OS_VER=latest",
                  "OS=fedora OS_VER=33",
-                 "TYPE=package OS=fedora OS_VER=33 PUSH_IMAGE=0",
+                 "OS=fedora OS_VER=34",
+                 "TYPE=package OS=fedora OS_VER=34 PUSH_IMAGE=0",
                  "OS=fedora OS_VER=rawhide TESTS_PMREORDER=0",
                  "OS=opensuse-leap OS_VER=latest",
                  "OS=opensuse-tumbleweed OS_VER=latest",
                  "OS=ubuntu OS_VER=18.04",
-                 "OS=ubuntu OS_VER=20.10",
+                 "OS=ubuntu OS_VER=21.04",
                  "OS=ubuntu OS_VER=devel PUSH_IMAGE=0",
                  "TYPE=package OS=ubuntu OS_VER=devel"]
     steps:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ You will need the following packages for compilation:
 - for Windows compilation:
 	- [**vcpkg**](https://github.com/microsoft/vcpkg#quick-start-windows)
 
+Required packages (or their names) for some OSes may differ. Some examples or scripts in this repository may require additional dependencies, but should not interrupt the build.
+
+See our **[Dockerfiles](utils/docker/images)** (used e.g. on our CI
+systems) to get an idea what packages are required to build
+the entire libpmemobj-cpp, with all tests and examples.
+
  ><sup>1</sup> C++11 is supported in GCC since version 4.8.1, but it does not support expanding variadic template variables in lambda expressions, which is required to build persistent containers and is possible with GCC >= 4.9.0. If you want to build libpmemobj-cpp without testing containers, use flag TEST_XXX=OFF (separate flag for each container).
 
  ><sup>2</sup> **radix_tree** is supported on Windows with MSBuild >=15 (Visual Studio at least 2017 is needed). Testing radix_tree can be disabled via CMake option (use -DTEST_RADIX_TREE=OFF).

--- a/utils/docker/images/Dockerfile.archlinux-base-latest
+++ b/utils/docker/images/Dockerfile.archlinux-base-latest
@@ -7,7 +7,7 @@
 #
 
 # Pull base image
-FROM registry.hub.docker.com/archlinux/base:latest
+FROM registry.hub.docker.com/library/archlinux:base
 MAINTAINER igor.chorazewicz@intel.com
 
 # Set required environment variables
@@ -31,7 +31,7 @@ ARG BASE_DEPS="\
 ARG LIBPMEMOBJ_CPP_DEPS="\
 	intel-tbb"
 
-# ndctl's dependencies (optional; ndctl-devel & daxctl-devel may be used instead)
+# ndctl's dependencies (optional; ndctl package may be used instead)
 ARG NDCTL_DEPS="\
 	automake \
 	asciidoc \
@@ -47,7 +47,7 @@ ARG PMDK_DEPS="\
 	python3 \
 	which"
 
-# pmem's Valgrind (optional; valgrind package may be used instead)
+# pmem's Valgrind dependencies (optional; valgrind package may be used instead)
 ARG VALGRIND_DEPS="\
 	autoconf \
 	automake"
@@ -75,7 +75,7 @@ ARG MISC_DEPS="\
 	sudo \
 	whois"
 
-# Update the Apt cache and install basic tools
+# Update the pacman cache and install basic tools
 RUN pacman -Syu --noconfirm \
  && pacman -S --noconfirm \
 	${BASE_DEPS} \

--- a/utils/docker/images/Dockerfile.centos-8
+++ b/utils/docker/images/Dockerfile.centos-8
@@ -48,7 +48,7 @@ ARG PMDK_DEPS="\
 	rpmdevtools \
 	which"
 
-# pmem's Valgrind (optional; valgrind-devel may be used instead)
+# pmem's Valgrind dependencies (optional; valgrind-devel package may be used instead)
 ARG VALGRIND_DEPS="\
 	autoconf \
 	automake"
@@ -62,6 +62,7 @@ ARG DOC_DEPS="\
 	doxygen"
 
 # Tests (optional)
+# NOTE: glibc is installed as a separate command; see below
 ARG TESTS_DEPS="\
 	gdb \
 	libunwind-devel"
@@ -89,6 +90,7 @@ RUN dnf update -y \
 	${DOC_DEPS} \
 	${TESTS_DEPS} \
 	${MISC_DEPS} \
+ && dnf debuginfo-install -y glibc \
  && dnf clean all
 
 # Install valgrind

--- a/utils/docker/images/Dockerfile.debian-latest
+++ b/utils/docker/images/Dockerfile.debian-latest
@@ -23,7 +23,7 @@ ARG SKIP_PMDK_BUILD
 # Base development packages
 ARG BASE_DEPS="\
 	cmake \
-	gcc \
+	build-essential \
 	git"
 
 # Dependencies for compiling libpmemobj-cpp project
@@ -31,7 +31,7 @@ ARG LIBPMEMOBJ_CPP_DEPS="\
 	libatomic1 \
 	libtbb-dev"
 
-# PMDK's dependencies (optional; libpmemobj-devel package may be used instead)
+# PMDK's dependencies (optional; libpmemobj-dev package may be used instead)
 ARG PMDK_DEPS="\
 	autoconf \
 	automake \
@@ -43,7 +43,7 @@ ARG PMDK_DEPS="\
 	pandoc \
 	python3"
 
-# pmem's Valgrind (optional; valgrind may be used instead)
+# pmem's Valgrind dependencies (optional; valgrind package may be used instead)
 ARG VALGRIND_DEPS="\
 	autoconf \
 	automake"
@@ -61,6 +61,7 @@ ARG DOC_DEPS="\
 # Tests (optional)
 ARG TESTS_DEPS="\
 	gdb \
+	libc6-dbg \
 	libunwind-dev"
 
 # Misc for our builds/CI (optional)
@@ -73,9 +74,9 @@ ARG MISC_DEPS="\
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# Update the Apt cache and install basic tools
+# Update the apt cache and install basic tools
 RUN apt-get update \
- && apt-get install -y software-properties-common \
+ && apt-get install -y --no-install-recommends \
 	${BASE_DEPS} \
 	${LIBPMEMOBJ_CPP_DEPS} \
 	${PMDK_DEPS} \

--- a/utils/docker/images/Dockerfile.debian-testing
+++ b/utils/docker/images/Dockerfile.debian-testing
@@ -23,7 +23,7 @@ ARG SKIP_PMDK_BUILD
 # Base development packages
 ARG BASE_DEPS="\
 	cmake \
-	gcc \
+	build-essential \
 	git"
 
 # Dependencies for compiling libpmemobj-cpp project
@@ -31,7 +31,7 @@ ARG LIBPMEMOBJ_CPP_DEPS="\
 	libatomic1 \
 	libtbb-dev"
 
-# PMDK's dependencies (optional; libpmemobj package may be used instead)
+# PMDK's dependencies (optional; libpmemobj-dev package may be used instead)
 ARG PMDK_DEPS="\
 	autoconf \
 	automake \
@@ -43,7 +43,7 @@ ARG PMDK_DEPS="\
 	pandoc \
 	python3"
 
-# pmem's Valgrind (optional; valgrind-devel may be used instead)
+# pmem's Valgrind dependencies (optional; valgrind package may be used instead)
 ARG VALGRIND_DEPS="\
 	autoconf \
 	automake"
@@ -61,6 +61,7 @@ ARG DOC_DEPS="\
 # Tests (optional)
 ARG TESTS_DEPS="\
 	gdb \
+	libc6-dbg \
 	libunwind-dev"
 
 # Misc for our builds/CI (optional)
@@ -73,9 +74,9 @@ ARG MISC_DEPS="\
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# Update the Apt cache and install basic tools
+# Update the apt cache and install basic tools
 RUN apt-get update \
- && apt-get install -y software-properties-common \
+ && apt-get install -y --no-install-recommends \
 	${BASE_DEPS} \
 	${LIBPMEMOBJ_CPP_DEPS} \
 	${PMDK_DEPS} \

--- a/utils/docker/images/Dockerfile.debian-unstable
+++ b/utils/docker/images/Dockerfile.debian-unstable
@@ -23,7 +23,7 @@ ARG SKIP_PMDK_BUILD
 # Base development packages
 ARG BASE_DEPS="\
 	cmake \
-	gcc \
+	build-essential \
 	git"
 
 # Dependencies for compiling libpmemobj-cpp project
@@ -31,7 +31,7 @@ ARG LIBPMEMOBJ_CPP_DEPS="\
 	libatomic1 \
 	libtbb-dev"
 
-# PMDK's dependencies (optional; libpmemobj package may be used instead)
+# PMDK's dependencies (optional; libpmemobj-dev package may be used instead)
 ARG PMDK_DEPS="\
 	autoconf \
 	automake \
@@ -43,7 +43,7 @@ ARG PMDK_DEPS="\
 	pandoc \
 	python3"
 
-# pmem's Valgrind (optional; valgrind-devel may be used instead)
+# pmem's Valgrind dependencies (optional; valgrind package may be used instead)
 ARG VALGRIND_DEPS="\
 	autoconf \
 	automake"
@@ -61,6 +61,7 @@ ARG DOC_DEPS="\
 # Tests (optional)
 ARG TESTS_DEPS="\
 	gdb \
+	libc6-dbg \
 	libunwind-dev"
 
 # Misc for our builds/CI (optional)
@@ -73,9 +74,9 @@ ARG MISC_DEPS="\
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# Update the Apt cache and install basic tools
+# Update the apt cache and install basic tools
 RUN apt-get update \
- && apt-get install -y software-properties-common \
+ && apt-get install -y --no-install-recommends \
 	${BASE_DEPS} \
 	${LIBPMEMOBJ_CPP_DEPS} \
 	${PMDK_DEPS} \
@@ -84,7 +85,7 @@ RUN apt-get update \
 	${DOC_DEPS} \
 	${TESTS_DEPS} \
 	${MISC_DEPS} \
- && rm -rf /var/lib/apt/lists/*
+&& rm -rf /var/lib/apt/lists/*
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh

--- a/utils/docker/images/Dockerfile.fedora-32
+++ b/utils/docker/images/Dockerfile.fedora-32
@@ -48,7 +48,7 @@ ARG PMDK_DEPS="\
 	rpmdevtools \
 	which"
 
-# pmem's Valgrind (optional; valgrind-devel may be used instead)
+# pmem's Valgrind dependencies (optional; valgrind-devel package may be used instead)
 ARG VALGRIND_DEPS="\
 	autoconf \
 	automake"
@@ -63,6 +63,7 @@ ARG DOC_DEPS="\
 	doxygen"
 
 # Tests (optional)
+# NOTE: glibc is installed as a separate command; see below
 ARG TESTS_DEPS="\
 	gdb \
 	libunwind-devel"
@@ -86,6 +87,7 @@ RUN dnf update -y \
 	${DOC_DEPS} \
 	${TESTS_DEPS} \
 	${MISC_DEPS} \
+ && dnf debuginfo-install -y glibc \
  && dnf clean all
 
 # Install valgrind

--- a/utils/docker/images/Dockerfile.fedora-33
+++ b/utils/docker/images/Dockerfile.fedora-33
@@ -48,7 +48,7 @@ ARG PMDK_DEPS="\
 	rpmdevtools \
 	which"
 
-# pmem's Valgrind (optional; valgrind-devel may be used instead)
+# pmem's Valgrind dependencies (optional; valgrind-devel package may be used instead)
 ARG VALGRIND_DEPS="\
 	autoconf \
 	automake"
@@ -63,6 +63,7 @@ ARG DOC_DEPS="\
 	doxygen"
 
 # Tests (optional)
+# NOTE: glibc is installed as a separate command; see below
 ARG TESTS_DEPS="\
 	gdb \
 	libunwind-devel"
@@ -85,6 +86,7 @@ RUN dnf update -y \
 	${DOC_DEPS} \
 	${TESTS_DEPS} \
 	${MISC_DEPS} \
+ && dnf debuginfo-install -y glibc \
  && dnf clean all
 
 # Install valgrind

--- a/utils/docker/images/Dockerfile.fedora-34
+++ b/utils/docker/images/Dockerfile.fedora-34
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2016-2021, Intel Corporation
+
+#
+# Dockerfile - a 'recipe' for Docker to build an image of fedora-based
+#              environment prepared for running libpmemobj-cpp tests.
+#
+
+# Pull base image
+FROM registry.fedoraproject.org/fedora:34
+MAINTAINER igor.chorazewicz@intel.com
+
+# Set required environment variables
+ENV OS fedora
+ENV OS_VER 34
+ENV PACKAGE_MANAGER rpm
+ENV NOTTY 1
+
+# Additional parameters to build docker without building components
+ARG SKIP_VALGRIND_BUILD
+ARG SKIP_PMDK_BUILD
+
+# Base development packages
+ARG BASE_DEPS="\
+	cmake \
+	gcc \
+	gcc-c++ \
+	git \
+	make"
+
+# Dependencies for compiling libpmemobj-cpp project
+ARG LIBPMEMOBJ_CPP_DEPS="\
+	libatomic \
+	tbb-devel"
+
+# PMDK's dependencies (optional; libpmemobj-devel package may be used instead)
+ARG PMDK_DEPS="\
+	autoconf \
+	automake \
+	daxctl-devel \
+	gdb \
+	man \
+	ndctl-devel \
+	pandoc \
+	python3 \
+	rpm-build \
+	rpm-build-libs \
+	rpmdevtools \
+	which"
+
+# pmem's Valgrind (optional; valgrind-devel may be used instead)
+ARG VALGRIND_DEPS="\
+	autoconf \
+	automake"
+
+# Examples (optional)
+ARG EXAMPLES_DEPS="\
+	ncurses-devel \
+	SFML-devel"
+
+# Documentation (optional)
+ARG DOC_DEPS="\
+	doxygen"
+
+# Tests (optional)
+# NOTE: glibc is installed as a separate command; see below
+ARG TESTS_DEPS="\
+	gdb \
+	libunwind-devel"
+
+# Misc for our builds/CI (optional)
+ARG MISC_DEPS="\
+	clang \
+	perl-Text-Diff \
+	pkgconf \
+	sudo"
+
+# Update packages and install basic tools
+RUN dnf update -y \
+ && dnf install -y \
+	${BASE_DEPS} \
+	${LIBPMEMOBJ_CPP_DEPS} \
+	${PMDK_DEPS} \
+	${VALGRIND_DEPS} \
+	${EXAMPLES_DEPS} \
+	${DOC_DEPS} \
+	${TESTS_DEPS} \
+	${MISC_DEPS} \
+ && dnf debuginfo-install -y glibc \
+ && dnf clean all
+
+# Install valgrind
+COPY install-valgrind.sh install-valgrind.sh
+RUN ./install-valgrind.sh
+
+# Install pmdk
+COPY install-pmdk.sh install-pmdk.sh
+RUN ./install-pmdk.sh rpm
+
+# Add user
+ENV USER user
+ENV USERPASS pass
+RUN useradd -m $USER \
+ && echo "$USER:$USERPASS" | chpasswd \
+ && gpasswd wheel -a $USER
+USER $USER

--- a/utils/docker/images/Dockerfile.fedora-rawhide
+++ b/utils/docker/images/Dockerfile.fedora-rawhide
@@ -4,11 +4,11 @@
 #
 # Dockerfile - a 'recipe' for Docker to build an image of fedora-based
 #              environment prepared for running libpmemobj-cpp tests.
-#              PMDK (libpmem & libpmemobj) are installed from dnf repo.
+#              PMDK (libpmem & libpmemobj) and Valgrind are installed from dnf repo.
 #
 
 # Pull base image
-FROM fedora:rawhide
+FROM registry.fedoraproject.org/fedora:rawhide
 MAINTAINER igor.chorazewicz@intel.com
 
 # Set required environment variables
@@ -41,6 +41,7 @@ ARG DOC_DEPS="\
 	doxygen"
 
 # Tests (optional)
+# NOTE: glibc is installed as a separate command; see below
 ARG TESTS_DEPS="\
 	gdb \
 	libpmem-devel \
@@ -64,6 +65,7 @@ RUN dnf update -y \
 	${DOC_DEPS} \
 	${TESTS_DEPS} \
 	${MISC_DEPS} \
+ && dnf debuginfo-install -y glibc \
  && dnf clean all
 
 # Add user

--- a/utils/docker/images/Dockerfile.opensuse-leap-latest
+++ b/utils/docker/images/Dockerfile.opensuse-leap-latest
@@ -46,7 +46,7 @@ ARG PMDK_DEPS="\
 	rpmdevtools \
 	which"
 
-# pmem's Valgrind (optional; valgrind package may be used instead)
+# pmem's Valgrind dependencies (optional; valgrind-devel package may be used instead)
 ARG VALGRIND_DEPS="\
 	autoconf \
 	automake"
@@ -62,6 +62,7 @@ ARG DOC_DEPS="\
 # Tests (optional)
 ARG TESTS_DEPS="\
 	gdb \
+	glibc-debuginfo \
 	libunwind-devel"
 
 # Misc for our builds/CI (optional)
@@ -72,8 +73,10 @@ ARG MISC_DEPS="\
 	sudo"
 
 # Update the OS, packages and install basic tools
+# using additional repos for glibc debuginfo
 RUN zypper dup -y \
  && zypper update -y \
+ && zypper mr -e repo-debug \
  && zypper install -y \
 	${BASE_DEPS} \
 	${LIBPMEMOBJ_CPP_DEPS} \

--- a/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
+++ b/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
@@ -46,7 +46,7 @@ ARG PMDK_DEPS="\
 	rpmdevtools \
 	which"
 
-# pmem's Valgrind (optional; valgrind package may be used instead)
+# pmem's Valgrind dependencies (optional; valgrind-devel package may be used instead)
 ARG VALGRIND_DEPS="\
 	autoconf \
 	automake"
@@ -62,6 +62,7 @@ ARG DOC_DEPS="\
 # Tests (optional)
 ARG TESTS_DEPS="\
 	gdb \
+	glibc-debuginfo \
 	libunwind-devel"
 
 # Misc for our builds/CI (optional)
@@ -72,8 +73,10 @@ ARG MISC_DEPS="\
 	sudo"
 
 # Update the OS, packages and install basic tools
+# using additional repo for glibc debuginfo
 RUN zypper dup -y \
  && zypper update -y \
+ && zypper mr -e repo-debug \
  && zypper install -y \
 	${BASE_DEPS} \
 	${LIBPMEMOBJ_CPP_DEPS} \

--- a/utils/docker/images/Dockerfile.ubuntu-18.04
+++ b/utils/docker/images/Dockerfile.ubuntu-18.04
@@ -35,6 +35,7 @@ ARG LIBPMEMOBJ_CPP_DEPS="\
 ARG NDCTL_DEPS="\
 	automake \
 	bash-completion \
+	ca-certificates \
 	libkeyutils-dev \
 	libkmod-dev \
 	libjson-c-dev \
@@ -53,7 +54,7 @@ ARG PMDK_DEPS="\
 	pandoc \
 	python3"
 
-# pmem's Valgrind (optional; valgrind package may be used instead)
+# pmem's Valgrind dependencies (optional; valgrind package may be used instead)
 ARG VALGRIND_DEPS="\
 	autoconf \
 	automake"
@@ -71,6 +72,7 @@ ARG DOC_DEPS="\
 # Tests (optional)
 ARG TESTS_DEPS="\
 	gdb \
+	libc6-dbg \
 	libunwind-dev"
 
 # Misc for our builds/CI (optional)
@@ -86,7 +88,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Update the apt cache and install basic tools
 RUN apt-get update \
- && apt-get install -y software-properties-common \
+ && apt-get install -y --no-install-recommends \
 	${BASE_DEPS} \
 	${LIBPMEMOBJ_CPP_DEPS} \
 	${NDCTL_DEPS} \

--- a/utils/docker/images/Dockerfile.ubuntu-20.04
+++ b/utils/docker/images/Dockerfile.ubuntu-20.04
@@ -44,7 +44,7 @@ ARG PMDK_DEPS="\
 	pandoc \
 	python3"
 
-# pmem's Valgrind (optional; valgrind package may be used instead)
+# pmem's Valgrind dependencies (optional; valgrind package may be used instead)
 ARG VALGRIND_DEPS="\
 	autoconf \
 	automake"
@@ -62,6 +62,7 @@ ARG DOC_DEPS="\
 # Tests (optional)
 ARG TESTS_DEPS="\
 	gdb \
+	libc6-dbg \
 	libunwind-dev"
 
 # Codecov - coverage tool (optional)
@@ -88,7 +89,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Update the apt cache and install basic tools
 RUN apt-get update \
- && apt-get install -y software-properties-common \
+ && apt-get install -y --no-install-recommends \
 	${BASE_DEPS} \
 	${LIBPMEMOBJ_CPP_DEPS} \
 	${PMDK_DEPS} \

--- a/utils/docker/images/Dockerfile.ubuntu-20.10
+++ b/utils/docker/images/Dockerfile.ubuntu-20.10
@@ -43,7 +43,7 @@ ARG PMDK_DEPS="\
 	pandoc \
 	python3"
 
-# pmem's Valgrind (optional; valgrind package may be used instead)
+# pmem's Valgrind dependencies (optional; valgrind package may be used instead)
 ARG VALGRIND_DEPS="\
 	autoconf \
 	automake"
@@ -61,6 +61,7 @@ ARG DOC_DEPS="\
 # Tests (optional)
 ARG TESTS_DEPS="\
 	gdb \
+	libc6-dbg \
 	libunwind-dev"
 
 # Misc for our builds/CI (optional)
@@ -76,7 +77,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Update the apt cache and install basic tools
 RUN apt-get update \
- && apt-get install -y software-properties-common \
+ && apt-get install -y --no-install-recommends \
 	${BASE_DEPS} \
 	${LIBPMEMOBJ_CPP_DEPS} \
 	${PMDK_DEPS} \

--- a/utils/docker/images/Dockerfile.ubuntu-21.04
+++ b/utils/docker/images/Dockerfile.ubuntu-21.04
@@ -7,12 +7,12 @@
 #
 
 # Pull base image
-FROM registry.hub.docker.com/library/ubuntu:20.10
+FROM registry.hub.docker.com/library/ubuntu:21.04
 MAINTAINER igor.chorazewicz@intel.com
 
 # Set required environment variables
 ENV OS ubuntu
-ENV OS_VER 20.10
+ENV OS_VER 21.04
 ENV PACKAGE_MANAGER deb
 ENV NOTTY 1
 

--- a/utils/docker/images/Dockerfile.ubuntu-devel
+++ b/utils/docker/images/Dockerfile.ubuntu-devel
@@ -43,7 +43,7 @@ ARG PMDK_DEPS="\
 	pandoc \
 	python3"
 
-# pmem's Valgrind (optional; valgrind package may be used instead)
+# pmem's Valgrind dependencies (optional; valgrind package may be used instead)
 ARG VALGRIND_DEPS="\
 	autoconf \
 	automake"
@@ -61,6 +61,7 @@ ARG DOC_DEPS="\
 # Tests (optional)
 ARG TESTS_DEPS="\
 	gdb \
+	libc6-dbg \
 	libunwind-dev"
 
 # Misc for our builds/CI (optional)
@@ -76,7 +77,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Update the apt cache and install basic tools
 RUN apt-get update \
- && apt-get install -y software-properties-common \
+ && apt-get install -y --no-install-recommends \
 	${BASE_DEPS} \
 	${LIBPMEMOBJ_CPP_DEPS} \
 	${PMDK_DEPS} \


### PR DESCRIPTION
- fix Arch Linux build,
- add new Fedora and replace latest Ubuntu with a new release,
- add a link to docker images dir in top-level README for references.

// all updated docker images build properly (except for Ubuntu 21.04/devel because of [PMDK issue](https://github.com/pmem/pmdk/issues/5197)):
https://github.com/pmem/libpmemobj-cpp/actions/runs/856144394

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1073)
<!-- Reviewable:end -->
