### PR TITLE
tests: link atomic to all tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Up-to-date support/maintenance status of branches/releases is available on [pmem
 	- valgrind-devel (at best with [pmemcheck support](https://github.com/pmem/valgrind))
 	- clang format 9.0
 	- perl
+	- libatomic
 
 ## On Linux ##
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2020, Intel Corporation
+# Copyright 2018-2021, Intel Corporation
 
 include(ctest_helpers.cmake)
 
@@ -252,10 +252,10 @@ if (TEST_SELF_RELATIVE_POINTER)
 	build_test(self_relative_ptr_arith ptr_arith/self_relative_ptr_arith.cpp)
 	add_test_generic(NAME self_relative_ptr_arith TRACERS none memcheck pmemcheck)
 
-	build_test_atomic(self_relative_ptr_atomic self_relative_ptr_atomic/self_relative_ptr_atomic.cpp)
+	build_test(self_relative_ptr_atomic self_relative_ptr_atomic/self_relative_ptr_atomic.cpp)
 	add_test_generic(NAME self_relative_ptr_atomic TRACERS none memcheck drd helgrind)
 
-	build_test_atomic(self_relative_ptr_atomic_pmem self_relative_ptr_atomic/self_relative_ptr_atomic_pmem.cpp)
+	build_test(self_relative_ptr_atomic_pmem self_relative_ptr_atomic/self_relative_ptr_atomic_pmem.cpp)
 	add_test_generic(NAME self_relative_ptr_atomic_pmem TRACERS none memcheck pmemcheck drd helgrind)
 endif()
 

--- a/tests/ctest_helpers.cmake
+++ b/tests/ctest_helpers.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2020, Intel Corporation
+# Copyright 2018-2021, Intel Corporation
 
 #
 # ctest_helpers.cmake - helper functions for tests/CMakeLists.txt
@@ -109,6 +109,8 @@ function(build_test name)
 	endif()
 	if(WIN32)
 		target_link_libraries(${name} dbghelp)
+	else()
+		target_link_libraries(${name} atomic)
 	endif()
 	target_compile_definitions(${name} PRIVATE TESTS_LIBPMEMOBJ_VERSION=0x${LIBPMEMOBJ_VERSION_NUM})
 
@@ -128,14 +130,6 @@ endfunction()
 function(build_test_tbb name)
 	build_test(${name} ${ARGN})
 	target_link_libraries(${name} ${TBB_LIBRARIES})
-endfunction()
-
-# Function to build test with atomic
-function(build_test_atomic name)
-	build_test(${name} ${ARGN})
-	if(CLANG)
-		target_link_libraries(${name} atomic)
-	endif()
 endfunction()
 
 # Function to build a TBB test with mocked pmemobj_defrag() function


### PR DESCRIPTION
Not only self_relative_ptr tests use atomics. On some platforms
(e.g. riscv64) -latomic is needed for a few other tests
(pool_cleanup, volatile_state).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1132)
<!-- Reviewable:end -->
