### PR TITLE
Extend radix_tree tests and disable operator-- (for MtMode)

### DIFF
--- a/tests/radix_tree/radix.hpp
+++ b/tests/radix_tree/radix.hpp
@@ -16,76 +16,73 @@ static std::mt19937_64 generator;
 namespace nvobj = pmem::obj;
 namespace nvobjex = pmem::obj::experimental;
 
-using container_int =
+using cntr_int =
 	nvobjex::radix_tree<nvobjex::inline_string, nvobj::p<unsigned>>;
-using container_string =
+using cntr_string =
 	nvobjex::radix_tree<nvobjex::inline_string, nvobjex::inline_string>;
 
-using container_int_int =
-	nvobjex::radix_tree<unsigned, nvobj::p<unsigned>,
-			    nvobjex::bytes_view<unsigned>, false>;
-using container_int_string =
-	nvobjex::radix_tree<unsigned, nvobjex::inline_string>;
+using cntr_int_int = nvobjex::radix_tree<unsigned, nvobj::p<unsigned>,
+					 nvobjex::bytes_view<unsigned>, false>;
+using cntr_int_string = nvobjex::radix_tree<unsigned, nvobjex::inline_string>;
 
-using container_inline_s_wchart =
+using cntr_inline_s_wchart =
 	nvobjex::radix_tree<nvobjex::basic_inline_string<wchar_t>,
 			    nvobj::p<unsigned>>;
-using container_inline_s_wchart_wchart =
+using cntr_inline_s_wchart_wchart =
 	nvobjex::radix_tree<nvobjex::basic_inline_string<wchar_t>,
 			    nvobjex::basic_inline_string<wchar_t>>;
-using container_inline_s_u8t =
+using cntr_inline_s_u8t =
 	nvobjex::radix_tree<nvobjex::basic_inline_string<uint8_t>,
 			    nvobjex::basic_inline_string<uint8_t>>;
 
-using container_int_mt =
+using cntr_int_mt =
 	nvobjex::radix_tree<nvobjex::inline_string, nvobj::p<unsigned>,
 			    nvobjex::bytes_view<nvobjex::inline_string>, true>;
-using container_string_mt =
+using cntr_string_mt =
 	nvobjex::radix_tree<nvobjex::inline_string, nvobjex::inline_string,
 			    nvobjex::bytes_view<nvobjex::inline_string>, true>;
 
-using container_int_int_mt =
+using cntr_int_int_mt =
 	nvobjex::radix_tree<unsigned, nvobj::p<unsigned>,
 			    nvobjex::bytes_view<unsigned>, true>;
-using container_int_string_mt =
+using cntr_int_string_mt =
 	nvobjex::radix_tree<unsigned, nvobjex::inline_string,
 			    nvobjex::bytes_view<unsigned>, true>;
 
-using container_inline_s_wchart_mt = nvobjex::radix_tree<
+using cntr_inline_s_wchart_mt = nvobjex::radix_tree<
 	nvobjex::basic_inline_string<wchar_t>, nvobj::p<unsigned>,
 	nvobjex::bytes_view<nvobjex::basic_inline_string<wchar_t>>, true>;
-using container_inline_s_wchart_wchart_mt = nvobjex::radix_tree<
+using cntr_inline_s_wchart_wchart_mt = nvobjex::radix_tree<
 	nvobjex::basic_inline_string<wchar_t>,
 	nvobjex::basic_inline_string<wchar_t>,
 	nvobjex::bytes_view<nvobjex::basic_inline_string<wchar_t>>, true>;
-using container_inline_s_u8t_mt = nvobjex::radix_tree<
+using cntr_inline_s_u8t_mt = nvobjex::radix_tree<
 	nvobjex::basic_inline_string<uint8_t>,
 	nvobjex::basic_inline_string<uint8_t>,
 	nvobjex::bytes_view<nvobjex::basic_inline_string<uint8_t>>, true>;
 
 struct root {
-	nvobj::persistent_ptr<container_int> radix_int;
-	nvobj::persistent_ptr<container_string> radix_str;
+	nvobj::persistent_ptr<cntr_int> radix_int;
+	nvobj::persistent_ptr<cntr_string> radix_str;
 
-	nvobj::persistent_ptr<container_int_int> radix_int_int;
-	nvobj::persistent_ptr<container_int_string> radix_int_str;
+	nvobj::persistent_ptr<cntr_int_int> radix_int_int;
+	nvobj::persistent_ptr<cntr_int_string> radix_int_str;
 
-	nvobj::persistent_ptr<container_inline_s_wchart> radix_inline_s_wchart;
-	nvobj::persistent_ptr<container_inline_s_wchart_wchart>
+	nvobj::persistent_ptr<cntr_inline_s_wchart> radix_inline_s_wchart;
+	nvobj::persistent_ptr<cntr_inline_s_wchart_wchart>
 		radix_inline_s_wchart_wchart;
-	nvobj::persistent_ptr<container_inline_s_u8t> radix_inline_s_u8t;
+	nvobj::persistent_ptr<cntr_inline_s_u8t> radix_inline_s_u8t;
 
-	nvobj::persistent_ptr<container_int_mt> radix_int_mt;
-	nvobj::persistent_ptr<container_string_mt> radix_str_mt;
+	nvobj::persistent_ptr<cntr_int_mt> radix_int_mt;
+	nvobj::persistent_ptr<cntr_string_mt> radix_str_mt;
 
-	nvobj::persistent_ptr<container_int_int_mt> radix_int_int_mt;
-	nvobj::persistent_ptr<container_int_string_mt> radix_int_str_mt;
+	nvobj::persistent_ptr<cntr_int_int_mt> radix_int_int_mt;
+	nvobj::persistent_ptr<cntr_int_string_mt> radix_int_str_mt;
 
-	nvobj::persistent_ptr<container_inline_s_wchart_mt>
-		radix_inline_s_wchart_mt;
-	nvobj::persistent_ptr<container_inline_s_wchart_wchart_mt>
+	nvobj::persistent_ptr<cntr_inline_s_wchart_mt> radix_inline_s_wchart_mt;
+	nvobj::persistent_ptr<cntr_inline_s_wchart_wchart_mt>
 		radix_inline_s_wchart_wchart_mt;
-	nvobj::persistent_ptr<container_inline_s_u8t_mt> radix_inline_s_u8t_mt;
+	nvobj::persistent_ptr<cntr_inline_s_u8t_mt> radix_inline_s_u8t_mt;
 };
 
 /* Helper functions to access key/value of different types */

--- a/tests/radix_tree/radix.hpp
+++ b/tests/radix_tree/radix.hpp
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2020-2021, Intel Corporation */
 
+#include <functional>
+#include <libpmemobj.h>
+#include <random>
+
 #include "transaction_helpers.hpp"
 #include "unittest.hpp"
 
 #include <libpmemobj++/experimental/inline_string.hpp>
 #include <libpmemobj++/experimental/radix_tree.hpp>
 
-#include <functional>
-
-#include <libpmemobj.h>
+static std::mt19937_64 generator;
 
 namespace nvobj = pmem::obj;
 namespace nvobjex = pmem::obj::experimental;
@@ -86,6 +88,7 @@ struct root {
 	nvobj::persistent_ptr<container_inline_s_u8t_mt> radix_inline_s_u8t_mt;
 };
 
+/* Helper functions to access key/value of different types */
 template <typename Container,
 	  typename Enable = typename std::enable_if<
 		  std::is_same<typename Container::mapped_type,
@@ -108,9 +111,9 @@ value(unsigned v, int repeats = 1)
 {
 	using CharT = typename Container::mapped_type::value_type;
 
+	auto str = std::to_string(v);
 	auto s = std::basic_string<CharT>{};
 	for (int i = 0; i < repeats; i++) {
-		auto str = std::to_string(v);
 		s += std::basic_string<CharT>(str.begin(), str.end());
 	}
 
@@ -178,6 +181,7 @@ operator!=(pmem::obj::experimental::basic_inline_string<CharT, Traits> &lhs,
 		       .compare(rhs) != 0;
 }
 
+/* verify all elements in container, using lower_/upper_bound and find */
 template <typename Container, typename K, typename F>
 void
 verify_elements(nvobj::persistent_ptr<Container> ptr, unsigned count, K &&key_f,
@@ -216,6 +220,8 @@ verify_elements(nvobj::persistent_ptr<Container> ptr, unsigned count, K &&key_f,
 	}
 }
 
+/* run 1 thread with modifications (erase/write/etc.) and multiple threads with
+ * reads */
 template <typename ModifyF, typename ReadF>
 static void
 parallel_modify_read(ModifyF modifier, std::vector<ReadF> &readers,
@@ -230,16 +236,30 @@ parallel_modify_read(ModifyF modifier, std::vector<ReadF> &readers,
 	});
 }
 
+/* each test suite should initialize generator at the beginning */
+void
+init_random()
+{
+	std::random_device rd;
+	auto seed = rd();
+	std::cout << "rand seed: " << seed << std::endl;
+	generator = std::mt19937_64(seed);
+}
+
 template <typename Container>
 static void
 init_container(nvobj::pool<root> &pop, nvobj::persistent_ptr<Container> &ptr,
-	       const size_t initial_elements, const size_t value_repeats = 1)
+	       const size_t initial_elements, const size_t value_repeats = 1,
+	       bool rand_keys = false)
 {
 	nvobj::transaction::run(
 		pop, [&] { ptr = nvobj::make_persistent<Container>(); });
 
 	for (size_t i = 0; i < initial_elements; ++i) {
-		ptr->emplace(key<Container>(i),
-			     value<Container>(i, value_repeats));
+		auto k = key<Container>(i);
+		if (rand_keys) {
+			k = key<Container>(static_cast<unsigned>(generator()));
+		}
+		ptr->emplace(k, value<Container>(i, value_repeats));
 	}
 }

--- a/tests/radix_tree/radix_basic.cpp
+++ b/tests/radix_tree/radix_basic.cpp
@@ -14,14 +14,14 @@ test_iterators(nvobj::pool<root> &pop)
 	auto r = pop.root();
 
 	nvobj::transaction::run(pop, [&] {
-		r->radix_int = nvobj::make_persistent<container_int>();
+		r->radix_int = nvobj::make_persistent<cntr_int>();
 		r->radix_int->try_emplace("", 0U);
 		r->radix_int->try_emplace("ab", 1U);
 		r->radix_int->try_emplace("ba", 2U);
 		r->radix_int->try_emplace("a", 3U);
 		r->radix_int->try_emplace("b", 4U);
 
-		r->radix_str = nvobj::make_persistent<container_string>();
+		r->radix_str = nvobj::make_persistent<cntr_string>();
 		r->radix_str->try_emplace("", "");
 
 		r->radix_str->try_emplace(" ", "ab");
@@ -120,8 +120,8 @@ test_iterators(nvobj::pool<root> &pop)
 	ss << *r->radix_str;
 
 	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_string>(r->radix_str);
-		nvobj::delete_persistent<container_int>(r->radix_int);
+		nvobj::delete_persistent<cntr_string>(r->radix_str);
+		nvobj::delete_persistent<cntr_int>(r->radix_int);
 	});
 
 	UT_ASSERTeq(num_allocs(pop), 0);
@@ -133,8 +133,8 @@ test_ref_stability(nvobj::pool<root> &pop)
 	auto r = pop.root();
 
 	nvobj::transaction::run(pop, [&] {
-		r->radix_str = nvobj::make_persistent<container_string>();
-		r->radix_int = nvobj::make_persistent<container_int>();
+		r->radix_str = nvobj::make_persistent<cntr_string>();
+		r->radix_int = nvobj::make_persistent<cntr_int>();
 	});
 
 	{
@@ -169,8 +169,8 @@ test_ref_stability(nvobj::pool<root> &pop)
 	}
 
 	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_string>(r->radix_str);
-		nvobj::delete_persistent<container_int>(r->radix_int);
+		nvobj::delete_persistent<cntr_string>(r->radix_str);
+		nvobj::delete_persistent<cntr_int>(r->radix_int);
 	});
 
 	UT_ASSERTeq(num_allocs(pop), 0);
@@ -184,8 +184,7 @@ test_find(nvobj::pool<root> &pop)
 
 	{
 		nvobj::transaction::run(pop, [&] {
-			r->radix_str =
-				nvobj::make_persistent<container_string>();
+			r->radix_str = nvobj::make_persistent<cntr_string>();
 		});
 
 		UT_ASSERT(r->radix_str->lower_bound("") == r->radix_str->end());
@@ -279,8 +278,7 @@ test_find(nvobj::pool<root> &pop)
 			  r->radix_str->find("ad"));
 
 		nvobj::transaction::run(pop, [&] {
-			nvobj::delete_persistent<container_string>(
-				r->radix_str);
+			nvobj::delete_persistent<cntr_string>(r->radix_str);
 		});
 
 		UT_ASSERTeq(num_allocs(pop), 0);
@@ -288,8 +286,7 @@ test_find(nvobj::pool<root> &pop)
 
 	{
 		nvobj::transaction::run(pop, [&] {
-			r->radix_str =
-				nvobj::make_persistent<container_string>();
+			r->radix_str = nvobj::make_persistent<cntr_string>();
 		});
 
 		r->radix_str->emplace("a", "");
@@ -329,8 +326,7 @@ test_find(nvobj::pool<root> &pop)
 			  r->radix_str->end());
 
 		nvobj::transaction::run(pop, [&] {
-			nvobj::delete_persistent<container_string>(
-				r->radix_str);
+			nvobj::delete_persistent<cntr_string>(r->radix_str);
 		});
 
 		UT_ASSERTeq(num_allocs(pop), 0);
