### PR TITLE
riscv: define cacheline size

### DIFF
--- a/include/libpmemobj++/detail/common.hpp
+++ b/include/libpmemobj++/detail/common.hpp
@@ -150,7 +150,8 @@ namespace experimental
 namespace detail
 {
 
-#if defined(__x86_64) || defined(_M_X64) || defined(__aarch64__)
+#if defined(__x86_64) || defined(_M_X64) || defined(__aarch64__) ||            \
+	defined(__riscv)
 static constexpr size_t CACHELINE_SIZE = 64ULL;
 #elif defined(__PPC64__)
 static constexpr size_t CACHELINE_SIZE = 128ULL;


### PR DESCRIPTION
Declaring the cacheline size is all that's needed to let the tests pass — of course assuming patched PMDK.

As this change is so non-intrusive, let's just commit and forget.

Among major lacking test dependencies there's valgrind (not ported yet) and libunwind (merged upstream, not released).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1153)
<!-- Reviewable:end -->
