### PR TITLE
radix_tree: fix key comparison in internal_bound

### DIFF
--- a/include/libpmemobj++/experimental/radix_tree.hpp
+++ b/include/libpmemobj++/experimental/radix_tree.hpp
@@ -2237,7 +2237,8 @@ radix_tree<Key, Value, BytesView>::internal_bound(const K &k) const
 			 * The left siblings of *slot are all less than the
 			 * looked-for key (this is the case fo AXXB from the
 			 * example above). */
-			if (key[diff] < leaf_key[diff]) {
+			if (static_cast<unsigned char>(key[diff]) <
+			    static_cast<unsigned char>(leaf_key[diff])) {
 				auto target_leaf =
 					find_leaf<node::direction::Forward>(n);
 
@@ -2248,7 +2249,9 @@ radix_tree<Key, Value, BytesView>::internal_bound(const K &k) const
 			} else if (slot == &root) {
 				result = const_iterator(nullptr, this);
 			} else {
-				assert(key[diff] > leaf_key[diff]);
+				assert(static_cast<unsigned char>(key[diff]) >
+				       static_cast<unsigned char>(
+					       leaf_key[diff]));
 
 				/* Since next byte in key is greater
 				 * than in leaf_key, the target node

--- a/tests/radix_tree/radix_basic.cpp
+++ b/tests/radix_tree/radix_basic.cpp
@@ -301,8 +301,6 @@ test_find(nvobj::pool<root> &pop)
 	}
 
 	{
-		auto r = pop.root();
-
 		nvobj::transaction::run(pop, [&] {
 			r->radix_str =
 				nvobj::make_persistent<container_string>();
@@ -391,6 +389,44 @@ test_find(nvobj::pool<root> &pop)
 		ub = r->radix_str->upper_bound(last_slot);
 
 		UT_ASSERTeq(std::distance(lb, ub), 8);
+
+		nvobj::transaction::run(pop, [&] {
+			nvobj::delete_persistent<container_string>(
+				r->radix_str);
+		});
+
+		UT_ASSERTeq(num_allocs(pop), 0);
+	}
+
+	{
+		nvobj::transaction::run(pop, [&] {
+			r->radix_str =
+				nvobj::make_persistent<container_string>();
+		});
+
+		r->radix_str->try_emplace(std::string(1, char(1)), "");
+
+		auto ub = r->radix_str->upper_bound(std::string(1, char(-1)));
+		UT_ASSERT(ub == r->radix_str->end());
+
+		nvobj::transaction::run(pop, [&] {
+			nvobj::delete_persistent<container_string>(
+				r->radix_str);
+		});
+
+		UT_ASSERTeq(num_allocs(pop), 0);
+	}
+
+	{
+		nvobj::transaction::run(pop, [&] {
+			r->radix_str =
+				nvobj::make_persistent<container_string>();
+		});
+
+		r->radix_str->try_emplace(std::string(1, char(-1)), "");
+
+		auto ub = r->radix_str->upper_bound(std::string(1, char(1)));
+		UT_ASSERT(ub == r->radix_str->begin());
 
 		nvobj::transaction::run(pop, [&] {
 			nvobj::delete_persistent<container_string>(


### PR DESCRIPTION
Key's bytes should be compared as unsigned chars. Otherwsie
thse comparison will yield incorrect result for values < 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1103)
<!-- Reviewable:end -->