@@ -338,8 +334,7 @@ test_find(nvobj::pool<root> &pop)
 
 	{
 		nvobj::transaction::run(pop, [&] {
-			r->radix_str =
-				nvobj::make_persistent<container_string>();
+			r->radix_str = nvobj::make_persistent<cntr_string>();
 		});
 
 		r->radix_str->try_emplace("Y", "1");
@@ -427,8 +422,7 @@ test_find(nvobj::pool<root> &pop)
 		UT_ASSERTeq(std::distance(lb, ub), 8);
 
 		nvobj::transaction::run(pop, [&] {
-			nvobj::delete_persistent<container_string>(
-				r->radix_str);
+			nvobj::delete_persistent<cntr_string>(r->radix_str);
 		});
 
 		UT_ASSERTeq(num_allocs(pop), 0);
@@ -436,8 +430,7 @@ test_find(nvobj::pool<root> &pop)
 
 	{
 		nvobj::transaction::run(pop, [&] {
-			r->radix_str =
-				nvobj::make_persistent<container_string>();
+			r->radix_str = nvobj::make_persistent<cntr_string>();
 		});
 
 		r->radix_str->try_emplace(std::string(1, char(1)), "");
@@ -446,8 +439,7 @@ test_find(nvobj::pool<root> &pop)
 		UT_ASSERT(ub == r->radix_str->end());
 
 		nvobj::transaction::run(pop, [&] {
-			nvobj::delete_persistent<container_string>(
-				r->radix_str);
+			nvobj::delete_persistent<cntr_string>(r->radix_str);
 		});
 
 		UT_ASSERTeq(num_allocs(pop), 0);
@@ -455,8 +447,7 @@ test_find(nvobj::pool<root> &pop)
 
 	{
 		nvobj::transaction::run(pop, [&] {
-			r->radix_str =
-				nvobj::make_persistent<container_string>();
+			r->radix_str = nvobj::make_persistent<cntr_string>();
 		});
 
 		r->radix_str->try_emplace(std::string(1, char(-1)), "");
@@ -465,8 +456,7 @@ test_find(nvobj::pool<root> &pop)
 		UT_ASSERT(ub == r->radix_str->begin());
 
 		nvobj::transaction::run(pop, [&] {
-			nvobj::delete_persistent<container_string>(
-				r->radix_str);
+			nvobj::delete_persistent<cntr_string>(r->radix_str);
 		});
 
 		UT_ASSERTeq(num_allocs(pop), 0);
@@ -475,8 +465,7 @@ test_find(nvobj::pool<root> &pop)
 	/* *_bound when there are multiple lesser elements with common prefix */
 	{
 		nvobj::transaction::run(pop, [&] {
-			r->radix_str =
-				nvobj::make_persistent<container_string>();
+			r->radix_str = nvobj::make_persistent<cntr_string>();
 		});
 
 		r->radix_str->try_emplace("in1", "");
@@ -501,8 +490,7 @@ test_find(nvobj::pool<root> &pop)
 		UT_ASSERT(it == r->radix_str->end());
 
 		nvobj::transaction::run(pop, [&] {
-			nvobj::delete_persistent<container_string>(
-				r->radix_str);
+			nvobj::delete_persistent<cntr_string>(r->radix_str);
 		});
 
 		UT_ASSERTeq(num_allocs(pop), 0);
@@ -511,8 +499,7 @@ test_find(nvobj::pool<root> &pop)
 	/* *_bound when there is a single lesser element */
 	{
 		nvobj::transaction::run(pop, [&] {
-			r->radix_str =
-				nvobj::make_persistent<container_string>();
+			r->radix_str = nvobj::make_persistent<cntr_string>();
 		});
 
 		r->radix_str->try_emplace("in", "");
@@ -524,8 +511,7 @@ test_find(nvobj::pool<root> &pop)
 		UT_ASSERT(it == r->radix_str->end());
 
 		nvobj::transaction::run(pop, [&] {
-			nvobj::delete_persistent<container_string>(
-				r->radix_str);
+			nvobj::delete_persistent<cntr_string>(r->radix_str);
 		});
 
 		UT_ASSERTeq(num_allocs(pop), 0);
@@ -536,7 +522,7 @@ const auto compressed_path_len = 4;
 const auto num_children = 3;
 
 static void
-generate_compressed_tree(nvobj::persistent_ptr<container_string> ptr,
+generate_compressed_tree(nvobj::persistent_ptr<cntr_string> ptr,
 			 std::string prefix, int level)
 {
 	/* it should be just one digit */
@@ -559,7 +545,7 @@ generate_compressed_tree(nvobj::persistent_ptr<container_string> ptr,
 }
 
 static void
-verify_bounds(nvobj::persistent_ptr<container_string> ptr,
+verify_bounds(nvobj::persistent_ptr<cntr_string> ptr,
 	      const std::vector<std::string> &keys)
 {
 	for (size_t i = 0; i < keys.size() - 1; i++) {
@@ -579,7 +565,7 @@ verify_bounds(nvobj::persistent_ptr<container_string> ptr,
 }
 
 static void
-verify_bounds_key(nvobj::persistent_ptr<container_string> ptr,
+verify_bounds_key(nvobj::persistent_ptr<cntr_string> ptr,
 		  const std::vector<std::string> &keys, const std::string &key)
 {
 	auto expected = std::lower_bound(keys.begin(), keys.end(), key);
@@ -601,7 +587,7 @@ test_compression(nvobj::pool<root> &pop)
 	auto r = pop.root();
 
 	nvobj::transaction::run(pop, [&] {
-		r->radix_str = nvobj::make_persistent<container_string>();
+		r->radix_str = nvobj::make_persistent<cntr_string>();
 	});
 
 	generate_compressed_tree(r->radix_str, "", num_levels);
@@ -659,7 +645,7 @@ test_compression(nvobj::pool<root> &pop)
 	}
 
 	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_string>(r->radix_str);
+		nvobj::delete_persistent<cntr_string>(r->radix_str);
 	});
 
 	UT_ASSERTeq(num_allocs(pop), 0);
@@ -673,16 +659,14 @@ test_erase(nvobj::pool<root> &pop)
 
 	{
 		nvobj::transaction::run(pop, [&] {
-			r->radix_str =
-				nvobj::make_persistent<container_string>();
+			r->radix_str = nvobj::make_persistent<cntr_string>();
 		});
 
 		std::unordered_set<std::string> set = {
 			"b", "ab", "acxxa", "acxxx", "acxxxa", "acxxx!"};
 
 		/* Used for testing iterator stability. */
-		std::unordered_map<std::string,
-				   typename container_string::iterator>
+		std::unordered_map<std::string, typename cntr_string::iterator>
 			its;
 
 		for (auto &s : set) {
@@ -725,8 +709,7 @@ test_erase(nvobj::pool<root> &pop)
 		UT_ASSERTeq(r->radix_str->size(), 0);
 
 		nvobj::transaction::run(pop, [&] {
-			nvobj::delete_persistent<container_string>(
-				r->radix_str);
+			nvobj::delete_persistent<cntr_string>(r->radix_str);
 		});
 
 		UT_ASSERTeq(num_allocs(pop), 0);
@@ -734,8 +717,7 @@ test_erase(nvobj::pool<root> &pop)
 
 	{
 		nvobj::transaction::run(pop, [&] {
-			r->radix_str =
-				nvobj::make_persistent<container_string>();
+			r->radix_str = nvobj::make_persistent<cntr_string>();
 		});
 
 		std::vector<std::string> elements = {
@@ -793,8 +775,7 @@ test_erase(nvobj::pool<root> &pop)
 		UT_ASSERTeq(r->radix_str->size(), 0);
 
 		nvobj::transaction::run(pop, [&] {
-			nvobj::delete_persistent<container_string>(
-				r->radix_str);
+			nvobj::delete_persistent<cntr_string>(r->radix_str);
 		});
 
 		UT_ASSERTeq(num_allocs(pop), 0);
@@ -810,11 +791,11 @@ test_binary_keys(nvobj::pool<root> &pop)
 	auto kv_f = [](unsigned i) { return i * 2; };
 
 	nvobj::transaction::run(pop, [&] {
-		r->radix_int_int = nvobj::make_persistent<container_int_int>();
+		r->radix_int_int = nvobj::make_persistent<cntr_int_int>();
 	});
 
 	/* Used for testing iterator stability. */
-	std::unordered_map<unsigned, typename container_int_int::iterator> its;
+	std::unordered_map<unsigned, typename cntr_int_int::iterator> its;
 
 	for (unsigned i = 2 * std::numeric_limits<uint16_t>::max(); i > 0;
 	     i -= 2) {
@@ -853,7 +834,7 @@ test_binary_keys(nvobj::pool<root> &pop)
 	}
 
 	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_int_int>(r->radix_int_int);
+		nvobj::delete_persistent<cntr_int_int>(r->radix_int_int);
 	});
 
 	its = {};
@@ -861,7 +842,7 @@ test_binary_keys(nvobj::pool<root> &pop)
 	UT_ASSERTeq(num_allocs(pop), 0);
 
 	nvobj::transaction::run(pop, [&] {
-		r->radix_int_int = nvobj::make_persistent<container_int_int>();
+		r->radix_int_int = nvobj::make_persistent<cntr_int_int>();
 	});
 
 	for (unsigned i = 0; i < 2 * std::numeric_limits<uint16_t>::max();
@@ -895,7 +876,7 @@ test_binary_keys(nvobj::pool<root> &pop)
 	}
 
 	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_int_int>(r->radix_int_int);
+		nvobj::delete_persistent<cntr_int_int>(r->radix_int_int);
 	});
 
 	UT_ASSERTeq(num_allocs(pop), 0);
@@ -912,8 +893,7 @@ test_pre_post_fixes(nvobj::pool<root> &pop)
 	elements.push_back("0");
 
 	/* Used for testing iterator stability. */
-	std::unordered_map<std::string, typename container_string::iterator>
-		its;
+	std::unordered_map<std::string, typename cntr_string::iterator> its;
 
 	/* This loop creates string so that elements[i] is prefix of
 	 * elements[i + 1] and they differ only by 4 bits:
@@ -942,7 +922,7 @@ test_pre_post_fixes(nvobj::pool<root> &pop)
 	auto r = pop.root();
 
 	nvobj::transaction::run(pop, [&] {
-		r->radix_str = nvobj::make_persistent<container_string>();
+		r->radix_str = nvobj::make_persistent<cntr_string>();
 	});
 
 	for (size_t i = elements.size(); i > 0; i--) {
@@ -973,7 +953,7 @@ test_pre_post_fixes(nvobj::pool<root> &pop)
 	}
 
 	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_string>(r->radix_str);
+		nvobj::delete_persistent<cntr_string>(r->radix_str);
 	});
 
 	UT_ASSERTeq(num_allocs(pop), 0);
@@ -987,7 +967,7 @@ test_assign_inline_string(nvobj::pool<root> &pop)
 	auto r = pop.root();
 
 	nvobj::transaction::run(pop, [&] {
-		r->radix_str = nvobj::make_persistent<container_string>();
+		r->radix_str = nvobj::make_persistent<cntr_string>();
 		r->radix_str->try_emplace("key", test_value);
 	});
 
@@ -1002,7 +982,7 @@ test_assign_inline_string(nvobj::pool<root> &pop)
 		    0);
 
 	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_string>(r->radix_str);
+		nvobj::delete_persistent<cntr_string>(r->radix_str);
 	});
 
 	UT_ASSERTeq(num_allocs(pop), 0);
@@ -1016,7 +996,7 @@ test_inline_string_u8t_key(nvobj::pool<root> &pop)
 
 	nvobj::transaction::run(pop, [&] {
 		r->radix_inline_s_u8t =
-			nvobj::make_persistent<container_inline_s_u8t>();
+			nvobj::make_persistent<cntr_inline_s_u8t>();
 	});
 	auto &m = *r->radix_inline_s_u8t;
 
@@ -1056,7 +1036,7 @@ test_inline_string_u8t_key(nvobj::pool<root> &pop)
 	UT_ASSERT(it->value() == std::basic_string<uint8_t>({uint8_t(7)}));
 
 	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_inline_s_u8t>(
+		nvobj::delete_persistent<cntr_inline_s_u8t>(
 			r->radix_inline_s_u8t);
 	});
 
@@ -1070,7 +1050,7 @@ test_inline_string_wchart_key(nvobj::pool<root> &pop)
 
 	nvobj::transaction::run(pop, [&] {
 		r->radix_inline_s_wchart =
-			nvobj::make_persistent<container_inline_s_wchart>();
+			nvobj::make_persistent<cntr_inline_s_wchart>();
 	});
 	auto &m = *r->radix_inline_s_wchart;
 
@@ -1100,7 +1080,7 @@ test_inline_string_wchart_key(nvobj::pool<root> &pop)
 	UT_ASSERTeq(m.size(), 0);
 
 	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_inline_s_wchart>(
+		nvobj::delete_persistent<cntr_inline_s_wchart>(
 			r->radix_inline_s_wchart);
 	});
 
@@ -1114,7 +1094,7 @@ test_remove_inserted(nvobj::pool<root> &pop)
 	auto r = pop.root();
 
 	nvobj::transaction::run(pop, [&] {
-		r->radix_str = nvobj::make_persistent<container_string>();
+		r->radix_str = nvobj::make_persistent<cntr_string>();
 	});
 
 	/* remove element which was just inserted */
@@ -1149,7 +1129,7 @@ test_remove_inserted(nvobj::pool<root> &pop)
 	UT_ASSERTeq(r->radix_str->size(), 0);
 
 	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_string>(r->radix_str);
+		nvobj::delete_persistent<cntr_string>(r->radix_str);
 	});
 
 	UT_ASSERTeq(num_allocs(pop), 0);
@@ -1161,7 +1141,7 @@ test_error_handle(nvobj::pool<root> &pop)
 	auto r = pop.root();
 
 	try {
-		r->radix_str = nvobj::make_persistent<container_string>();
+		r->radix_str = nvobj::make_persistent<cntr_string>();
 	} catch (pmem::transaction_scope_error &tse) {
 	} catch (...) {
 		UT_ASSERT(0);

--- a/tests/radix_tree/radix_basic.cpp
+++ b/tests/radix_tree/radix_basic.cpp
@@ -1,16 +1,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2020-2021, Intel Corporation */
 
-#include "radix.hpp"
-
 #include <algorithm>
-#include <random>
+#include <sstream>
 #include <unordered_map>
 #include <unordered_set>
 
-#include <sstream>
-
-static std::mt19937_64 generator;
+#include "radix.hpp"
 
 void
 test_iterators(nvobj::pool<root> &pop)
@@ -37,8 +33,9 @@ test_iterators(nvobj::pool<root> &pop)
 		r->radix_str->try_emplace("b", "b");
 	});
 
+	/* Test int keys. */
 	auto it = r->radix_int->find("a");
-	UT_ASSERT(nvobj::string_view(it->key()).compare(std::string("a")) == 0);
+	UT_ASSERTeq(nvobj::string_view(it->key()).compare(std::string("a")), 0);
 	UT_ASSERTeq(it->value(), 3);
 
 	++it;
@@ -47,7 +44,7 @@ test_iterators(nvobj::pool<root> &pop)
 	UT_ASSERTeq(it->value(), 1);
 
 	++it;
-	UT_ASSERT(nvobj::string_view(it->key()).compare(std::string("b")) == 0);
+	UT_ASSERTeq(nvobj::string_view(it->key()).compare(std::string("b")), 0);
 	UT_ASSERTeq(it->value(), 4);
 
 	++it;
@@ -55,59 +52,68 @@ test_iterators(nvobj::pool<root> &pop)
 		  0);
 	UT_ASSERTeq(it->value(), 2);
 
+	++it;
+	UT_ASSERT(it == r->radix_int->end());
 	--it;
-	UT_ASSERT(nvobj::string_view(it->key()).compare(std::string("b")) == 0);
+
+	--it;
+	UT_ASSERTeq(nvobj::string_view(it->key()).compare(std::string("b")), 0);
 	UT_ASSERTeq(it->value(), 4);
 
 	--it;
-	UT_ASSERT(nvobj::string_view(it->key()).compare(std::string("ab")) ==
-		  0);
+	UT_ASSERTeq(nvobj::string_view(it->key()).compare(std::string("ab")),
+		    0);
 	UT_ASSERTeq(it->value(), 1);
 
 	--it;
-	UT_ASSERT(nvobj::string_view(it->key()).compare(std::string("a")) == 0);
+	UT_ASSERTeq(nvobj::string_view(it->key()).compare(std::string("a")), 0);
 	UT_ASSERTeq(it->value(), 3);
 
 	--it;
-	UT_ASSERT(nvobj::string_view(it->key()).compare(std::string("")) == 0);
+	UT_ASSERTeq(nvobj::string_view(it->key()).compare(std::string("")), 0);
 	UT_ASSERTeq(it->value(), 0);
+	UT_ASSERT(it == r->radix_int->begin());
 
 	it = r->radix_int->erase(it);
-	UT_ASSERT(nvobj::string_view(it->key()).compare(std::string("a")) == 0);
+	UT_ASSERTeq(nvobj::string_view(it->key()).compare(std::string("a")), 0);
 	UT_ASSERTeq(it->value(), 3);
+	UT_ASSERT(it == r->radix_int->begin());
 
 	(*it).value() = 4;
-	UT_ASSERT(nvobj::string_view(it->key()).compare(std::string("a")) == 0);
+	UT_ASSERTeq(nvobj::string_view(it->key()).compare(std::string("a")), 0);
 	UT_ASSERTeq(it->value(), 4);
 
 	it = r->radix_int->lower_bound("b");
-	UT_ASSERT(nvobj::string_view(it->key()).compare(std::string("b")) == 0);
+	UT_ASSERTeq(nvobj::string_view(it->key()).compare(std::string("b")), 0);
 
 	it = r->radix_int->lower_bound("aa");
-	UT_ASSERT(nvobj::string_view(it->key()).compare(std::string("ab")) ==
-		  0);
+	UT_ASSERTeq(nvobj::string_view(it->key()).compare(std::string("ab")),
+		    0);
 
+	/* Test string keys. */
 	auto it2 = r->radix_str->find("");
 
 	it2 = r->radix_str->lower_bound("aa");
 	auto it3 = it2;
 	it2.assign_val("xx");
 
-	UT_ASSERT(nvobj::string_view(it2->value()).compare("xx") == 0);
-	UT_ASSERT(nvobj::string_view(it3->value()).compare("xx") == 0);
+	UT_ASSERTeq(nvobj::string_view(it2->value()).compare("xx"), 0);
+	UT_ASSERTeq(nvobj::string_view(it3->value()).compare("xx"), 0);
 
 	auto long_string = std::string(1024, 'x');
 	/* The previous assignment should not invalidate the iterator. */
 	it2.assign_val(long_string);
 
-	UT_ASSERT(nvobj::string_view(it2->value()).compare(long_string) == 0);
+	UT_ASSERTeq(nvobj::string_view(it2->value()).compare(long_string), 0);
 
-	UT_ASSERT(nvobj::string_view(r->radix_str->lower_bound("aa")->value())
-			  .compare(long_string) == 0);
+	UT_ASSERTeq(nvobj::string_view(r->radix_str->lower_bound("aa")->value())
+			    .compare(long_string),
+		    0);
 
 	UT_ASSERT(r->radix_str->find("") != r->radix_str->end());
+	UT_ASSERT(r->radix_str->find("") == r->radix_str->begin());
 	UT_ASSERT(r->radix_str->find(" ") != r->radix_str->end());
-	UT_ASSERT(r->radix_str->find(" ") != r->radix_str->end());
+	UT_ASSERT(r->radix_str->find("  ") != r->radix_str->end());
 
 	/* Verify operator<< compiles. */
 	std::stringstream ss;
@@ -139,13 +145,15 @@ test_ref_stability(nvobj::pool<root> &pop)
 		auto &acxxxz_ref =
 			*r->radix_str->emplace("acxxxz", "acxxxz").first;
 
-		UT_ASSERT(nvobj::string_view(ab_ref.value()).compare("ab") ==
-			  0);
-		UT_ASSERT(nvobj::string_view(a_ref.value()).compare("a") == 0);
-		UT_ASSERT(nvobj::string_view(acxxxy_ref.value())
-				  .compare("acxxxy") == 0);
-		UT_ASSERT(nvobj::string_view(acxxxz_ref.value())
-				  .compare("acxxxz") == 0);
+		UT_ASSERTeq(nvobj::string_view(ab_ref.value()).compare("ab"),
+			    0);
+		UT_ASSERTeq(nvobj::string_view(a_ref.value()).compare("a"), 0);
+		UT_ASSERTeq(nvobj::string_view(acxxxy_ref.value())
+				    .compare("acxxxy"),
+			    0);
+		UT_ASSERTeq(nvobj::string_view(acxxxz_ref.value())
+				    .compare("acxxxz"),
+			    0);
 	}
 
 	{
@@ -154,16 +162,18 @@ test_ref_stability(nvobj::pool<root> &pop)
 		auto &acxxxy_ref = *r->radix_int->emplace("acxxxy", 3U).first;
 		auto &acxxxz_ref = *r->radix_int->emplace("acxxxz", 4U).first;
 
-		UT_ASSERT(ab_ref.value() == 1U);
-		UT_ASSERT(a_ref.value() == 2U);
-		UT_ASSERT(acxxxy_ref.value() == 3U);
-		UT_ASSERT(acxxxz_ref.value() == 4U);
+		UT_ASSERTeq(ab_ref.value(), 1U);
+		UT_ASSERTeq(a_ref.value(), 2U);
+		UT_ASSERTeq(acxxxy_ref.value(), 3U);
+		UT_ASSERTeq(acxxxz_ref.value(), 4U);
 	}
 
 	nvobj::transaction::run(pop, [&] {
 		nvobj::delete_persistent<container_string>(r->radix_str);
 		nvobj::delete_persistent<container_int>(r->radix_int);
 	});
+
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 /* Tests some corner cases (not covered by libcxx find/bound tests). */
@@ -221,6 +231,10 @@ test_find(nvobj::pool<root> &pop)
 			  r->radix_str->end());
 		UT_ASSERT(r->radix_str->upper_bound("acyyy") ==
 			  r->radix_str->end());
+		UT_ASSERT(r->radix_str->lower_bound("acy") ==
+			  r->radix_str->end());
+		UT_ASSERT(r->radix_str->upper_bound("acy") ==
+			  r->radix_str->end());
 
 		/* Look for key which shares some common part with leafs but
 		 * differs on compressed bytes. */
@@ -236,6 +250,10 @@ test_find(nvobj::pool<root> &pop)
 			  r->radix_str->find("acxxxy"));
 		UT_ASSERT(r->radix_str->upper_bound("acxxa") ==
 			  r->radix_str->find("acxxxy"));
+		UT_ASSERT(r->radix_str->lower_bound("acxxyy") ==
+			  r->radix_str->end());
+		UT_ASSERT(r->radix_str->upper_bound("acxxyy") ==
+			  r->radix_str->end());
 		UT_ASSERT(r->radix_str->lower_bound("acaaa") ==
 			  r->radix_str->find("acxxxy"));
 		UT_ASSERT(r->radix_str->upper_bound("acaaa") ==
@@ -250,6 +268,10 @@ test_find(nvobj::pool<root> &pop)
 		UT_ASSERT(r->radix_str->lower_bound("acyyy") ==
 			  r->radix_str->find("ad"));
 		UT_ASSERT(r->radix_str->upper_bound("acyyy") ==
+			  r->radix_str->find("ad"));
+		UT_ASSERT(r->radix_str->lower_bound("acxxzy") ==
+			  r->radix_str->find("ad"));
+		UT_ASSERT(r->radix_str->upper_bound("acxxzy") ==
 			  r->radix_str->find("ad"));
 		UT_ASSERT(r->radix_str->lower_bound("acxxxzz") ==
 			  r->radix_str->find("ad"));
@@ -279,10 +301,24 @@ test_find(nvobj::pool<root> &pop)
 			  r->radix_str->find("bccc"));
 		UT_ASSERT(r->radix_str->upper_bound("baaaba") ==
 			  r->radix_str->find("bccc"));
+		UT_ASSERT(r->radix_str->lower_bound("aaaaaaaaa") ==
+			  r->radix_str->find("bccc"));
+		UT_ASSERT(r->radix_str->upper_bound("aaaaaaaaa") ==
+			  r->radix_str->find("bccc"));
 		UT_ASSERT(r->radix_str->lower_bound("ba") ==
 			  r->radix_str->find("bccc"));
 		UT_ASSERT(r->radix_str->upper_bound("ba") ==
 			  r->radix_str->find("bccc"));
+		UT_ASSERT(r->radix_str->lower_bound("bcca") ==
+			  r->radix_str->find("bccc"));
+		UT_ASSERT(r->radix_str->upper_bound("bcca") ==
+			  r->radix_str->find("bccc"));
+		UT_ASSERT(r->radix_str->upper_bound("bccc") ==
+			  r->radix_str->find("bccca"));
+		UT_ASSERT(r->radix_str->lower_bound("bccd") ==
+			  r->radix_str->end());
+		UT_ASSERT(r->radix_str->upper_bound("bccd") ==
+			  r->radix_str->end());
 		UT_ASSERT(r->radix_str->lower_bound("b") ==
 			  r->radix_str->find("bccc"));
 		UT_ASSERT(r->radix_str->upper_bound("b") ==
@@ -317,17 +353,17 @@ test_find(nvobj::pool<root> &pop)
 		auto lb = r->radix_str->lower_bound("");
 		auto ub = r->radix_str->upper_bound("@@@@");
 
-		UT_ASSERT(std::distance(lb, ub) == 0);
+		UT_ASSERTeq(std::distance(lb, ub), 0);
 
 		lb = r->radix_str->lower_bound("");
 		ub = r->radix_str->upper_bound("ZZZZ");
 
-		UT_ASSERT(std::distance(lb, ub) == 7);
+		UT_ASSERTeq(std::distance(lb, ub), 7);
 
 		lb = r->radix_str->lower_bound("");
 		ub = r->radix_str->upper_bound("ZZZZ");
 
-		UT_ASSERT(std::distance(lb, ub) == 7);
+		UT_ASSERTeq(std::distance(lb, ub), 7);
 		r->radix_str->clear();
 
 		r->radix_str->try_emplace("A", "1");
@@ -341,12 +377,12 @@ test_find(nvobj::pool<root> &pop)
 		lb = r->radix_str->lower_bound("");
 		ub = r->radix_str->upper_bound("CCCC");
 
-		UT_ASSERT(std::distance(lb, ub) == 7);
+		UT_ASSERTeq(std::distance(lb, ub), 7);
 
 		lb = r->radix_str->lower_bound("");
 		ub = r->radix_str->upper_bound("ZZZZ");
 
-		UT_ASSERT(std::distance(lb, ub) == 7);
+		UT_ASSERTeq(std::distance(lb, ub), 7);
 		r->radix_str->clear();
 
 		r->radix_str->try_emplace("A", "1");
@@ -360,7 +396,7 @@ test_find(nvobj::pool<root> &pop)
 		lb = r->radix_str->lower_bound("");
 		ub = r->radix_str->upper_bound("BB");
 
-		UT_ASSERT(std::distance(lb, ub) == 3);
+		UT_ASSERTeq(std::distance(lb, ub), 3);
 		r->radix_str->clear();
 
 		r->radix_str->try_emplace("A", "1");
@@ -374,7 +410,7 @@ test_find(nvobj::pool<root> &pop)
 		lb = r->radix_str->lower_bound("");
 		ub = r->radix_str->upper_bound("@@@@");
 
-		UT_ASSERT(std::distance(lb, ub) == 0);
+		UT_ASSERTeq(std::distance(lb, ub), 0);
 
 		char ch[] = {char((15 << 4)), 0};
 		r->radix_str->try_emplace(ch, "8");
@@ -382,7 +418,7 @@ test_find(nvobj::pool<root> &pop)
 		lb = r->radix_str->lower_bound("");
 		ub = r->radix_str->upper_bound("@@@@");
 
-		UT_ASSERT(std::distance(lb, ub) == 0);
+		UT_ASSERTeq(std::distance(lb, ub), 0);
 
 		char last_slot[] = {char((15 << 4) | 15), 0};
 		lb = r->radix_str->lower_bound("");
@@ -436,8 +472,7 @@ test_find(nvobj::pool<root> &pop)
 		UT_ASSERTeq(num_allocs(pop), 0);
 	}
 
-	/* Upper bound when there are multiple less elements with common prefix
-	 */
+	/* *_bound when there are multiple lesser elements with common prefix */
 	{
 		nvobj::transaction::run(pop, [&] {
 			r->radix_str =
@@ -449,8 +484,21 @@ test_find(nvobj::pool<root> &pop)
 		r->radix_str->try_emplace("in3", "");
 		r->radix_str->try_emplace("in4", "");
 
-		auto ub = r->radix_str->upper_bound("in6");
-		UT_ASSERT(ub == r->radix_str->end());
+		auto it = r->radix_str->upper_bound("in6");
+		UT_ASSERT(it == r->radix_str->end());
+
+		it = r->radix_str->lower_bound("in6");
+		UT_ASSERT(it == r->radix_str->end());
+
+		r->radix_str->try_emplace("in5", "");
+		r->radix_str->try_emplace("in6", "");
+		r->radix_str->try_emplace("in7", "");
+
+		it = r->radix_str->upper_bound("in9");
+		UT_ASSERT(it == r->radix_str->end());
+
+		it = r->radix_str->lower_bound("in9");
+		UT_ASSERT(it == r->radix_str->end());
 
 		nvobj::transaction::run(pop, [&] {
 			nvobj::delete_persistent<container_string>(
@@ -460,7 +508,7 @@ test_find(nvobj::pool<root> &pop)
 		UT_ASSERTeq(num_allocs(pop), 0);
 	}
 
-	/* Upper bound when there is single, less element */
+	/* *_bound when there is a single lesser element */
 	{
 		nvobj::transaction::run(pop, [&] {
 			r->radix_str =
@@ -469,8 +517,11 @@ test_find(nvobj::pool<root> &pop)
 
 		r->radix_str->try_emplace("in", "");
 
-		auto ub = r->radix_str->upper_bound("inA");
-		UT_ASSERT(ub == r->radix_str->end());
+		auto it = r->radix_str->upper_bound("inA");
+		UT_ASSERT(it == r->radix_str->end());
+
+		it = r->radix_str->lower_bound("inA");
+		UT_ASSERT(it == r->radix_str->end());
 
 		nvobj::transaction::run(pop, [&] {
 			nvobj::delete_persistent<container_string>(
@@ -512,7 +563,7 @@ verify_bounds(nvobj::persistent_ptr<container_string> ptr,
 	      const std::vector<std::string> &keys)
 {
 	for (size_t i = 0; i < keys.size() - 1; i++) {
-		/* generate key k for which k < keys[i] && k >= keys[i - 1] */
+		/* generate key k, where: k < keys[i] && k > keys[i - 1] */
 		auto k = keys[i];
 		k[k.size() - 1]--;
 
@@ -620,54 +671,134 @@ test_erase(nvobj::pool<root> &pop)
 {
 	auto r = pop.root();
 
-	nvobj::transaction::run(pop, [&] {
-		r->radix_str = nvobj::make_persistent<container_string>();
-	});
+	{
+		nvobj::transaction::run(pop, [&] {
+			r->radix_str =
+				nvobj::make_persistent<container_string>();
+		});
 
-	std::unordered_set<std::string> set = {"b", "acxxx", "acxxxa",
-					       "acxxx!"};
+		std::unordered_set<std::string> set = {
+			"b", "ab", "acxxa", "acxxx", "acxxxa", "acxxx!"};
 
-	/* Used for testing iterator stability. */
-	std::unordered_map<std::string, typename container_string::iterator>
-		its;
-
-	for (auto &s : set) {
-		auto ret = r->radix_str->emplace(s, s);
-		UT_ASSERT(ret.second);
-		its.emplace(s, ret.first);
-	}
-
-	auto erase = [&](std::string key) {
-		UT_ASSERT(r->radix_str->erase(key) == 1);
-		set.erase(key);
+		/* Used for testing iterator stability. */
+		std::unordered_map<std::string,
+				   typename container_string::iterator>
+			its;
 
 		for (auto &s : set) {
-			auto it = r->radix_str->find(s);
-			UT_ASSERT(it != r->radix_str->end());
-			UT_ASSERT(nvobj::string_view(it->value()).compare(s) ==
-				  0);
-
-			auto &m_it = its.find(s)->second;
-			UT_ASSERT(nvobj::string_view(m_it->key()).compare(s) ==
-				  0);
-			UT_ASSERT(
-				nvobj::string_view(m_it->value()).compare(s) ==
-				0);
+			auto ret = r->radix_str->emplace(s, s);
+			UT_ASSERT(ret.second);
+			its.emplace(s, ret.first);
 		}
-	};
 
-	erase("acxxxa");
-	erase("acxxx!");
-	erase("acxxx");
-	erase("b");
+		auto erase_one = [&](std::string key) {
+			UT_ASSERTeq(r->radix_str->erase(key), 1);
+			set.erase(key);
 
-	UT_ASSERT(r->radix_str->size() == 0);
+			for (auto &s : set) {
+				auto it = r->radix_str->find(s);
+				UT_ASSERT(it != r->radix_str->end());
+				UT_ASSERTeq(nvobj::string_view(it->value())
+						    .compare(s),
+					    0);
 
-	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_string>(r->radix_str);
-	});
+				auto &m_it = its.find(s)->second;
+				UT_ASSERTeq(nvobj::string_view(m_it->key())
+						    .compare(s),
+					    0);
+				UT_ASSERTeq(nvobj::string_view(m_it->value())
+						    .compare(s),
+					    0);
+			}
+		};
 
-	UT_ASSERTeq(num_allocs(pop), 0);
+		UT_ASSERTeq(r->radix_str->erase("ac"), 0);
+		erase_one("acxxxa");
+		UT_ASSERTeq(r->radix_str->erase("acxxxa"), 0);
+		erase_one("acxxa");
+		erase_one("acxxx!");
+		erase_one("ab");
+		erase_one("acxxx");
+		erase_one("b");
+		UT_ASSERTeq(r->radix_str->erase("acxxa"), 0);
+
+		UT_ASSERTeq(r->radix_str->size(), 0);
+
+		nvobj::transaction::run(pop, [&] {
+			nvobj::delete_persistent<container_string>(
+				r->radix_str);
+		});
+
+		UT_ASSERTeq(num_allocs(pop), 0);
+	}
+
+	{
+		nvobj::transaction::run(pop, [&] {
+			r->radix_str =
+				nvobj::make_persistent<container_string>();
+		});
+
+		std::vector<std::string> elements = {
+			"",	 "acxxx!", "b",	     "ab",
+			"acxxa", "acxxx",  "acxxxa", "x",
+		};
+		size_t value_size = 8;
+		for (auto &e : elements) {
+			std::string value = std::string(value_size, '.');
+			value_size *= 2;
+			auto ret = r->radix_str->emplace(e, value);
+			UT_ASSERT(ret.second);
+		}
+
+		/* sort them, to always remove first element;
+		 * iterate on all left elements from front to back */
+		std::vector<std::string> sorted = elements;
+		std::sort(sorted.begin(), sorted.end());
+
+		for (auto i = elements.size(); i >= 1; --i) {
+			auto it = r->radix_str->erase(
+				r->radix_str->find(sorted.front()));
+			auto it_v = sorted.erase(sorted.begin());
+			UT_ASSERT(it == r->radix_str->begin());
+			while (it != r->radix_str->end()) {
+				UT_ASSERT(nvobj::string_view(it->key()) ==
+					  *it_v);
+				++it;
+				++it_v;
+			}
+		}
+
+		/* set and sort them again, to always remove last element;
+		 * iterate on all left elements from back to front */
+		for (auto &e : elements) {
+			auto ret = r->radix_str->emplace(e, e);
+			UT_ASSERT(ret.second);
+		}
+		sorted = elements;
+		std::sort(sorted.begin(), sorted.end());
+
+		for (auto i = elements.size(); i >= 1; --i) {
+			auto it = r->radix_str->erase(
+				r->radix_str->find(sorted.back()));
+			auto it_v = sorted.erase(--sorted.end());
+			UT_ASSERT(it == r->radix_str->end());
+			while (it != r->radix_str->begin()) {
+				--it;
+				--it_v;
+				UT_ASSERT(nvobj::string_view(it->key()) ==
+					  *it_v);
+			}
+		}
+
+		UT_ASSERTeq(r->radix_str->size(), 0);
+
+		nvobj::transaction::run(pop, [&] {
+			nvobj::delete_persistent<container_string>(
+				r->radix_str);
+		});
+
+		UT_ASSERTeq(num_allocs(pop), 0);
+	}
 }
 
 /* This test inserts elements in range [0:2:2 * numeric_limits<uint16_t>::max()]
@@ -773,7 +904,7 @@ test_binary_keys(nvobj::pool<root> &pop)
 void
 test_pre_post_fixes(nvobj::pool<root> &pop)
 {
-	auto num_elements = (1U << 10);
+	size_t num_elements = (1U << 10);
 
 	std::vector<std::string> elements;
 	elements.reserve(num_elements);
@@ -788,7 +919,7 @@ test_pre_post_fixes(nvobj::pool<root> &pop)
 	 * elements[i + 1] and they differ only by 4 bits:
 	 * '0xA0', '0xA0 0xAB', '0xA0 0xAB 0xC0', '0xA0 0xAB 0xC0 0xCD'
 	 */
-	for (unsigned i = 1; i < num_elements * 2; i++) {
+	for (size_t i = 1; i < num_elements * 2; i++) {
 		if (i % 2 == 0)
 			elements.push_back(
 				elements.back() +
@@ -814,7 +945,7 @@ test_pre_post_fixes(nvobj::pool<root> &pop)
 		r->radix_str = nvobj::make_persistent<container_string>();
 	});
 
-	for (unsigned i = elements.size(); i > 0; i--) {
+	for (size_t i = elements.size(); i > 0; i--) {
 		auto ret =
 			r->radix_str->emplace(elements[i - 1], elements[i - 1]);
 		if (ret.second)
@@ -824,19 +955,21 @@ test_pre_post_fixes(nvobj::pool<root> &pop)
 	verify_bounds(r->radix_str, s_elements);
 
 	UT_ASSERTeq(r->radix_str->size(), num_elements);
-	unsigned i = 0;
+	size_t i = 0;
 	for (auto it = r->radix_str->begin(); it != r->radix_str->end();
 	     ++it, ++i) {
 		UT_ASSERT(nvobj::string_view(it->key()) == s_elements[i]);
 	}
 
 	/* Used for testing iterator stability. */
-	for (unsigned i = num_elements; i > 0; i--) {
+	for (size_t i = num_elements; i > 0; i--) {
 		auto &it = its.find(s_elements[i - 1])->second;
-		UT_ASSERT(nvobj::string_view(it->key()).compare(
-				  s_elements[i - 1]) == 0);
-		UT_ASSERT(nvobj::string_view(it->value())
-				  .compare(s_elements[i - 1]) == 0);
+		UT_ASSERTeq(nvobj::string_view(it->key()).compare(
+				    s_elements[i - 1]),
+			    0);
+		UT_ASSERTeq(nvobj::string_view(it->value())
+				    .compare(s_elements[i - 1]),
+			    0);
 	}
 
 	nvobj::transaction::run(pop, [&] {
@@ -864,8 +997,9 @@ test_assign_inline_string(nvobj::pool<root> &pop)
 		r->radix_str->find("key").assign_val(new_value);
 	}
 
-	UT_ASSERT(nvobj::string_view(r->radix_str->find("key")->value())
-			  .compare(new_value) == 0);
+	UT_ASSERTeq(nvobj::string_view(r->radix_str->find("key")->value())
+			    .compare(new_value),
+		    0);
 
 	nvobj::transaction::run(pop, [&] {
 		nvobj::delete_persistent<container_string>(r->radix_str);
@@ -877,6 +1011,7 @@ test_assign_inline_string(nvobj::pool<root> &pop)
 void
 test_inline_string_u8t_key(nvobj::pool<root> &pop)
 {
+	const size_t NUM_ITER = 10;
 	auto r = pop.root();
 
 	nvobj::transaction::run(pop, [&] {
@@ -885,38 +1020,39 @@ test_inline_string_u8t_key(nvobj::pool<root> &pop)
 	});
 	auto &m = *r->radix_inline_s_u8t;
 
-	UT_ASSERT(m.size() == 0);
+	UT_ASSERTeq(m.size(), 0);
 
-	for (unsigned i = 0; i < 10; i++) {
+	for (size_t i = 0; i < NUM_ITER; i++) {
 		auto key = std::basic_string<uint8_t>(i + 10, 99);
 		auto ret = m.try_emplace(
 			key, std::basic_string<uint8_t>({uint8_t(i)}));
 		UT_ASSERT(ret.second);
-		UT_ASSERT(key.compare(ret.first->key().data()) == 0);
+		UT_ASSERTeq(key.compare(ret.first->key().data()), 0);
 		UT_ASSERT(ret.first->value() ==
 			  std::basic_string<uint8_t>({uint8_t(i)}));
-		UT_ASSERT(m.size() == i + 1);
+		UT_ASSERTeq(m.size(), i + 1);
 	}
 
-	for (unsigned i = 0; i < 10; i++) {
+	for (size_t i = 0; i < NUM_ITER; i++) {
 		auto key = std::basic_string<uint8_t>(i + 10, 99);
 		auto ret = m.insert_or_assign(
 			key, std::basic_string<uint8_t>({uint8_t(i + 1)}));
 		UT_ASSERT(!ret.second);
-		UT_ASSERT(key.compare(ret.first->key().data()) == 0);
+		UT_ASSERTeq(key.compare(ret.first->key().data()), 0);
 		UT_ASSERT(ret.first->value() ==
 			  std::basic_string<uint8_t>({uint8_t(i + 1)}));
-		UT_ASSERT(m.size() == 10);
+		UT_ASSERTeq(m.size(), NUM_ITER);
 	}
 
 	auto key = std::basic_string<uint8_t>(15, 99);
 	auto it = m.find(key);
-	UT_ASSERT(key.compare(it->key().data()) == 0);
+	UT_ASSERTeq(key.compare(it->key().data()), 0);
 	UT_ASSERT(it->value() == std::basic_string<uint8_t>({uint8_t(6)}));
 
 	it = m.erase(it);
-	UT_ASSERT(std::basic_string<uint8_t>(16, 99).compare(
-			  it->key().data()) == 0);
+	UT_ASSERTeq(
+		std::basic_string<uint8_t>(16, 99).compare(it->key().data()),
+		0);
 	UT_ASSERT(it->value() == std::basic_string<uint8_t>({uint8_t(7)}));
 
 	nvobj::transaction::run(pop, [&] {
@@ -938,39 +1074,43 @@ test_inline_string_wchart_key(nvobj::pool<root> &pop)
 	});
 	auto &m = *r->radix_inline_s_wchart;
 
-	UT_ASSERT(m.size() == 0);
+	UT_ASSERTeq(m.size(), 0);
 
 	auto key1 = std::basic_string<wchar_t>(1, 256);
 	auto key2 = std::basic_string<wchar_t>(1, 0);
 	m.try_emplace(key1, 256U);
 	m.try_emplace(key2, 0U);
-	UT_ASSERT(m.size() == 2);
+	UT_ASSERTeq(m.size(), 2);
 	auto it = m.find(key1);
-	UT_ASSERT(it->value() == 256U);
+	UT_ASSERTeq(it->value(), 256U);
 	it = m.find(key2);
-	UT_ASSERT(it->value() == 0U);
+	UT_ASSERTeq(it->value(), 0U);
 
 	key1 = std::basic_string<wchar_t>(10, 257);
 	key2 = std::basic_string<wchar_t>(10, 1);
 	m.try_emplace(key1, 999U);
 	m.try_emplace(key2, 100U);
-	UT_ASSERT(m.size() == 4);
+	UT_ASSERTeq(m.size(), 4);
 	it = m.find(key1);
-	UT_ASSERT(it->value() == 999U);
+	UT_ASSERTeq(it->value(), 999U);
 	it = m.find(key2);
-	UT_ASSERT(it->value() == 100U);
+	UT_ASSERTeq(it->value(), 100U);
+
+	r->radix_inline_s_wchart->clear();
+	UT_ASSERTeq(m.size(), 0);
 
 	nvobj::transaction::run(pop, [&] {
 		nvobj::delete_persistent<container_inline_s_wchart>(
 			r->radix_inline_s_wchart);
 	});
+
+	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 void
 test_remove_inserted(nvobj::pool<root> &pop)
 {
 	const size_t NUM_ITER = 100;
-
 	auto r = pop.root();
 
 	nvobj::transaction::run(pop, [&] {
@@ -980,37 +1120,52 @@ test_remove_inserted(nvobj::pool<root> &pop)
 	/* remove element which was just inserted */
 	nvobj::transaction::run(pop, [&] {
 		for (size_t i = 0; i < NUM_ITER; i++) {
-			UT_ASSERT(r->radix_str
-					  ->emplace(std::to_string(i),
-						    std::to_string(i))
-					  .second);
-			UT_ASSERT(r->radix_str->erase(std::to_string(i)));
+			std::string i_str = std::to_string(i);
+			UT_ASSERT(!r->radix_str->erase(i_str));
+			UT_ASSERT(r->radix_str->emplace(i_str, i_str).second);
+			UT_ASSERT(r->radix_str->erase(i_str));
 		}
 	});
 
 	/* insert some initial elements */
 	nvobj::transaction::run(pop, [&] {
-		for (size_t i = 0; i < 5; i++)
-			UT_ASSERT(r->radix_str
-					  ->emplace("init" + std::to_string(i),
-						    std::to_string(i))
+		for (size_t i = 0; i < 5; i++) {
+			std::string i_str = std::to_string(i);
+			UT_ASSERT(r->radix_str->emplace("init" + i_str, i_str)
 					  .second);
+		}
 	});
 
 	/* remove element which was just inserted */
 	nvobj::transaction::run(pop, [&] {
 		for (size_t i = 0; i < NUM_ITER; i++) {
-			UT_ASSERT(r->radix_str
-					  ->emplace(std::to_string(i),
-						    std::to_string(i))
-					  .second);
-			UT_ASSERT(r->radix_str->erase(std::to_string(i)));
+			std::string i_str = std::to_string(i);
+			UT_ASSERT(r->radix_str->emplace(i_str, i_str).second);
+			UT_ASSERT(r->radix_str->erase(i_str));
 		}
 	});
+
+	r->radix_str->clear();
+	UT_ASSERTeq(r->radix_str->size(), 0);
 
 	nvobj::transaction::run(pop, [&] {
 		nvobj::delete_persistent<container_string>(r->radix_str);
 	});
+
+	UT_ASSERTeq(num_allocs(pop), 0);
+}
+
+void
+test_error_handle(nvobj::pool<root> &pop)
+{
+	auto r = pop.root();
+
+	try {
+		r->radix_str = nvobj::make_persistent<container_string>();
+	} catch (pmem::transaction_scope_error &tse) {
+	} catch (...) {
+		UT_ASSERT(0);
+	}
 
 	UT_ASSERTeq(num_allocs(pop), 0);
 }
@@ -1033,10 +1188,7 @@ test(int argc, char *argv[])
 		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
 
-	std::random_device rd;
-	auto seed = rd();
-	std::cout << "rand seed: " << seed << std::endl;
-	generator = std::mt19937_64(seed);
+	init_random();
 
 	test_ref_stability(pop);
 	test_iterators(pop);
@@ -1049,6 +1201,7 @@ test(int argc, char *argv[])
 	test_inline_string_u8t_key(pop);
 	test_inline_string_wchart_key(pop);
 	test_remove_inserted(pop);
+	test_error_handle(pop);
 
 	pop.close();
 }

--- a/tests/radix_tree/radix_concurrent.cpp
+++ b/tests/radix_tree/radix_concurrent.cpp
@@ -57,7 +57,7 @@ test_write_find(nvobj::pool<root> &pop, nvobj::persistent_ptr<Container> &ptr)
 /* this test only works with int as a key type */
 static void
 test_various_readers(nvobj::pool<root> &pop,
-		     nvobj::persistent_ptr<container_int_int_mt> &ptr)
+		     nvobj::persistent_ptr<cntr_int_int_mt> &ptr)
 {
 	size_t threads = 16;
 	if (On_drd)
@@ -72,38 +72,36 @@ test_various_readers(nvobj::pool<root> &pop,
 	auto readers = std::vector<std::function<void()>>{
 		[&]() {
 			for (size_t i = 0; i < INITIAL_ELEMENTS; ++i) {
-				auto res =
-					ptr->find(key<container_int_int_mt>(i));
+				auto res = ptr->find(key<cntr_int_int_mt>(i));
 				UT_ASSERT(res != ptr->end());
 				UT_ASSERT(res->value() ==
-					  value<container_int_int_mt>(i));
+					  value<cntr_int_int_mt>(i));
 			}
 		},
 		[&]() {
 			for (size_t i = 0; i < INITIAL_ELEMENTS; ++i) {
 				auto res = ptr->lower_bound(
-					key<container_int_int_mt>(i));
+					key<cntr_int_int_mt>(i));
 				UT_ASSERT(res != ptr->end());
 				UT_ASSERT(res->value() ==
-					  value<container_int_int_mt>(i));
+					  value<cntr_int_int_mt>(i));
 			}
 		},
 		[&]() {
 			for (size_t i = 0; i < INITIAL_ELEMENTS - 1; ++i) {
-				auto res = ptr->upper_bound(
-					key<container_int_int>(i));
+				auto res =
+					ptr->upper_bound(key<cntr_int_int>(i));
 				UT_ASSERT(res != ptr->end());
 				UT_ASSERT(res->value() ==
-					  value<container_int_int_mt>(i + 1));
+					  value<cntr_int_int_mt>(i + 1));
 			}
 		},
 	};
 
 	parallel_modify_read(writer, readers, threads);
 
-	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_int_int_mt>(ptr);
-	});
+	nvobj::transaction::run(
+		pop, [&] { nvobj::delete_persistent<cntr_int_int_mt>(ptr); });
 
 	UT_ASSERTeq(num_allocs(pop), 0);
 }

--- a/tests/radix_tree/radix_concurrent_erase.cpp
+++ b/tests/radix_tree/radix_concurrent_erase.cpp
@@ -14,7 +14,7 @@ static size_t INITIAL_ELEMENTS = 512;
  * erase all elements and read them from the other threads. */
 static void
 test_erase_find(nvobj::pool<root> &pop,
-		nvobj::persistent_ptr<container_string_mt> &ptr)
+		nvobj::persistent_ptr<cntr_string_mt> &ptr)
 {
 	const size_t value_repeats = 1000;
 	size_t threads = 4;
@@ -26,7 +26,7 @@ test_erase_find(nvobj::pool<root> &pop,
 
 	auto erase_f = [&] {
 		for (size_t i = 0; i < INITIAL_ELEMENTS; ++i) {
-			ptr->erase(key<container_string_mt>(i));
+			ptr->erase(key<cntr_string_mt>(i));
 			ptr->garbage_collect();
 		}
 	};
@@ -38,11 +38,11 @@ test_erase_find(nvobj::pool<root> &pop,
 			for (size_t i = 0; i < INITIAL_ELEMENTS; ++i) {
 				w.critical([&] {
 					auto res = ptr->find(
-						key<container_string_mt>(i));
+						key<cntr_string_mt>(i));
 					UT_ASSERT(
 						res == ptr->end() ||
 						res->value() ==
-							value<container_string_mt>(
+							value<cntr_string_mt>(
 								i,
 								value_repeats));
 				});
@@ -57,9 +57,8 @@ test_erase_find(nvobj::pool<root> &pop,
 
 	ptr->runtime_finalize_mt();
 
-	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_string_mt>(ptr);
-	});
+	nvobj::transaction::run(
+		pop, [&] { nvobj::delete_persistent<cntr_string_mt>(ptr); });
 
 	UT_ASSERTeq(num_allocs(pop), 0);
 }
@@ -71,7 +70,7 @@ test_erase_find(nvobj::pool<root> &pop,
  */
 // static void
 // test_erase_decrement(nvobj::pool<root> &pop,
-//		     nvobj::persistent_ptr<container_int_int_mt> &ptr)
+//		     nvobj::persistent_ptr<cntr_int_int_mt> &ptr)
 // {
 //	size_t threads = 4;
 //	if (On_drd)
@@ -92,7 +91,7 @@ test_erase_find(nvobj::pool<root> &pop,
 
 //	auto erase_f = [&] {
 //		for (size_t i = 0; i < to_erase.size(); ++i) {
-//			ptr->erase(key<container_int_int_mt>(to_erase[i]));
+//			ptr->erase(key<cntr_int_int_mt>(to_erase[i]));
 //			ptr->garbage_collect();
 //		}
 //	};
@@ -106,10 +105,10 @@ test_erase_find(nvobj::pool<root> &pop,
 //				for (int j = 0; j < 15; ++j) {
 //					w.critical([&] {
 //						auto k = key<
-//							container_int_int_mt>(
+//							cntr_int_int_mt>(
 //							i);
 //						auto v = value<
-//							container_int_int_mt>(
+//							cntr_int_int_mt>(
 //							i);
 //						auto it = ptr->find(k);
 //						UT_ASSERT(it == ptr->end() ||
@@ -135,7 +134,7 @@ test_erase_find(nvobj::pool<root> &pop,
 //	ptr->runtime_finalize_mt();
 
 //	nvobj::transaction::run(pop, [&] {
-//		nvobj::delete_persistent<container_int_int_mt>(ptr);
+//		nvobj::delete_persistent<cntr_int_int_mt>(ptr);
 //	});
 
 //	UT_ASSERTeq(num_allocs(pop), 0);
@@ -147,7 +146,7 @@ test_erase_find(nvobj::pool<root> &pop,
  */
 static void
 test_erase_increment(nvobj::pool<root> &pop,
-		     nvobj::persistent_ptr<container_int_int_mt> &ptr)
+		     nvobj::persistent_ptr<cntr_int_int_mt> &ptr)
 {
 	size_t threads = 4;
 	if (On_drd)
@@ -158,7 +157,7 @@ test_erase_increment(nvobj::pool<root> &pop,
 
 	auto erase_f = [&] {
 		for (size_t i = 0; i < INITIAL_ELEMENTS; ++i) {
-			ptr->erase(key<container_int_int_mt>(i));
+			ptr->erase(key<cntr_int_int_mt>(i));
 			ptr->garbage_collect();
 		}
 	};
@@ -170,8 +169,8 @@ test_erase_increment(nvobj::pool<root> &pop,
 			/* start one element ahead */
 			for (size_t i = 1; i < INITIAL_ELEMENTS - 1; ++i) {
 				w.critical([&] {
-					auto k = key<container_int_int_mt>(i);
-					auto v = value<container_int_int_mt>(i);
+					auto k = key<cntr_int_int_mt>(i);
+					auto v = value<cntr_int_int_mt>(i);
 					auto it = ptr->find(k);
 					UT_ASSERT(it == ptr->end() ||
 						  it->value() == v);
@@ -192,9 +191,8 @@ test_erase_increment(nvobj::pool<root> &pop,
 
 	ptr->runtime_finalize_mt();
 
-	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_int_int_mt>(ptr);
-	});
+	nvobj::transaction::run(
+		pop, [&] { nvobj::delete_persistent<cntr_int_int_mt>(ptr); });
 
 	UT_ASSERTeq(num_allocs(pop), 0);
 }
@@ -203,7 +201,7 @@ test_erase_increment(nvobj::pool<root> &pop,
  * Concurrently try to read this element from other threads */
 static void
 test_write_erase_find(nvobj::pool<root> &pop,
-		      nvobj::persistent_ptr<container_string_mt> &ptr)
+		      nvobj::persistent_ptr<cntr_string_mt> &ptr)
 {
 	const size_t value_repeats = 1000;
 	size_t threads = 8;
@@ -215,10 +213,9 @@ test_write_erase_find(nvobj::pool<root> &pop,
 
 	auto writer_f = [&] {
 		for (size_t i = 0; i < INITIAL_ELEMENTS; ++i) {
-			ptr->emplace(
-				key<container_string_mt>(0),
-				value<container_string_mt>(0, value_repeats));
-			ptr->erase(key<container_string_mt>(0));
+			ptr->emplace(key<cntr_string_mt>(0),
+				     value<cntr_string_mt>(0, value_repeats));
+			ptr->erase(key<cntr_string_mt>(0));
 			ptr->garbage_collect();
 		}
 	};
@@ -230,11 +227,11 @@ test_write_erase_find(nvobj::pool<root> &pop,
 			for (size_t i = 0; i < INITIAL_ELEMENTS; ++i) {
 				w.critical([&] {
 					auto res = ptr->find(
-						key<container_string_mt>(0));
+						key<cntr_string_mt>(0));
 					UT_ASSERT(
 						res == ptr->end() ||
 						res->value() ==
-							value<container_string_mt>(
+							value<cntr_string_mt>(
 								0,
 								value_repeats));
 				});
@@ -248,9 +245,8 @@ test_write_erase_find(nvobj::pool<root> &pop,
 
 	ptr->runtime_finalize_mt();
 
-	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_string_mt>(ptr);
-	});
+	nvobj::transaction::run(
+		pop, [&] { nvobj::delete_persistent<cntr_string_mt>(ptr); });
 
 	UT_ASSERTeq(num_allocs(pop), 0);
 }
@@ -261,7 +257,7 @@ test_write_erase_find(nvobj::pool<root> &pop,
  * deleting and reading elements */
 static void
 test_garbage_collection(nvobj::pool<root> &pop,
-			nvobj::persistent_ptr<container_string_mt> &ptr)
+			nvobj::persistent_ptr<cntr_string_mt> &ptr)
 {
 	const size_t value_repeats = 1000;
 	size_t threads = 8;
@@ -277,7 +273,7 @@ test_garbage_collection(nvobj::pool<root> &pop,
 		if (id == 0) {
 			/* deleter */
 			for (size_t i = 0; i < INITIAL_ELEMENTS; ++i) {
-				ptr->erase(key<container_string_mt>(i));
+				ptr->erase(key<cntr_string_mt>(i));
 
 				if (i % 50 == 0) {
 					syncthreads();
@@ -292,11 +288,11 @@ test_garbage_collection(nvobj::pool<root> &pop,
 			for (size_t i = 0; i < INITIAL_ELEMENTS; ++i) {
 				w.critical([&] {
 					auto res = ptr->find(
-						key<container_string_mt>(i));
+						key<cntr_string_mt>(i));
 					UT_ASSERT(
 						res == ptr->end() ||
 						res->value() ==
-							value<container_string_mt>(
+							value<cntr_string_mt>(
 								i,
 								value_repeats));
 				});
@@ -315,9 +311,8 @@ test_garbage_collection(nvobj::pool<root> &pop,
 
 	ptr->runtime_finalize_mt();
 
-	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_string_mt>(ptr);
-	});
+	nvobj::transaction::run(
+		pop, [&] { nvobj::delete_persistent<cntr_string_mt>(ptr); });
 
 	UT_ASSERTeq(num_allocs(pop), 0);
 }

--- a/tests/radix_tree/radix_concurrent_erase.cpp
+++ b/tests/radix_tree/radix_concurrent_erase.cpp
@@ -64,6 +64,141 @@ test_erase_find(nvobj::pool<root> &pop,
 	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
+/* operator-- does not work well when MtMode is enabled */
+
+/* Insert INITAL_ELEMENTS elements to the radix. After that concurrently try to
+ * erase some at the end and read them (and decrement) from the other threads.
+ */
+// static void
+// test_erase_decrement(nvobj::pool<root> &pop,
+//		     nvobj::persistent_ptr<container_int_int_mt> &ptr)
+// {
+//	size_t threads = 4;
+//	if (On_drd)
+//		threads = 2;
+
+//	init_container(pop, ptr, INITIAL_ELEMENTS);
+//	ptr->runtime_initialize_mt();
+
+//	std::vector<size_t> to_erase;
+
+//	/* order randomly elements to remove */
+//	auto it = ptr->begin();
+//	while (it != ptr->end()) {
+//		to_erase.emplace_back(it->key());
+//		++it;
+//	}
+//	std::shuffle(to_erase.begin(), to_erase.end(), generator);
+
+//	auto erase_f = [&] {
+//		for (size_t i = 0; i < to_erase.size(); ++i) {
+//			ptr->erase(key<container_int_int_mt>(to_erase[i]));
+//			ptr->garbage_collect();
+//		}
+//	};
+
+//	auto readers_f = std::vector<std::function<void()>>{
+//		[&] {
+//			auto w = ptr->register_worker();
+
+//			for (size_t i = INITIAL_ELEMENTS - 1; i > 1; --i) {
+//				/* reading is slower than erasing - repeat it */
+//				for (int j = 0; j < 15; ++j) {
+//					w.critical([&] {
+//						auto k = key<
+//							container_int_int_mt>(
+//							i);
+//						auto v = value<
+//							container_int_int_mt>(
+//							i);
+//						auto it = ptr->find(k);
+//						UT_ASSERT(it == ptr->end() ||
+//							  it->value() == v);
+//						if (it != ptr->end()) {
+//							auto prev = --it;
+//							if (prev != ptr->end())
+//								UT_ASSERT(
+//									prev->value()
+//									< v);
+//						}
+//					});
+//				}
+//			}
+//		},
+//	};
+
+//	parallel_modify_read(erase_f, readers_f, threads);
+
+//	ptr->garbage_collect_force();
+//	UT_ASSERT(num_allocs(pop) <= 5);
+
+//	ptr->runtime_finalize_mt();
+
+//	nvobj::transaction::run(pop, [&] {
+//		nvobj::delete_persistent<container_int_int_mt>(ptr);
+//	});
+
+//	UT_ASSERTeq(num_allocs(pop), 0);
+// }
+
+/* Insert INITAL_ELEMENTS elements to the radix. After that concurrently try to
+ * erase some at the beginning and read them (and increment) from the other
+ * threads.
+ */
+static void
+test_erase_increment(nvobj::pool<root> &pop,
+		     nvobj::persistent_ptr<container_int_int_mt> &ptr)
+{
+	size_t threads = 4;
+	if (On_drd)
+		threads = 2;
+
+	init_container(pop, ptr, INITIAL_ELEMENTS);
+	ptr->runtime_initialize_mt();
+
+	auto erase_f = [&] {
+		for (size_t i = 0; i < INITIAL_ELEMENTS; ++i) {
+			ptr->erase(key<container_int_int_mt>(i));
+			ptr->garbage_collect();
+		}
+	};
+
+	auto readers_f = std::vector<std::function<void()>>{
+		[&] {
+			auto w = ptr->register_worker();
+
+			/* start one element ahead */
+			for (size_t i = 1; i < INITIAL_ELEMENTS - 1; ++i) {
+				w.critical([&] {
+					auto k = key<container_int_int_mt>(i);
+					auto v = value<container_int_int_mt>(i);
+					auto it = ptr->find(k);
+					UT_ASSERT(it == ptr->end() ||
+						  it->value() == v);
+					if (it != ptr->end()) {
+						auto next = ++it;
+						UT_ASSERT(next != ptr->end());
+						UT_ASSERT(next->key() > k);
+					}
+				});
+			}
+		},
+	};
+
+	parallel_modify_read(erase_f, readers_f, threads);
+
+	ptr->garbage_collect_force();
+	UT_ASSERT(num_allocs(pop) <= 4);
+
+	ptr->runtime_finalize_mt();
+
+	nvobj::transaction::run(pop, [&] {
+		nvobj::delete_persistent<container_int_int_mt>(ptr);
+	});
+
+	UT_ASSERTeq(num_allocs(pop), 0);
+}
+
 /* Insert and erase the same element in loop for INITAL_ELEMENTS times.
  * Concurrently try to read this element from other threads */
 static void
@@ -206,6 +341,8 @@ test(int argc, char *argv[])
 	}
 
 	test_erase_find(pop, pop.root()->radix_str_mt);
+	// test_erase_decrement(pop, pop.root()->radix_int_int_mt);
+	test_erase_increment(pop, pop.root()->radix_int_int_mt);
 	test_write_erase_find(pop, pop.root()->radix_str_mt);
 	test_garbage_collection(pop, pop.root()->radix_str_mt);
 

--- a/tests/radix_tree/radix_concurrent_iterate.cpp
+++ b/tests/radix_tree/radix_concurrent_iterate.cpp
@@ -49,17 +49,21 @@ test_write_iterate(nvobj::pool<root> &pop,
 			}
 			UT_ASSERTeq(cnt, INITIAL_ELEMENTS);
 		},
-		[&]() {
-			size_t cnt = 0;
-			for (auto it = --ptr->end(); it != ptr->end(); --it) {
-				if (it->value() !=
-				    value<Container>(INITIAL_ELEMENTS)) {
-					++cnt;
-				}
-			}
+		/* XXX: it's disabled due to:
+		 * https://github.com/pmem/libpmemobj-cpp/issues/1159
+		 */
+		// [&]() {
+		//	size_t cnt = 0;
+		//	for (auto it = --ptr->end(); it != ptr->end(); --it) {
+		//		if (it->value() !=
+		//		    value<Container>(INITIAL_ELEMENTS)) {
+		//			++cnt;
+		//		}
+		//	}
 
-			UT_ASSERTeq(cnt, INITIAL_ELEMENTS);
-		}};
+		//	UT_ASSERTeq(cnt, INITIAL_ELEMENTS);
+		// }
+	};
 
 	parallel_modify_read(writer, readers, threads);
 
@@ -250,7 +254,7 @@ test_erase_upper_lower_bounds_neighbours(
 		std::find(middle_key.begin(), middle_key.end(), separator[0]),
 		middle_key.end());
 
-	auto last = ptr->rbegin();
+	auto last = std::next(ptr->begin(), static_cast<int>(ptr->size() - 1));
 	auto last_key = std::string(last->key().data(), last->key().size());
 	last_key.erase(
 		std::find(last_key.begin(), last_key.end(), separator[0]),
@@ -275,10 +279,14 @@ test_erase_upper_lower_bounds_neighbours(
 			auto &tmp = std::next(it)->key();
 			keys_to_erase.emplace_back(tmp.data(), tmp.size());
 		}
-		if (it != ptr->begin()) {
-			auto &tmp = std::prev(it)->key();
-			keys_to_erase.emplace_back(tmp.data(), tmp.size());
-		}
+
+		/* XXX: it's disabled due to:
+		 * https://github.com/pmem/libpmemobj-cpp/issues/1159
+		 */
+		// if (it != ptr->begin()) {
+		//	auto &tmp = std::prev(it)->key();
+		//	keys_to_erase.emplace_back(tmp.data(), tmp.size());
+		// }
 
 		std::shuffle(keys_to_erase.begin(), keys_to_erase.end(),
 			     generator);
@@ -295,31 +303,41 @@ test_erase_upper_lower_bounds_neighbours(
 
 					/* There is no element
 						bigger/equal to k. */
-					if (lo == ptr->end())
+					if (lo == ptr->end()) {
+						auto last_el = ptr->begin();
+						auto it = ptr->begin();
+						while (it != ptr->end()) {
+							last_el = it;
+							it++;
+						}
 						UT_ASSERT(
-							ptr->rbegin()->key() <
+							last_el->key() <
 							pmem::obj::string_view(
 								k));
-					else
+					} else
 						UT_ASSERT(
 							lo->key() >=
 							pmem::obj::string_view(
 								k));
 
-					auto prev = std::prev(lo);
-
-					/* There is no element smaller than k.
+					/* XXX: it's disabled due to:
+					 * https://github.com/pmem/libpmemobj-cpp/issues/1159
 					 */
-					if (prev == ptr->end())
-						UT_ASSERT(
-							ptr->begin()->key() >=
-							pmem::obj::string_view(
-								k));
-					else
-						UT_ASSERT(
-							prev->key() <
-							pmem::obj::string_view(
-								k));
+					// auto prev = std::prev(lo);
+
+					// /* There is no element smaller than
+					// k.
+					//  */
+					// if (prev == ptr->end())
+					//	UT_ASSERT(
+					//		ptr->begin()->key() >=
+					//		pmem::obj::string_view(
+					//			k));
+					// else
+					//	UT_ASSERT(
+					//		prev->key() <
+					//		pmem::obj::string_view(
+					//			k));
 				}
 			},
 			[&] {
@@ -328,31 +346,41 @@ test_erase_upper_lower_bounds_neighbours(
 
 					/* There is no element
 					bigger than k. */
-					if (ub == ptr->end())
+					if (ub == ptr->end()) {
+						auto last_el = ptr->begin();
+						auto it = ptr->begin();
+						while (it != ptr->end()) {
+							last_el = it;
+							it++;
+						}
 						UT_ASSERT(
-							ptr->rbegin()->key() <=
+							last_el->key() <=
 							pmem::obj::string_view(
 								k));
-					else
+					} else
 						UT_ASSERT(
 							ub->key() >
 							pmem::obj::string_view(
 								k));
 
-					auto prev = std::prev(ub);
-
-					/* There is no element smaller than k.
+					/* XXX: it's disabled due to:
+					 * https://github.com/pmem/libpmemobj-cpp/issues/1159
 					 */
-					if (prev == ptr->end())
-						UT_ASSERT(
-							ptr->begin()->key() >
-							pmem::obj::string_view(
-								k));
-					else
-						UT_ASSERT(
-							prev->key() <=
-							pmem::obj::string_view(
-								k));
+					// auto prev = std::prev(ub);
+
+					// /* There is no element smaller than
+					// k.
+					//  */
+					// if (prev == ptr->end())
+					//	UT_ASSERT(
+					//		ptr->begin()->key() >
+					//		pmem::obj::string_view(
+					//			k));
+					// else
+					//	UT_ASSERT(
+					//		prev->key() <=
+					//		pmem::obj::string_view(
+					//			k));
 				}
 			}};
 

--- a/tests/radix_tree/radix_concurrent_iterate.cpp
+++ b/tests/radix_tree/radix_concurrent_iterate.cpp
@@ -79,7 +79,7 @@ test_write_iterate(nvobj::pool<root> &pop,
  * count elements with odd keys. */
 void
 test_erase_iterate(nvobj::pool<root> &pop,
-		   nvobj::persistent_ptr<container_int_int_mt> &ptr)
+		   nvobj::persistent_ptr<cntr_int_int_mt> &ptr)
 {
 	const size_t value_repeats = 1000;
 	size_t threads = 4;
@@ -90,12 +90,11 @@ test_erase_iterate(nvobj::pool<root> &pop,
 	 * keys */
 	init_container(pop, ptr, INITIAL_ELEMENTS, value_repeats);
 	for (size_t i = 0; i < INITIAL_ELEMENTS; i += 2) {
-		ptr->erase(key<container_int_int_mt>(i));
+		ptr->erase(key<cntr_int_int_mt>(i));
 	}
 	auto expected_allocs = num_allocs(pop);
-	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_int_int_mt>(ptr);
-	});
+	nvobj::transaction::run(
+		pop, [&] { nvobj::delete_persistent<cntr_int_int_mt>(ptr); });
 
 	init_container(pop, ptr, INITIAL_ELEMENTS, value_repeats);
 	ptr->runtime_initialize_mt();
@@ -103,15 +102,15 @@ test_erase_iterate(nvobj::pool<root> &pop,
 	/* force 3 gc cycles to ensure that all garbage vectors will be
 	 * allocated */
 	for (size_t i = 0; i < 3; ++i) {
-		ptr->erase(key<container_int_int_mt>(i));
+		ptr->erase(key<cntr_int_int_mt>(i));
 		ptr->garbage_collect();
-		ptr->emplace(key<container_int_int_mt>(i),
-			     value<container_int_int_mt>(i));
+		ptr->emplace(key<cntr_int_int_mt>(i),
+			     value<cntr_int_int_mt>(i));
 	}
 
 	auto writer_f = [&] {
 		for (size_t i = 0; i < INITIAL_ELEMENTS; i += 2) {
-			ptr->erase(key<container_int_int_mt>(i));
+			ptr->erase(key<cntr_int_int_mt>(i));
 			ptr->garbage_collect();
 		}
 	};
@@ -144,9 +143,8 @@ test_erase_iterate(nvobj::pool<root> &pop,
 
 	ptr->runtime_finalize_mt();
 
-	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_int_int_mt>(ptr);
-	});
+	nvobj::transaction::run(
+		pop, [&] { nvobj::delete_persistent<cntr_int_int_mt>(ptr); });
 
 	UT_ASSERTeq(num_allocs(pop), 0);
 }
@@ -156,7 +154,7 @@ test_erase_iterate(nvobj::pool<root> &pop,
  * from the other threads. */
 void
 test_write_upper_lower_bounds(nvobj::pool<root> &pop,
-			      nvobj::persistent_ptr<container_int_int_mt> &ptr)
+			      nvobj::persistent_ptr<cntr_int_int_mt> &ptr)
 {
 	const size_t value_repeats = 10;
 	size_t threads = 4;
@@ -164,22 +162,20 @@ test_write_upper_lower_bounds(nvobj::pool<root> &pop,
 		threads = 2;
 	const size_t batch_size = INITIAL_ELEMENTS / threads;
 
-	nvobj::transaction::run(pop, [&] {
-		ptr = nvobj::make_persistent<container_int_int_mt>();
-	});
+	nvobj::transaction::run(
+		pop, [&] { ptr = nvobj::make_persistent<cntr_int_int_mt>(); });
 
 	ptr->runtime_initialize_mt();
 
 	for (size_t i = 0; i < 2 * INITIAL_ELEMENTS; i += 2) {
-		ptr->emplace(key<container_int_int_mt>(i),
-			     value<container_int_int_mt>(i, value_repeats));
+		ptr->emplace(key<cntr_int_int_mt>(i),
+			     value<cntr_int_int_mt>(i, value_repeats));
 	}
 
 	auto writer = [&]() {
 		for (size_t i = 1; i < 2 * INITIAL_ELEMENTS; i += 2) {
-			ptr->emplace(
-				key<container_int_int_mt>(i),
-				value<container_int_int_mt>(INITIAL_ELEMENTS));
+			ptr->emplace(key<cntr_int_int_mt>(i),
+				     value<cntr_int_int_mt>(INITIAL_ELEMENTS));
 		}
 	};
 
@@ -191,8 +187,7 @@ test_write_upper_lower_bounds(nvobj::pool<root> &pop,
 			for (size_t i = id * batch_size;
 			     i < (id + 1) * batch_size; ++i) {
 				auto it = ptr->lower_bound(i);
-				UT_ASSERT(it->key() >=
-					  key<container_int_int_mt>(i));
+				UT_ASSERT(it->key() >= key<cntr_int_int_mt>(i));
 			}
 		},
 		[&]() {
@@ -200,8 +195,7 @@ test_write_upper_lower_bounds(nvobj::pool<root> &pop,
 			for (size_t i = id * batch_size;
 			     i < (id + 1) * batch_size; ++i) {
 				auto it = ptr->upper_bound(i);
-				UT_ASSERT(it->key() >
-					  key<container_int_int_mt>(i));
+				UT_ASSERT(it->key() > key<cntr_int_int_mt>(i));
 			}
 		},
 	};
@@ -209,16 +203,15 @@ test_write_upper_lower_bounds(nvobj::pool<root> &pop,
 	parallel_modify_read(writer, readers, threads);
 
 	ptr->runtime_finalize_mt();
-	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_int_int_mt>(ptr);
-	});
+	nvobj::transaction::run(
+		pop, [&] { nvobj::delete_persistent<cntr_int_int_mt>(ptr); });
 
 	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 void
 test_erase_upper_lower_bounds_neighbours(
-	nvobj::pool<root> &pop, nvobj::persistent_ptr<container_string_mt> &ptr)
+	nvobj::pool<root> &pop, nvobj::persistent_ptr<cntr_string_mt> &ptr)
 {
 	const size_t value_repeats = 10;
 	const size_t repeats = 100;
@@ -226,19 +219,18 @@ test_erase_upper_lower_bounds_neighbours(
 	if (On_drd)
 		threads = 2;
 
-	nvobj::transaction::run(pop, [&] {
-		ptr = nvobj::make_persistent<container_string_mt>();
-	});
+	nvobj::transaction::run(
+		pop, [&] { ptr = nvobj::make_persistent<cntr_string_mt>(); });
 
 	ptr->runtime_initialize_mt();
 
 	const auto separator = "!!";
 	for (size_t i = 0; i < INITIAL_ELEMENTS / 2; i++) {
-		ptr->emplace(key<container_string_mt>(i),
-			     value<container_string_mt>(i, value_repeats));
-		ptr->emplace(key<container_string_mt>(i) + separator +
-				     key<container_string_mt>(i),
-			     value<container_string_mt>(i, value_repeats));
+		ptr->emplace(key<cntr_string_mt>(i),
+			     value<cntr_string_mt>(i, value_repeats));
+		ptr->emplace(key<cntr_string_mt>(i) + separator +
+				     key<cntr_string_mt>(i),
+			     value<cntr_string_mt>(i, value_repeats));
 	}
 
 	/* Run this test for first, last, middle keys and a few non-existent
@@ -388,16 +380,15 @@ test_erase_upper_lower_bounds_neighbours(
 	}
 
 	ptr->runtime_finalize_mt();
-	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_string_mt>(ptr);
-	});
+	nvobj::transaction::run(
+		pop, [&] { nvobj::delete_persistent<cntr_string_mt>(ptr); });
 
 	UT_ASSERTeq(num_allocs(pop), 0);
 }
 
 void
 test_write_erase_upper_lower_bounds_split(
-	nvobj::pool<root> &pop, nvobj::persistent_ptr<container_string_mt> &ptr)
+	nvobj::pool<root> &pop, nvobj::persistent_ptr<cntr_string_mt> &ptr)
 {
 	const size_t value_repeats = 10;
 	const size_t repeats = 100;
@@ -405,9 +396,8 @@ test_write_erase_upper_lower_bounds_split(
 	if (On_drd)
 		threads = 2;
 
-	nvobj::transaction::run(pop, [&] {
-		ptr = nvobj::make_persistent<container_string_mt>();
-	});
+	nvobj::transaction::run(
+		pop, [&] { ptr = nvobj::make_persistent<cntr_string_mt>(); });
 
 	ptr->runtime_initialize_mt();
 
@@ -416,13 +406,12 @@ test_write_erase_upper_lower_bounds_split(
 
 	/* Generate two-level tree. */
 	for (size_t i = 0; i < n_child; i++) {
-		ptr->emplace(key<container_string_mt>(i),
-			     value<container_string_mt>(i, value_repeats));
+		ptr->emplace(key<cntr_string_mt>(i),
+			     value<cntr_string_mt>(i, value_repeats));
 		for (size_t j = 0; j < n_child; j++) {
-			ptr->emplace(
-				key<container_string_mt>(i) + separator +
-					key<container_string_mt>(j),
-				value<container_string_mt>(j, value_repeats));
+			ptr->emplace(key<cntr_string_mt>(i) + separator +
+					     key<cntr_string_mt>(j),
+				     value<cntr_string_mt>(j, value_repeats));
 		}
 	}
 
@@ -431,9 +420,8 @@ test_write_erase_upper_lower_bounds_split(
 	std::vector<size_t> key_nums_to_process = {0, n_child / 2, n_child - 1};
 	std::vector<std::string> keys_to_process;
 	for (auto &k : key_nums_to_process)
-		keys_to_process.push_back(key<container_string_mt>(k) +
-					  separator +
-					  key<container_string_mt>(k));
+		keys_to_process.push_back(key<cntr_string_mt>(k) + separator +
+					  key<cntr_string_mt>(k));
 
 	for (auto &k : keys_to_process) {
 
@@ -485,9 +473,8 @@ test_write_erase_upper_lower_bounds_split(
 	}
 
 	ptr->runtime_finalize_mt();
-	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_string_mt>(ptr);
-	});
+	nvobj::transaction::run(
+		pop, [&] { nvobj::delete_persistent<cntr_string_mt>(ptr); });
 
 	UT_ASSERTeq(num_allocs(pop), 0);
 }
@@ -497,7 +484,7 @@ test_write_erase_upper_lower_bounds_split(
  * in the other threads. */
 void
 test_erase_upper_lower_bounds(nvobj::pool<root> &pop,
-			      nvobj::persistent_ptr<container_int_int_mt> &ptr,
+			      nvobj::persistent_ptr<cntr_int_int_mt> &ptr,
 			      bool rand_keys)
 {
 	const size_t value_repeats = 10;
@@ -511,7 +498,7 @@ test_erase_upper_lower_bounds(nvobj::pool<root> &pop,
 
 	auto writer = [&]() {
 		for (size_t i = 0; i < INITIAL_ELEMENTS; i += 2) {
-			ptr->erase(key<container_int_int_mt>(i));
+			ptr->erase(key<cntr_int_int_mt>(i));
 		}
 	};
 
@@ -530,8 +517,7 @@ test_erase_upper_lower_bounds(nvobj::pool<root> &pop,
 				}
 
 				for (auto &k : keys) {
-					UT_ASSERT(k >=
-						  key<container_int_int_mt>(i));
+					UT_ASSERT(k >= key<cntr_int_int_mt>(i));
 				}
 			}
 		},
@@ -547,8 +533,7 @@ test_erase_upper_lower_bounds(nvobj::pool<root> &pop,
 				}
 
 				for (auto &k : keys) {
-					UT_ASSERT(k >
-						  key<container_int_int_mt>(i));
+					UT_ASSERT(k > key<cntr_int_int_mt>(i));
 				}
 			}
 		},
@@ -558,9 +543,8 @@ test_erase_upper_lower_bounds(nvobj::pool<root> &pop,
 
 	ptr->runtime_finalize_mt();
 
-	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_int_int_mt>(ptr);
-	});
+	nvobj::transaction::run(
+		pop, [&] { nvobj::delete_persistent<cntr_int_int_mt>(ptr); });
 
 	UT_ASSERTeq(num_allocs(pop), 0);
 }

--- a/tests/radix_tree/radix_concurrent_iterate.cpp
+++ b/tests/radix_tree/radix_concurrent_iterate.cpp
@@ -12,8 +12,6 @@
  * iterators.
  */
 
-static std::mt19937_64 generator;
-
 static size_t INITIAL_ELEMENTS = 256;
 
 /* Insert INITIAL_ELEMENTS elements to the radix. After that, concurrently
@@ -23,13 +21,13 @@ static size_t INITIAL_ELEMENTS = 256;
 template <typename Container>
 void
 test_write_iterate(nvobj::pool<root> &pop,
-		   nvobj::persistent_ptr<Container> &ptr)
+		   nvobj::persistent_ptr<Container> &ptr, bool rand_keys)
 {
 	size_t threads = 8;
 	if (On_drd)
 		threads = 2;
 
-	init_container(pop, ptr, INITIAL_ELEMENTS);
+	init_container(pop, ptr, INITIAL_ELEMENTS, 1, rand_keys);
 	ptr->runtime_initialize_mt();
 
 	auto writer = [&]() {
@@ -471,7 +469,8 @@ test_write_erase_upper_lower_bounds_split(
  * in the other threads. */
 void
 test_erase_upper_lower_bounds(nvobj::pool<root> &pop,
-			      nvobj::persistent_ptr<container_int_int_mt> &ptr)
+			      nvobj::persistent_ptr<container_int_int_mt> &ptr,
+			      bool rand_keys)
 {
 	const size_t value_repeats = 10;
 	size_t threads = 4;
@@ -479,7 +478,7 @@ test_erase_upper_lower_bounds(nvobj::pool<root> &pop,
 		threads = 2;
 	const size_t batch_size = INITIAL_ELEMENTS / threads;
 
-	init_container(pop, ptr, INITIAL_ELEMENTS, value_repeats);
+	init_container(pop, ptr, INITIAL_ELEMENTS, value_repeats, rand_keys);
 	ptr->runtime_initialize_mt();
 
 	auto writer = [&]() {
@@ -560,14 +559,16 @@ test(int argc, char *argv[])
 		INITIAL_ELEMENTS = 64;
 	}
 
-	std::random_device rd;
-	auto seed = rd();
-	std::cout << "rand seed: " << seed << std::endl;
-	generator = std::mt19937_64(seed);
+	init_random();
 
-	test_write_iterate(pop, pop.root()->radix_int_int_mt);
-	test_erase_iterate(pop, pop.root()->radix_int_int_mt);
+	for (int i = 0; i < 2; ++i) {
+		bool rand = static_cast<bool>(i);
+		test_write_iterate(pop, pop.root()->radix_int_int_mt, rand);
+		test_erase_upper_lower_bounds(pop, pop.root()->radix_int_int_mt,
+					      rand);
+	}
 	test_write_upper_lower_bounds(pop, pop.root()->radix_int_int_mt);
+	test_erase_iterate(pop, pop.root()->radix_int_int_mt);
 	test_erase_upper_lower_bounds_neighbours(pop, pop.root()->radix_str_mt);
 	test_write_erase_upper_lower_bounds_split(pop,
 						  pop.root()->radix_str_mt);

--- a/tests/radix_tree/radix_concurrent_overwrite.cpp
+++ b/tests/radix_tree/radix_concurrent_overwrite.cpp
@@ -11,9 +11,8 @@
 static size_t INITIAL_ELEMENTS = 256;
 
 static void
-test_overwrite_bigger_size_find(
-	nvobj::pool<root> &pop,
-	nvobj::persistent_ptr<container_int_string_mt> &ptr)
+test_overwrite_bigger_size_find(nvobj::pool<root> &pop,
+				nvobj::persistent_ptr<cntr_int_string_mt> &ptr)
 {
 	size_t threads = 16;
 	if (On_drd)
@@ -27,8 +26,8 @@ test_overwrite_bigger_size_find(
 		for (size_t i = 0; i < INITIAL_ELEMENTS * 2; ++i) {
 			auto k = i % INITIAL_ELEMENTS;
 			ptr->insert_or_assign(
-				key<container_int_string_mt>(k),
-				value<container_int_string_mt>(i, 100));
+				key<cntr_int_string_mt>(k),
+				value<cntr_int_string_mt>(i, 100));
 		}
 	};
 
@@ -36,18 +35,17 @@ test_overwrite_bigger_size_find(
 		[&]() {
 			for (size_t i = 0; i < INITIAL_ELEMENTS * 2; ++i) {
 				auto k = i % INITIAL_ELEMENTS;
-				auto res = ptr->find(
-					key<container_int_string_mt>(k));
+				auto res =
+					ptr->find(key<cntr_int_string_mt>(k));
 				UT_ASSERT(res != ptr->end());
 				UT_ASSERT(
 					res->value() ==
-						value<container_int_string_mt>(
-							k) ||
+						value<cntr_int_string_mt>(k) ||
 					res->value() ==
-						value<container_int_string_mt>(
+						value<cntr_int_string_mt>(
 							k, 100) ||
 					res->value() ==
-						value<container_int_string_mt>(
+						value<cntr_int_string_mt>(
 							k + INITIAL_ELEMENTS,
 							100));
 			}
@@ -59,7 +57,7 @@ test_overwrite_bigger_size_find(
 	ptr->runtime_finalize_mt();
 
 	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_int_string_mt>(ptr);
+		nvobj::delete_persistent<cntr_int_string_mt>(ptr);
 	});
 
 	UT_ASSERTeq(num_allocs(pop), 0);

--- a/tests/radix_tree/radix_large.cpp
+++ b/tests/radix_tree/radix_large.cpp
@@ -27,12 +27,11 @@ struct bytes_view {
 	const nvobj::string *s;
 };
 
-using container_t =
-	nvobj::experimental::radix_tree<nvobj::string, int, bytes_view>;
+using cntr_t = nvobj::experimental::radix_tree<nvobj::string, int, bytes_view>;
 
 struct root {
 	nvobj::persistent_ptr<nvobj::string> str;
-	nvobj::persistent_ptr<container_t> map;
+	nvobj::persistent_ptr<cntr_t> map;
 };
 
 void
@@ -41,7 +40,7 @@ test_long_string(nvobj::pool<root> &pop)
 	auto r = pop.root();
 
 	nvobj::transaction::run(pop, [&] {
-		r->map = nvobj::make_persistent<container_t>();
+		r->map = nvobj::make_persistent<cntr_t>();
 		r->str = nvobj::make_persistent<nvobj::string>((1ULL << 32),
 							       'a');
 	});
@@ -53,7 +52,7 @@ test_long_string(nvobj::pool<root> &pop)
 	UT_ASSERT(!ret.second);
 
 	nvobj::transaction::run(pop, [&] {
-		nvobj::delete_persistent<container_t>(r->map);
+		nvobj::delete_persistent<cntr_t>(r->map);
 		nvobj::delete_persistent<nvobj::string>(r->str);
 	});
 

--- a/tests/radix_tree/radix_large.cpp
+++ b/tests/radix_tree/radix_large.cpp
@@ -6,8 +6,6 @@
 #include <libpmemobj++/container/string.hpp>
 #include <libpmemobj++/experimental/radix_tree.hpp>
 
-#include <libpmemobj/iterator.h>
-
 namespace nvobj = pmem::obj;
 
 struct bytes_view {

--- a/tests/radix_tree/radix_tx_abort.cpp
+++ b/tests/radix_tree/radix_tx_abort.cpp
@@ -486,96 +486,90 @@ test(int argc, char *argv[])
 	}
 
 	test_emplace(pop, pop.root()->radix_str);
-	test_assign<container_string, 1>(pop, pop.root()->radix_str);
-	test_assign<container_string, 1024>(pop, pop.root()->radix_str);
-	test_assign_root<container_string, 1>(pop, pop.root()->radix_str);
-	test_assign_root<container_string, 1024>(pop, pop.root()->radix_str);
-	test_erase<container_string, 1024>(pop, pop.root()->radix_str);
-	test_assign_internal_leaf<container_string, 1>(pop,
-						       pop.root()->radix_str);
-	test_assign_internal_leaf<container_string, 1024>(
-		pop, pop.root()->radix_str);
-	test_erase_internal<container_string, 1024>(pop, pop.root()->radix_str);
-	test_insert_or_assign<container_string, 1>(pop, pop.root()->radix_str);
-	test_try_emplace<container_string, 1>(pop, pop.root()->radix_str);
+	test_assign<cntr_string, 1>(pop, pop.root()->radix_str);
+	test_assign<cntr_string, 1024>(pop, pop.root()->radix_str);
+	test_assign_root<cntr_string, 1>(pop, pop.root()->radix_str);
+	test_assign_root<cntr_string, 1024>(pop, pop.root()->radix_str);
+	test_erase<cntr_string, 1024>(pop, pop.root()->radix_str);
+	test_assign_internal_leaf<cntr_string, 1>(pop, pop.root()->radix_str);
+	test_assign_internal_leaf<cntr_string, 1024>(pop,
+						     pop.root()->radix_str);
+	test_erase_internal<cntr_string, 1024>(pop, pop.root()->radix_str);
+	test_insert_or_assign<cntr_string, 1>(pop, pop.root()->radix_str);
+	test_try_emplace<cntr_string, 1>(pop, pop.root()->radix_str);
 
 	test_emplace(pop, pop.root()->radix_int);
-	test_assign<container_int, 1>(pop, pop.root()->radix_int);
-	test_assign_root<container_int, 1>(pop, pop.root()->radix_int);
-	test_erase<container_int, 1024>(pop, pop.root()->radix_int);
-	test_assign_internal_leaf<container_int, 1>(pop, pop.root()->radix_int);
-	test_erase_internal<container_int, 1024>(pop, pop.root()->radix_int);
-	test_insert_or_assign<container_int, 1>(pop, pop.root()->radix_int);
-	test_try_emplace<container_int, 1>(pop, pop.root()->radix_int);
+	test_assign<cntr_int, 1>(pop, pop.root()->radix_int);
+	test_assign_root<cntr_int, 1>(pop, pop.root()->radix_int);
+	test_erase<cntr_int, 1024>(pop, pop.root()->radix_int);
+	test_assign_internal_leaf<cntr_int, 1>(pop, pop.root()->radix_int);
+	test_erase_internal<cntr_int, 1024>(pop, pop.root()->radix_int);
+	test_insert_or_assign<cntr_int, 1>(pop, pop.root()->radix_int);
+	test_try_emplace<cntr_int, 1>(pop, pop.root()->radix_int);
 
 	test_emplace(pop, pop.root()->radix_int_int);
-	test_assign<container_int_int, 1>(pop, pop.root()->radix_int_int);
-	test_assign_root<container_int_int, 1>(pop, pop.root()->radix_int_int);
-	test_erase<container_int_int, 1>(pop, pop.root()->radix_int_int);
-	test_insert<container_int_int, 1>(pop, pop.root()->radix_int_int);
-	test_insert_or_assign<container_int_int, 1>(pop,
-						    pop.root()->radix_int_int);
-	test_try_emplace<container_int_int, 1>(pop, pop.root()->radix_int_int);
+	test_assign<cntr_int_int, 1>(pop, pop.root()->radix_int_int);
+	test_assign_root<cntr_int_int, 1>(pop, pop.root()->radix_int_int);
+	test_erase<cntr_int_int, 1>(pop, pop.root()->radix_int_int);
+	test_insert<cntr_int_int, 1>(pop, pop.root()->radix_int_int);
+	test_insert_or_assign<cntr_int_int, 1>(pop, pop.root()->radix_int_int);
+	test_try_emplace<cntr_int_int, 1>(pop, pop.root()->radix_int_int);
 
 	test_emplace(pop, pop.root()->radix_int_str);
-	test_assign<container_int_string, 1>(pop, pop.root()->radix_int_str);
-	test_assign<container_int_string, 1024>(pop, pop.root()->radix_int_str);
-	test_assign_root<container_int_string, 1>(pop,
+	test_assign<cntr_int_string, 1>(pop, pop.root()->radix_int_str);
+	test_assign<cntr_int_string, 1024>(pop, pop.root()->radix_int_str);
+	test_assign_root<cntr_int_string, 1>(pop, pop.root()->radix_int_str);
+	test_assign_root<cntr_int_string, 1024>(pop, pop.root()->radix_int_str);
+	test_erase<cntr_int_string, 1024>(pop, pop.root()->radix_int_str);
+	test_insert_or_assign<cntr_int_string, 1>(pop,
 						  pop.root()->radix_int_str);
-	test_assign_root<container_int_string, 1024>(pop,
-						     pop.root()->radix_int_str);
-	test_erase<container_int_string, 1024>(pop, pop.root()->radix_int_str);
-	test_insert_or_assign<container_int_string, 1>(
-		pop, pop.root()->radix_int_str);
-	test_try_emplace<container_int_string, 1>(pop,
-						  pop.root()->radix_int_str);
+	test_try_emplace<cntr_int_string, 1>(pop, pop.root()->radix_int_str);
 
 	test_emplace(pop, pop.root()->radix_inline_s_u8t);
-	test_assign<container_inline_s_u8t, 1>(pop,
+	test_assign<cntr_inline_s_u8t, 1>(pop, pop.root()->radix_inline_s_u8t);
+	test_assign<cntr_inline_s_u8t, 1024>(pop,
+					     pop.root()->radix_inline_s_u8t);
+	test_assign_root<cntr_inline_s_u8t, 1>(pop,
 					       pop.root()->radix_inline_s_u8t);
-	test_assign<container_inline_s_u8t, 1024>(
+	test_assign_root<cntr_inline_s_u8t, 1024>(
 		pop, pop.root()->radix_inline_s_u8t);
-	test_assign_root<container_inline_s_u8t, 1>(
+	test_erase<cntr_inline_s_u8t, 1024>(pop,
+					    pop.root()->radix_inline_s_u8t);
+	test_insert_or_assign<cntr_inline_s_u8t, 1>(
 		pop, pop.root()->radix_inline_s_u8t);
-	test_assign_root<container_inline_s_u8t, 1024>(
-		pop, pop.root()->radix_inline_s_u8t);
-	test_erase<container_inline_s_u8t, 1024>(
-		pop, pop.root()->radix_inline_s_u8t);
-	test_insert_or_assign<container_inline_s_u8t, 1>(
-		pop, pop.root()->radix_inline_s_u8t);
-	test_try_emplace<container_inline_s_u8t, 1>(
-		pop, pop.root()->radix_inline_s_u8t);
+	test_try_emplace<cntr_inline_s_u8t, 1>(pop,
+					       pop.root()->radix_inline_s_u8t);
 
 	test_emplace(pop, pop.root()->radix_inline_s_wchart);
-	test_assign<container_inline_s_wchart, 1>(
+	test_assign<cntr_inline_s_wchart, 1>(pop,
+					     pop.root()->radix_inline_s_wchart);
+	test_assign<cntr_inline_s_wchart, 1024>(
 		pop, pop.root()->radix_inline_s_wchart);
-	test_assign<container_inline_s_wchart, 1024>(
+	test_assign_root<cntr_inline_s_wchart, 1>(
 		pop, pop.root()->radix_inline_s_wchart);
-	test_assign_root<container_inline_s_wchart, 1>(
+	test_assign_root<cntr_inline_s_wchart, 1024>(
 		pop, pop.root()->radix_inline_s_wchart);
-	test_assign_root<container_inline_s_wchart, 1024>(
+	test_erase<cntr_inline_s_wchart, 1024>(
 		pop, pop.root()->radix_inline_s_wchart);
-	test_erase<container_inline_s_wchart, 1024>(
+	test_insert_or_assign<cntr_inline_s_wchart, 1>(
 		pop, pop.root()->radix_inline_s_wchart);
-	test_insert_or_assign<container_inline_s_wchart, 1>(
-		pop, pop.root()->radix_inline_s_wchart);
-	test_try_emplace<container_inline_s_wchart, 1>(
+	test_try_emplace<cntr_inline_s_wchart, 1>(
 		pop, pop.root()->radix_inline_s_wchart);
 
 	test_emplace(pop, pop.root()->radix_inline_s_wchart_wchart);
-	test_assign<container_inline_s_wchart_wchart, 1>(
+	test_assign<cntr_inline_s_wchart_wchart, 1>(
 		pop, pop.root()->radix_inline_s_wchart_wchart);
-	test_assign<container_inline_s_wchart_wchart, 1024>(
+	test_assign<cntr_inline_s_wchart_wchart, 1024>(
 		pop, pop.root()->radix_inline_s_wchart_wchart);
-	test_assign_root<container_inline_s_wchart_wchart, 1>(
+	test_assign_root<cntr_inline_s_wchart_wchart, 1>(
 		pop, pop.root()->radix_inline_s_wchart_wchart);
-	test_assign_root<container_inline_s_wchart_wchart, 1024>(
+	test_assign_root<cntr_inline_s_wchart_wchart, 1024>(
 		pop, pop.root()->radix_inline_s_wchart_wchart);
-	test_erase<container_inline_s_wchart_wchart, 1024>(
+	test_erase<cntr_inline_s_wchart_wchart, 1024>(
 		pop, pop.root()->radix_inline_s_wchart_wchart);
-	test_insert_or_assign<container_inline_s_wchart_wchart, 1>(
+	test_insert_or_assign<cntr_inline_s_wchart_wchart, 1>(
 		pop, pop.root()->radix_inline_s_wchart_wchart);
-	test_try_emplace<container_inline_s_wchart_wchart, 1>(
+	test_try_emplace<cntr_inline_s_wchart_wchart, 1>(
 		pop, pop.root()->radix_inline_s_wchart_wchart);
 
 	pop.close();


### PR DESCRIPTION
- disable `operator--` when `MtMode` is enabled
- add concurrent decrement test that is failing at the moment
- extend existing radix_tree tests
- cleanup

random fails in `try_decrement()`
```
radix_concurrent_erase: /home/luke/repos/luke/libpmemobj-cpp/include/libpmemobj++/experimental/radix_tree.hpp:3251: bool pmem::obj::experimental::radix_tree<Key, Value, BytesView, MtMode>::radix_tree_iterator<IsConst>::try_decrement()
[with bool IsConst = false; Key = unsigned int; Value = pmem::obj::p<unsigned int>; BytesView = pmem::obj::experimental::bytes_view<unsigned int>; bool MtMode = true]:
Assertion `parent_ptr' failed.
```
```
radix_concurrent_erase: /home/luke/repos/luke/libpmemobj-cpp/include/libpmemobj++/experimental/radix_tree.hpp:3240: bool pmem::obj::experimental::radix_tree<Key, Value, BytesView, MtMode>::radix_tree_iterator<IsConst>::try_decrement()
[with bool IsConst = false; Key = unsigned int; Value = pmem::obj::p<unsigned int>; BytesView = pmem::obj::experimental::bytes_view<unsigned int>; bool MtMode = true]:
Assertion `r' failed.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1156)
<!-- Reviewable:end -->
