### PR TITLE
radix_tree: fix pmemcheck annotation

### DIFF
--- a/include/libpmemobj++/experimental/radix_tree.hpp
+++ b/include/libpmemobj++/experimental/radix_tree.hpp
@@ -1024,7 +1024,7 @@ void
 radix_tree<Key, Value, BytesView>::runtime_initialize_mt(ebr *e)
 {
 	mt.get(false) = true;
-#if LIBPMEMOBJ_CPP_ANY_VG_TOOL_ENABLED
+#if LIBPMEMOBJ_CPP_VG_PMEMCHECK_ENABLED
 	VALGRIND_PMC_REMOVE_PMEM_MAPPING(&ebr_, sizeof(ebr *));
 #endif
 	ebr_ = e;


### PR DESCRIPTION
Use annotation only if PMEMCHECK is enabled (not just any valgrind tool).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1123)
<!-- Reviewable:end -->
