### PR TITLE
Make cpp-format targets always working

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,12 +189,15 @@ add_custom_target(copyright-format
 			BSD-3-Clause -d)
 
 
+find_program(CLANG_FORMAT NAMES clang-format-9 clang-format-9.0 clang-format)
+set(CLANG_FORMAT_REQUIRED "9.0")
+if(CLANG_FORMAT)
+	get_program_version_major_minor(${CLANG_FORMAT} CLANG_FORMAT_VERSION)
+	message(STATUS "Found clang-format: ${CLANG_FORMAT} (version: ${CLANG_FORMAT_VERSION})")
+endif()
+
 if(CHECK_CPP_STYLE)
-	find_program(CLANG_FORMAT NAMES clang-format clang-format-9 clang-format-9.0)
-	set(CLANG_FORMAT_REQUIRED "9.0")
 	if(CLANG_FORMAT)
-		get_program_version_major_minor(${CLANG_FORMAT} CLANG_FORMAT_VERSION)
-		message(STATUS "Found clang-format: ${CLANG_FORMAT} (version: ${CLANG_FORMAT_VERSION})")
 		if(NOT (CLANG_FORMAT_VERSION VERSION_EQUAL CLANG_FORMAT_REQUIRED))
 			message(FATAL_ERROR "required clang-format version is ${CLANG_FORMAT_REQUIRED}")
 		endif()

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -99,7 +99,7 @@ endmacro()
 # instead.
 # ${name} must be unique.
 function(add_cppstyle name)
-	if(NOT CLANG_FORMAT)
+	if(NOT CLANG_FORMAT OR NOT (CLANG_FORMAT_VERSION VERSION_EQUAL CLANG_FORMAT_REQUIRED))
 		return()
 	endif()
 


### PR DESCRIPTION
As cpp-format targets are always generated anyway, they should work even
if CHECK_CPP_STYLE flag is disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1118)
<!-- Reviewable:end -->
