### PR TITLE
[exceptions] Remove unnecessary multibase inheritance

### DIFF
--- a/include/libpmemobj++/pexceptions.hpp
+++ b/include/libpmemobj++/pexceptions.hpp
@@ -134,18 +134,15 @@ public:
  *
  * Thrown when there is out of memory error inside of transaction.
  */
-class transaction_out_of_memory : public transaction_alloc_error,
-				  public std::bad_alloc {
+class transaction_out_of_memory : public transaction_alloc_error {
 public:
 	using transaction_alloc_error::transaction_alloc_error;
-	using transaction_alloc_error::what;
 
 	transaction_out_of_memory &
 	with_pmemobj_errormsg()
 	{
-		(*this) = transaction_out_of_memory(
-			transaction_alloc_error::what() + std::string(": ") +
-			detail::errormsg());
+		(*this) = transaction_out_of_memory(what() + std::string(": ") +
+						    detail::errormsg());
 		return *this;
 	}
 };


### PR DESCRIPTION
Remove unnecessary inheritance to avoid "diamond problem".
Additionally, using virtual inheritance force to implement move
operators. Better for this part of code is to follow KISS rule
and simplify this implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1144)
<!-- Reviewable:end -->
