### PR TITLE
[ebr+tagged_ptr] add assignment declarations needed by Klocwork

### DIFF
--- a/include/libpmemobj++/detail/ebr.hpp
+++ b/include/libpmemobj++/detail/ebr.hpp
@@ -89,6 +89,9 @@ public:
 		worker(worker &&w) = default;
 		~worker();
 
+		worker &operator=(worker &w) = delete;
+		worker &operator=(worker &&w) = default;
+
 		template <typename F>
 		void critical(F &&f);
 

--- a/include/libpmemobj++/detail/tagged_ptr.hpp
+++ b/include/libpmemobj++/detail/tagged_ptr.hpp
@@ -248,6 +248,9 @@ public:
 		this->store_with_snapshot(tmp);
 	}
 
+	atomic<pmem::detail::tagged_ptr<P1, P2>> &
+	operator=(atomic<pmem::detail::tagged_ptr<P1, P2>> &) = delete;
+
 private:
 	ptr_type ptr;
 };


### PR DESCRIPTION
I'm not sure that is enough, let's talk about it.

Klocwork said: "Class 'atomic/worker' defines a copy constructor,
but no assignment operator".