### PR TITLE
Fix Clang detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,14 +154,6 @@ elseif(NOT VALGRIND_FOUND)
 	message(WARNING "Valgrind not found. Valgrind tests will not be performed.")
 endif()
 
-# Find Clang
-find_program(CLANG NAMES clang)
-if(CLANG)
-	message(STATUS "Found clang: ${CLANG} (version: ${CLANG_VERSION})")
-else()
-	message(STATUS "clang not found")
-endif()
-
 if(BUILD_TESTS OR BUILD_EXAMPLES OR BUILD_BENCHMARKS)
 	# Find libpmem and libpmemobj (PMDK libraries)
 	if(PKG_CONFIG_FOUND)
@@ -174,10 +166,9 @@ if(BUILD_TESTS OR BUILD_EXAMPLES OR BUILD_BENCHMARKS)
 
 	# Some tests and examples require clang >= 8.0, because of the bug
 	# (https://bugs.llvm.org/show_bug.cgi?id=28280), which is fixed in clang v8.0.
-	set(CLANG_REQUIRED_BY_DESTRUCTOR_REFERENCE_BUG "8.0")
-	if(CLANG)
-		get_program_version_major_minor(${CLANG} CLANG_VERSION)
-		if(CLANG_VERSION VERSION_LESS CLANG_REQUIRED_BY_DESTRUCTOR_REFERENCE_BUG)
+
+	if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang" AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+		if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.0")
 			set(CLANG_DESTRUCTOR_REFERENCE_BUG_PRESENT 1)
 		endif()
 	endif()

--- a/tests/ctest_helpers.cmake
+++ b/tests/ctest_helpers.cmake
@@ -139,7 +139,7 @@ endfunction()
 # Function to build test with atomic
 function(build_test_atomic name)
 	build_test(${name} ${ARGN})
-	if(CLANG)
+	if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang" AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 		target_link_libraries(${name} atomic)
 	endif()
 endfunction()


### PR DESCRIPTION
- use CMAKE_CXX_COMPILER_VERSION/CMAKE_CXX_COMPILER_ID for
  setting compiler conditions
- fixes #1090

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1102)
<!-- Reviewable:end -->
