### PR TITLE
tests: do not use basic_string_view comparison as a workaround

### DIFF
--- a/tests/inline_string/inline_string.cpp
+++ b/tests/inline_string/inline_string.cpp
@@ -265,8 +265,10 @@ test_dram(nvobj::pool<struct root<T>> &pop)
 	new (dram_location)
 		string_type(nvobj::basic_string_view<T>(s.data(), s.length()));
 
-	UT_ASSERT(nvobj::basic_string_view<T>(s.data(), s.length()) ==
-		  nvobj::basic_string_view<T>(*dram_location));
+	UT_ASSERTeq(s.length(), dram_location->size());
+	UT_ASSERTeq(std::char_traits<T>::compare(
+			    s.data(), dram_location->data(), s.length()),
+		    0);
 
 	dram_location->~string_type();
 


### PR DESCRIPTION
for C2593: 'operator ==' is ambigous on Visual Studio 14.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1126)
<!-- Reviewable:end -->
