### PR TITLE
mpsc_queue: allow interrupting try_consume_batch

### DIFF
--- a/include/libpmemobj++/detail/ringbuf.hpp
+++ b/include/libpmemobj++/detail/ringbuf.hpp
@@ -106,6 +106,9 @@ struct ringbuf_t {
 	unsigned nworkers;
 	std::unique_ptr<ringbuf_worker_t[]> workers;
 
+	/* Set by ringbuf_consume, reset by ringbuf_release. */
+	bool consume_in_progress;
+
 	ringbuf_t(size_t max_workers, size_t length)
 	    : workers(new ringbuf_worker_t[max_workers])
 	{
@@ -115,6 +118,7 @@ struct ringbuf_t {
 		space = length;
 		end = RBUF_OFF_MAX;
 		nworkers = max_workers;
+		consume_in_progress = false;
 
 		/* Helgrind/Drd does not understand std::atomic */
 #if LIBPMEMOBJ_CPP_VG_HELGRIND_ENABLED
@@ -321,10 +325,14 @@ ringbuf_produce(ringbuf_t *rbuf, ringbuf_worker_t *w)
 
 /*
  * ringbuf_consume: get a contiguous range which is ready to be consumed.
+ *
+ * Nested consumes are not allowed.
  */
 inline size_t
 ringbuf_consume(ringbuf_t *rbuf, size_t *offset)
 {
+	assert(!rbuf->consume_in_progress);
+
 	ringbuf_off_t written = rbuf->written, next, ready;
 	size_t towrite;
 retry:
@@ -430,6 +438,10 @@ retry:
 
 	assert(ready >= written);
 	assert(towrite <= rbuf->space);
+
+	if (towrite)
+		rbuf->consume_in_progress = true;
+
 	return towrite;
 }
 
@@ -439,6 +451,8 @@ retry:
 inline void
 ringbuf_release(ringbuf_t *rbuf, size_t nbytes)
 {
+	rbuf->consume_in_progress = false;
+
 	const size_t nwritten = rbuf->written + nbytes;
 
 	assert(rbuf->written <= rbuf->space);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -975,6 +975,9 @@ if(TEST_MPSC_QUEUE)
 	build_test(mpsc_queue_consume_multipass mpsc_queue/consume_multipass.cpp)
 	add_test_generic(NAME mpsc_queue_consume_multipass TRACERS none memcheck pmemcheck)
 
+	build_test(mpsc_queue_consume_interrupt mpsc_queue/consume_interrupt.cpp)
+	add_test_generic(NAME mpsc_queue_consume_interrupt SCRIPT mpsc_queue/mpsc_queue_consume_interrupt.cmake TRACERS none memcheck pmemcheck)
+
 	build_test(mpsc_queue_basic mpsc_queue/basic.cpp)
 	add_test_generic(NAME mpsc_queue_basic SCRIPT mpsc_queue/basic.cmake TRACERS none memcheck pmemcheck)
 

--- a/tests/mpsc_queue/consume_interrupt.cpp
+++ b/tests/mpsc_queue/consume_interrupt.cpp
@@ -2,8 +2,8 @@
 /* Copyright 2021, Intel Corporation */
 
 /*
- * basic.pp -- Single threaded tests for
- * pmem::obj::experimental::mpsc_queue
+ * consume_interrupt.cpp -- Test for mpsc_queue which interrupts
+ * try_consume_batch and check if the data is accessible afterwards.
  */
 
 #include "unittest.hpp"
@@ -14,7 +14,6 @@
 #include <libpmemobj++/experimental/mpsc_queue.hpp>
 #include <libpmemobj++/make_persistent.hpp>
 #include <libpmemobj++/persistent_ptr.hpp>
-#include <libpmemobj++/string_view.hpp>
 #include <libpmemobj++/transaction.hpp>
 
 #define LAYOUT "layout"
@@ -29,7 +28,7 @@ struct root {
 
 /* Basic try_produce-consume-recovery scenario */
 static void
-basic_test(pmem::obj::pool<root> pop, bool create)
+consume_interrupt(pmem::obj::pool<root> pop, bool create)
 {
 	auto proot = pop.root();
 
@@ -39,7 +38,7 @@ basic_test(pmem::obj::pool<root> pop, bool create)
 
 	std::vector<std::string> values = {"xxx", "aaaaaaa", "bbbbb",
 					   std::string(120, 'a')};
-	std::string store_to_next_run = "old";
+
 	if (create) {
 		auto ret = queue.try_consume_batch(
 			[&](queue_type::batch_type acc) {
@@ -47,9 +46,24 @@ basic_test(pmem::obj::pool<root> pop, bool create)
 			});
 		UT_ASSERT(!ret);
 
+		/* XXX: this is to make sure that try_consume_batch later in the
+		 * test returns all elements within a single callback call. */
+		ret = worker.try_produce(values[0]);
+		UT_ASSERT(ret);
+		ret = queue.try_consume_batch(
+			[&](queue_type::batch_type rd_acc) {
+				std::vector<std::string> v;
+				for (const auto &str : rd_acc)
+					v.emplace_back(str.data(), str.size());
+
+				UT_ASSERTeq(v.size(), 1);
+				UT_ASSERT(v[0] == values[0]);
+			});
+		UT_ASSERT(ret);
+
 		/* Insert the data */
 		for (const auto &e : values) {
-			auto ret = worker.try_produce(
+			ret = worker.try_produce(
 				e.size(), [&](pmem::obj::slice<char *> range) {
 					std::copy_n(e.begin(), e.size(),
 						    range.begin());
@@ -59,32 +73,33 @@ basic_test(pmem::obj::pool<root> pop, bool create)
 
 		/* Consume all the data */
 		std::vector<std::string> values_on_pmem;
-		ret = queue.try_consume_batch(
-			[&](queue_type::batch_type rd_acc) {
-				for (const auto &str : rd_acc) {
-					values_on_pmem.emplace_back(str.data(),
-								    str.size());
-				}
-			});
-		UT_ASSERT(ret);
+		const int retries = 3;
 
-		UT_ASSERTeq(values_on_pmem.size(), values.size());
+		for (int i = 0; i < retries; i++) {
+			try {
+				ret = queue.try_consume_batch(
+					[&](queue_type::batch_type rd_acc) {
+						for (const auto &str : rd_acc) {
+							values_on_pmem.emplace_back(
+								str.data(),
+								str.size());
+						}
+
+						throw std::runtime_error("");
+					});
+				ASSERT_UNREACHABLE;
+			} catch (std::runtime_error &) {
+			} catch (...) {
+				ASSERT_UNREACHABLE;
+			}
+		}
+
+		UT_ASSERTeq(values_on_pmem.size(), values.size() * retries);
 		for (auto &str : values) {
 			auto count = std::count(values_on_pmem.begin(),
 						values_on_pmem.end(), str);
-			UT_ASSERTeq(count, 1);
+			UT_ASSERTeq(count, retries);
 		}
-
-		/* Insert new data, which may be recovered in next run of
-		 * application */
-		ret = worker.try_produce(
-			store_to_next_run.size(),
-			[&](pmem::obj::slice<char *> range) {
-				std::copy_n(store_to_next_run.begin(),
-					    store_to_next_run.size(),
-					    range.begin());
-			});
-		UT_ASSERT(ret);
 	} else {
 		std::vector<std::string> values_on_pmem;
 		/* Recover the data in second run of application */
@@ -95,9 +110,12 @@ basic_test(pmem::obj::pool<root> pop, bool create)
 						entry.data(), entry.size());
 			});
 		UT_ASSERT(ret);
-		UT_ASSERTeq(values_on_pmem.size(), 1);
-		UT_ASSERTeq(values_on_pmem[0].size(), store_to_next_run.size());
-		UT_ASSERT(values_on_pmem[0] == store_to_next_run);
+		UT_ASSERTeq(values_on_pmem.size(), values.size());
+		for (auto &str : values) {
+			auto count = std::count(values_on_pmem.begin(),
+						values_on_pmem.end(), str);
+			UT_ASSERTeq(count, 1);
+		}
 	}
 }
 
@@ -125,7 +143,7 @@ test(int argc, char *argv[])
 		pop = pmem::obj::pool<root>::open(std::string(path), LAYOUT);
 	}
 
-	basic_test(pop, create);
+	consume_interrupt(pop, create);
 
 	pop.close();
 }

--- a/tests/mpsc_queue/mpsc_queue_consume_interrupt.cmake
+++ b/tests/mpsc_queue/mpsc_queue_consume_interrupt.cmake
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2021, Intel Corporation
+
+include(${SRC_DIR}/../helpers.cmake)
+
+setup()
+
+execute(${TEST_EXECUTABLE} ${DIR}/testfile 1)
+execute(${TEST_EXECUTABLE} ${DIR}/testfile 0)
+
+finish()


### PR DESCRIPTION
If interrupt (exception) happens, next try_consume_batch will
resume from the previous position.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1104)
<!-- Reviewable:end -->
