### PR TITLE
vector: Fix undefined behaviour on realloc

### DIFF
--- a/include/libpmemobj++/container/vector.hpp
+++ b/include/libpmemobj++/container/vector.hpp
@@ -2349,7 +2349,8 @@ vector<T>::internal_insert(size_type idx, InputIt first, InputIt last)
  * Private helper function. Must be called during transaction. Allocates new
  * memory for capacity_new number of elements and copies or moves old elements
  * to new memory area. If the current size is greater than capacity_new, the
- * container is reduced to its first capacity_new elements.
+ * container is reduced to its first capacity_new elements. If was never
+ * allocated behaves as an alloc call.
  *
  * param[in] capacity_new new capacity.
  *
@@ -2367,6 +2368,13 @@ void
 vector<T>::realloc(size_type capacity_new)
 {
 	assert(pmemobj_tx_stage() == TX_STAGE_WORK);
+
+	/*
+	 * If _data == nullptr this object has never allocated any memory
+	 * so we need to behave as alloc instead.
+	 */
+	if (_data == nullptr)
+		return alloc(capacity_new);
 
 	/*
 	 * XXX: future optimization: we don't have to snapshot data


### PR DESCRIPTION
On tests listed bellow the reserve method is being called before any
allocation on the object therefore realloc being called without
any previous allocation. Inside realloc _data is being used with the
operator '[]', as it is nullptr at that moment it's an undefined
behaviour.

This patch simply calls alloc instead of realloc if _data is nullptr.

This tests fails on PowerPC with Segmentation Fault because of this
issue:
segment_vector_array_expsize_assign_exceptions_oom_0_none
segment_vector_array_expsize_assign_exceptions_oom_0_memcheck
segment_vector_array_expsize_capacity_exceptions_oom_0_none
segment_vector_array_expsize_capacity_exceptions_oom_0_memcheck
segment_vector_array_expsize_modifiers_exceptions_oom_0_none
segment_vector_array_expsize_modifiers_exceptions_oom_0_memcheck
segment_vector_vector_expsize_assign_exceptions_oom_0_none
segment_vector_vector_expsize_assign_exceptions_oom_0_memcheck
segment_vector_vector_expsize_capacity_exceptions_oom_0_none
segment_vector_vector_expsize_capacity_exceptions_oom_0_memcheck
segment_vector_vector_expsize_modifiers_exceptions_oom_0_none
segment_vector_vector_expsize_modifiers_exceptions_oom_0_memcheck
segment_vector_vector_fixedsize_assign_exceptions_oom_0_none
segment_vector_vector_fixedsize_assign_exceptions_oom_0_memcheck

Signed-off-by: Lucas A. M. Magalhães <lamm@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1095)
<!-- Reviewable:end -->
