### PR TITLE
tests: add libunwind suppresion

### DIFF
--- a/tests/memcheck-libunwind.supp
+++ b/tests/memcheck-libunwind.supp
@@ -21,3 +21,17 @@
    obj:*libunwind*
    ...
 }
+{
+   libunwind calls glibc's setcontext on some architectures, e.g. ppc
+   Memcheck:Addr8
+   fun:setcontext*
+   ...
+}
+{
+   libunwind exception suppresion
+   Memcheck:Param
+   write(buf)
+   ...
+   obj:*libunwind*
+   ...
+}


### PR DESCRIPTION
Memcheck reports an error in libunwind exception raising.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1127)
<!-- Reviewable:end -->
