### PR TITLE
[stable-1.11] Fix Clang detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,22 +127,6 @@ if (PERL_VERSION_STRING VERSION_LESS 5.16)
 	message(FATAL_ERROR "Too old Perl (<5.16)")
 endif()
 
-# Some tests and examples require clang >= 8.0
-# because of the following bug:
-# https://bugs.llvm.org/show_bug.cgi?id=28280
-# which is fixed in clang v8.0.
-set(CLANG_REQUIRED_BY_DESTRUCTOR_REFERENCE_BUG "8.0")
-find_program(CLANG NAMES clang)
-if(CLANG)
-	get_program_version_major_minor(${CLANG} CLANG_VERSION)
-	message(STATUS "Found clang: ${CLANG} (version: ${CLANG_VERSION})")
-	if(CLANG_VERSION VERSION_LESS CLANG_REQUIRED_BY_DESTRUCTOR_REFERENCE_BUG)
-		set(CLANG_DESTRUCTOR_REFERENCE_BUG_PRESENT 1)
-	endif()
-else()
-	message(STATUS "clang not found")
-endif()
-
 if(BUILD_TESTS OR BUILD_EXAMPLES OR BUILD_BENCHMARKS)
 	if(PKG_CONFIG_FOUND)
 		pkg_check_modules(LIBPMEMOBJ REQUIRED libpmemobj>=${LIBPMEMOBJ_REQUIRED_VERSION})
@@ -161,6 +145,13 @@ if(BUILD_TESTS OR BUILD_EXAMPLES OR BUILD_BENCHMARKS)
 		list(LENGTH VERSION_LIST OBJ_VER_COMPS)
 		if (${OBJ_VER_COMPS} LESS 3)
 			list(APPEND VERSION_LIST "0")
+
+	# Some tests and examples require clang >= 8.0, because of the bug
+	# (https://bugs.llvm.org/show_bug.cgi?id=28280), which is fixed in clang v8.0.
+
+	if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang" AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+		if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.0")
+			set(CLANG_DESTRUCTOR_REFERENCE_BUG_PRESENT 1)
 		endif()
 		list(GET VERSION_LIST 2 LIBPMEMOBJ_VERSION_PATCH)
 	else()

--- a/tests/ctest_helpers.cmake
+++ b/tests/ctest_helpers.cmake
@@ -133,7 +133,7 @@ endfunction()
 # Function to build test with atomic
 function(build_test_atomic name)
 	build_test(${name} ${ARGN})
-	if(CLANG)
+	if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang" AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 		target_link_libraries(${name} atomic)
 	endif()
 endfunction()


### PR DESCRIPTION
- use CMAKE_CXX_COMPILER_VERSION/CMAKE_C[XX]_COMPILER_ID for
  setting compiler conditions
- fixes #1090

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1130)
<!-- Reviewable:end -->
