### PR TITLE
inline_string: disallow creating basic_inline_string on dram

### DIFF
--- a/include/libpmemobj++/experimental/inline_string.hpp
+++ b/include/libpmemobj++/experimental/inline_string.hpp
@@ -20,6 +20,69 @@
 namespace pmem
 {
 
+namespace detail
+{
+
+template <typename CharT, bool AllowDram = false,
+	  typename Traits = std::char_traits<CharT>>
+class basic_inline_string_base {
+public:
+	using traits_type = Traits;
+	using value_type = CharT;
+	using size_type = std::size_t;
+	using difference_type = std::ptrdiff_t;
+	using reference = value_type &;
+	using const_reference = const value_type &;
+	using pointer = value_type *;
+	using const_pointer = const value_type *;
+
+	basic_inline_string_base(obj::basic_string_view<CharT, Traits> v);
+	basic_inline_string_base(size_type capacity);
+	basic_inline_string_base(const basic_inline_string_base &rhs);
+	basic_inline_string_base(
+		const basic_inline_string_base<CharT, !AllowDram, Traits> &rhs);
+
+	basic_inline_string_base &
+	operator=(const basic_inline_string_base &rhs);
+	basic_inline_string_base &operator=(
+		const basic_inline_string_base<CharT, !AllowDram, Traits> &rhs);
+
+	basic_inline_string_base &
+	operator=(obj::basic_string_view<CharT, Traits> rhs);
+
+	basic_inline_string_base(basic_inline_string_base<CharT> &&) = delete;
+	basic_inline_string_base &
+	operator=(basic_inline_string_base &&) = delete;
+	operator obj::basic_string_view<CharT, Traits>() const;
+
+	size_type size() const noexcept;
+	size_type capacity() const noexcept;
+
+	pointer data();
+	const_pointer data() const noexcept;
+	const_pointer cdata() const noexcept;
+
+	int compare(const basic_inline_string_base &rhs) const noexcept;
+
+	reference operator[](size_type p);
+	const_reference operator[](size_type p) const noexcept;
+
+	reference at(size_type p);
+	const_reference at(size_type p) const;
+
+	obj::slice<pointer> range(size_type p, size_type count);
+
+	basic_inline_string_base &
+	assign(obj::basic_string_view<CharT, Traits> rhs);
+
+private:
+	pointer snapshotted_data(size_t p, size_t n);
+
+	obj::p<uint64_t> size_;
+	obj::p<uint64_t> capacity_;
+};
+}
+
 namespace obj
 {
 
@@ -30,7 +93,27 @@ namespace experimental
  * This class serves similar purpose to pmem::obj::string, but
  * keeps the data within the same allocation as inline_string itself.
  *
- * Unlike other containers, it can be used on pmem and dram. Modifiers (like
+ * Can only be kept on pmem.
+ *
+ * The data is always kept right after the inline_string structure.
+ * It means that creating an object of inline_string must be done
+ * as follows:
+ * 1. Allocate memory of sizeof(inline_string) + size of the characters string +
+ * sizeof('\0')
+ * 2. Use emplace new() to create inline_string
+ *
+ * Example:
+ * @snippet inline_string/inline_string.cpp inline_string_example
+ */
+template <typename CharT, typename Traits = std::char_traits<CharT>>
+using basic_inline_string =
+	detail::basic_inline_string_base<CharT, false, Traits>;
+
+/**
+ * This class serves similar purpose to pmem::obj::string, but
+ * keeps the data within the same allocation as inline_string itself.
+ *
+ * Unlike basic_inline_string, it can be used on pmem and dram. Modifiers (like
  * assign()) can only be called if inline string is kept on pmem).
  *
  * The data is always kept right after the inline_string structure.
@@ -44,54 +127,8 @@ namespace experimental
  * @snippet inline_string/inline_string.cpp inline_string_example
  */
 template <typename CharT, typename Traits = std::char_traits<CharT>>
-class basic_inline_string {
-public:
-	using traits_type = Traits;
-	using value_type = CharT;
-	using size_type = std::size_t;
-	using difference_type = std::ptrdiff_t;
-	using reference = value_type &;
-	using const_reference = const value_type &;
-	using pointer = value_type *;
-	using const_pointer = const value_type *;
-
-	basic_inline_string(basic_string_view<CharT, Traits> v);
-	basic_inline_string(size_type capacity);
-	basic_inline_string(const basic_inline_string &rhs);
-
-	basic_inline_string &operator=(const basic_inline_string &rhs);
-
-	basic_inline_string &operator=(basic_string_view<CharT, Traits> rhs);
-
-	basic_inline_string(basic_inline_string<CharT> &&) = delete;
-	basic_inline_string &operator=(basic_inline_string &&) = delete;
-	operator basic_string_view<CharT, Traits>() const;
-
-	size_type size() const noexcept;
-	size_type capacity() const noexcept;
-
-	pointer data();
-	const_pointer data() const noexcept;
-	const_pointer cdata() const noexcept;
-
-	int compare(const basic_inline_string &rhs) const noexcept;
-
-	reference operator[](size_type p);
-	const_reference operator[](size_type p) const noexcept;
-
-	reference at(size_type p);
-	const_reference at(size_type p) const;
-
-	slice<pointer> range(size_type p, size_type count);
-
-	basic_inline_string &assign(basic_string_view<CharT, Traits> rhs);
-
-private:
-	pointer snapshotted_data(size_t p, size_t n);
-
-	obj::p<uint64_t> size_;
-	obj::p<uint64_t> capacity_;
-};
+using basic_dram_inline_string =
+	detail::basic_inline_string_base<CharT, true, Traits>;
 
 using inline_string = basic_inline_string<char>;
 using inline_wstring = basic_inline_string<wchar_t>;
@@ -99,13 +136,57 @@ using inline_u16string = basic_inline_string<char16_t>;
 using inline_u32string = basic_inline_string<char32_t>;
 
 /**
+ * A helper trait which calculates required memory capacity (in bytes) for a
+ * type.
+ *
+ * All standard types require capacity equal to the sizeof of such type.
+ */
+template <typename T>
+struct total_sizeof {
+	template <typename... Args>
+	static size_t
+	value(const Args &... args)
+	{
+		return sizeof(T);
+	}
+};
+
+/**
+ * A helper trait which calculates required memory capacity (in bytes) for a
+ * type.
+ *
+ * Inline_string requires capacity of sizeof(basic_inline_string_base<CharT>) +
+ * size of the data itself.
+ */
+template <typename CharT, bool AllowDram, typename Traits>
+struct total_sizeof<
+	detail::basic_inline_string_base<CharT, AllowDram, Traits>> {
+	static size_t
+	value(const obj::basic_string_view<CharT, Traits> &s)
+	{
+		return sizeof(detail::basic_inline_string_base<CharT, AllowDram,
+							       Traits>) +
+			(s.size() + 1 /* '\0' */) * sizeof(CharT);
+	}
+};
+
+}
+}
+
+namespace detail
+{
+
+/**
  * Constructs inline string from a string_view.
  */
-template <typename CharT, typename Traits>
-basic_inline_string<CharT, Traits>::basic_inline_string(
-	basic_string_view<CharT, Traits> v)
+template <typename CharT, bool AllowDram, typename Traits>
+basic_inline_string_base<CharT, AllowDram, Traits>::basic_inline_string_base(
+	obj::basic_string_view<CharT, Traits> v)
     : size_(v.size()), capacity_(v.size())
 {
+	if (!AllowDram && nullptr == pmemobj_pool_by_ptr(this))
+		throw pmem::pool_error("Invalid pool handle.");
+
 	std::copy(v.data(), v.data() + static_cast<ptrdiff_t>(size_), data());
 
 	data()[static_cast<ptrdiff_t>(size_)] = '\0';
@@ -114,21 +195,46 @@ basic_inline_string<CharT, Traits>::basic_inline_string(
 /**
  * Constructs empty inline_string with specified capacity.
  */
-template <typename CharT, typename Traits>
-basic_inline_string<CharT, Traits>::basic_inline_string(size_type capacity)
+template <typename CharT, bool AllowDram, typename Traits>
+basic_inline_string_base<CharT, AllowDram, Traits>::basic_inline_string_base(
+	size_type capacity)
     : size_(0), capacity_(capacity)
 {
+	if (!AllowDram && nullptr == pmemobj_pool_by_ptr(this))
+		throw pmem::pool_error("Invalid pool handle.");
+
 	data()[static_cast<ptrdiff_t>(size_)] = '\0';
 }
 
 /**
  * Copy constructor
  */
-template <typename CharT, typename Traits>
-basic_inline_string<CharT, Traits>::basic_inline_string(
-	const basic_inline_string &rhs)
+template <typename CharT, bool AllowDram, typename Traits>
+basic_inline_string_base<CharT, AllowDram, Traits>::basic_inline_string_base(
+	const basic_inline_string_base &rhs)
     : size_(rhs.size()), capacity_(rhs.capacity())
 {
+	if (!AllowDram && nullptr == pmemobj_pool_by_ptr(this))
+		throw pmem::pool_error("Invalid pool handle.");
+
+	std::copy(rhs.data(), rhs.data() + static_cast<ptrdiff_t>(size_),
+		  data());
+
+	data()[static_cast<ptrdiff_t>(size_)] = '\0';
+}
+
+/**
+ * Copy constructor taking alternative specialization of
+ * basic_inline_string_base.
+ */
+template <typename CharT, bool AllowDram, typename Traits>
+basic_inline_string_base<CharT, AllowDram, Traits>::basic_inline_string_base(
+	const basic_inline_string_base<CharT, !AllowDram, Traits> &rhs)
+    : size_(rhs.size()), capacity_(rhs.capacity())
+{
+	if (!AllowDram && nullptr == pmemobj_pool_by_ptr(this))
+		throw pmem::pool_error("Invalid pool handle.");
+
 	std::copy(rhs.data(), rhs.data() + static_cast<ptrdiff_t>(size_),
 		  data());
 
@@ -138,9 +244,21 @@ basic_inline_string<CharT, Traits>::basic_inline_string(
 /**
  * Copy assignment operator
  */
-template <typename CharT, typename Traits>
-basic_inline_string<CharT, Traits> &
-basic_inline_string<CharT, Traits>::operator=(const basic_inline_string &rhs)
+template <typename CharT, bool AllowDram, typename Traits>
+basic_inline_string_base<CharT, AllowDram, Traits> &
+basic_inline_string_base<CharT, AllowDram, Traits>::operator=(
+	const basic_inline_string_base &rhs)
+{
+	if (this == &rhs)
+		return *this;
+
+	return assign(rhs);
+}
+
+template <typename CharT, bool AllowDram, typename Traits>
+basic_inline_string_base<CharT, AllowDram, Traits> &
+basic_inline_string_base<CharT, AllowDram, Traits>::operator=(
+	const basic_inline_string_base<CharT, !AllowDram, Traits> &rhs)
 {
 	if (this == &rhs)
 		return *this;
@@ -151,26 +269,26 @@ basic_inline_string<CharT, Traits>::operator=(const basic_inline_string &rhs)
 /**
  * Assignment operator from string_view.
  */
-template <typename CharT, typename Traits>
-basic_inline_string<CharT, Traits> &
-basic_inline_string<CharT, Traits>::operator=(
-	basic_string_view<CharT, Traits> rhs)
+template <typename CharT, bool AllowDram, typename Traits>
+basic_inline_string_base<CharT, AllowDram, Traits> &
+basic_inline_string_base<CharT, AllowDram, Traits>::operator=(
+	obj::basic_string_view<CharT, Traits> rhs)
 {
 	return assign(rhs);
 }
 
 /** Conversion operator to string_view */
-template <typename CharT, typename Traits>
-basic_inline_string<CharT, Traits>::operator basic_string_view<CharT, Traits>()
-	const
+template <typename CharT, bool AllowDram, typename Traits>
+basic_inline_string_base<CharT, AllowDram, Traits>::operator obj::
+	basic_string_view<CharT, Traits>() const
 {
 	return {data(), size()};
 }
 
 /** @return size of the string */
-template <typename CharT, typename Traits>
-typename basic_inline_string<CharT, Traits>::size_type
-basic_inline_string<CharT, Traits>::size() const noexcept
+template <typename CharT, bool AllowDram, typename Traits>
+typename basic_inline_string_base<CharT, AllowDram, Traits>::size_type
+basic_inline_string_base<CharT, AllowDram, Traits>::size() const noexcept
 {
 	return size_;
 }
@@ -182,9 +300,9 @@ basic_inline_string<CharT, Traits>::size() const noexcept
  * sizeof(inline_string) + capacity() + sizeof('\0') and cannot be
  * expanded.
  */
-template <typename CharT, typename Traits>
-typename basic_inline_string<CharT, Traits>::size_type
-basic_inline_string<CharT, Traits>::capacity() const noexcept
+template <typename CharT, bool AllowDram, typename Traits>
+typename basic_inline_string_base<CharT, AllowDram, Traits>::size_type
+basic_inline_string_base<CharT, AllowDram, Traits>::capacity() const noexcept
 {
 	return capacity_;
 }
@@ -198,17 +316,17 @@ basic_inline_string<CharT, Traits>::capacity() const noexcept
  *
  * @throw pmem::transaction_error when snapshotting failed.
  */
-template <typename CharT, typename Traits>
-typename basic_inline_string<CharT, Traits>::pointer
-basic_inline_string<CharT, Traits>::data()
+template <typename CharT, bool AllowDram, typename Traits>
+typename basic_inline_string_base<CharT, AllowDram, Traits>::pointer
+basic_inline_string_base<CharT, AllowDram, Traits>::data()
 {
 	return snapshotted_data(0, size_);
 }
 
 /** @return const_pointer to the data (equal to (this + 1)) */
-template <typename CharT, typename Traits>
-typename basic_inline_string<CharT, Traits>::const_pointer
-basic_inline_string<CharT, Traits>::data() const noexcept
+template <typename CharT, bool AllowDram, typename Traits>
+typename basic_inline_string_base<CharT, AllowDram, Traits>::const_pointer
+basic_inline_string_base<CharT, AllowDram, Traits>::data() const noexcept
 {
 	return cdata();
 }
@@ -220,9 +338,9 @@ basic_inline_string<CharT, Traits>::data() const noexcept
  *
  * @return const_pointer to the data (equal to (this + 1))
  */
-template <typename CharT, typename Traits>
-typename basic_inline_string<CharT, Traits>::const_pointer
-basic_inline_string<CharT, Traits>::cdata() const noexcept
+template <typename CharT, bool AllowDram, typename Traits>
+typename basic_inline_string_base<CharT, AllowDram, Traits>::const_pointer
+basic_inline_string_base<CharT, AllowDram, Traits>::cdata() const noexcept
 {
 	return reinterpret_cast<const CharT *>(this + 1);
 }
@@ -235,12 +353,13 @@ basic_inline_string<CharT, Traits>::cdata() const noexcept
  *			positive value if this is lexicographically greater than
  * other, negative value if this is lexicographically less than other.
  */
-template <typename CharT, typename Traits>
+template <typename CharT, bool AllowDram, typename Traits>
 int
-basic_inline_string<CharT, Traits>::compare(
-	const basic_inline_string &rhs) const noexcept
+basic_inline_string_base<CharT, AllowDram, Traits>::compare(
+	const basic_inline_string_base &rhs) const noexcept
 {
-	return basic_string_view<CharT, Traits>(data(), size()).compare(rhs);
+	return obj::basic_string_view<CharT, Traits>(data(), size())
+		.compare(rhs);
 }
 
 /**
@@ -251,9 +370,10 @@ basic_inline_string<CharT, Traits>::compare(
  *
  * @throw pmem::transaction_error when snapshotting failed.
  */
-template <typename CharT, typename Traits>
-typename basic_inline_string<CharT, Traits>::reference
-	basic_inline_string<CharT, Traits>::operator[](size_type p)
+template <typename CharT, bool AllowDram, typename Traits>
+typename basic_inline_string_base<CharT, AllowDram, Traits>::reference
+	basic_inline_string_base<CharT, AllowDram, Traits>::operator[](
+		size_type p)
 {
 	return snapshotted_data(p, 1)[0];
 }
@@ -264,10 +384,10 @@ typename basic_inline_string<CharT, Traits>::reference
  *
  * @return const_reference to a CharT
  */
-template <typename CharT, typename Traits>
-typename basic_inline_string<CharT, Traits>::const_reference
-	basic_inline_string<CharT, Traits>::operator[](size_type p) const
-	noexcept
+template <typename CharT, bool AllowDram, typename Traits>
+typename basic_inline_string_base<CharT, AllowDram, Traits>::const_reference
+	basic_inline_string_base<CharT, AllowDram, Traits>::operator[](
+		size_type p) const noexcept
 {
 	return cdata()[p];
 }
@@ -281,12 +401,12 @@ typename basic_inline_string<CharT, Traits>::const_reference
  * @throw pmem::transaction_error when snapshotting failed.
  * @throw std::out_of_range if p is not within the range of the container.
  */
-template <typename CharT, typename Traits>
-typename basic_inline_string<CharT, Traits>::reference
-basic_inline_string<CharT, Traits>::at(size_type p)
+template <typename CharT, bool AllowDram, typename Traits>
+typename basic_inline_string_base<CharT, AllowDram, Traits>::reference
+basic_inline_string_base<CharT, AllowDram, Traits>::at(size_type p)
 {
 	if (p >= size())
-		throw std::out_of_range("basic_inline_string::at");
+		throw std::out_of_range("basic_inline_string_base::at");
 
 	return snapshotted_data(p, 1)[0];
 }
@@ -299,12 +419,12 @@ basic_inline_string<CharT, Traits>::at(size_type p)
  *
  * @throw std::out_of_range if p is not within the range of the container.
  */
-template <typename CharT, typename Traits>
-typename basic_inline_string<CharT, Traits>::const_reference
-basic_inline_string<CharT, Traits>::at(size_type p) const
+template <typename CharT, bool AllowDram, typename Traits>
+typename basic_inline_string_base<CharT, AllowDram, Traits>::const_reference
+basic_inline_string_base<CharT, AllowDram, Traits>::at(size_type p) const
 {
 	if (p >= size())
-		throw std::out_of_range("basic_inline_string::at");
+		throw std::out_of_range("basic_inline_string_base::at");
 
 	return cdata()[p];
 }
@@ -322,12 +442,13 @@ basic_inline_string<CharT, Traits>::at(size_type p) const
  * container.
  * @throw pmem::transaction_error when snapshotting failed.
  */
-template <typename CharT, typename Traits>
-slice<typename basic_inline_string<CharT, Traits>::pointer>
-basic_inline_string<CharT, Traits>::range(size_type start, size_type n)
+template <typename CharT, bool AllowDram, typename Traits>
+obj::slice<typename basic_inline_string_base<CharT, AllowDram, Traits>::pointer>
+basic_inline_string_base<CharT, AllowDram, Traits>::range(size_type start,
+							  size_type n)
 {
 	if (start + n > size())
-		throw std::out_of_range("basic_inline_string::range");
+		throw std::out_of_range("basic_inline_string_base::range");
 
 	auto data = snapshotted_data(start, n);
 
@@ -338,9 +459,10 @@ basic_inline_string<CharT, Traits>::range(size_type start, size_type n)
  * Return pointer to data at position p and if there is an active transaction
  * snapshot elements from p to p + n.
  */
-template <typename CharT, typename Traits>
-typename basic_inline_string<CharT, Traits>::pointer
-basic_inline_string<CharT, Traits>::snapshotted_data(size_t p, size_t n)
+template <typename CharT, bool AllowDram, typename Traits>
+typename basic_inline_string_base<CharT, AllowDram, Traits>::pointer
+basic_inline_string_base<CharT, AllowDram, Traits>::snapshotted_data(size_t p,
+								     size_t n)
 {
 	assert(p + n <= size());
 
@@ -356,15 +478,16 @@ basic_inline_string<CharT, Traits>::snapshotted_data(size_t p, size_t n)
  * @throw std::out_of_range if rhs is larger than capacity.
  * @throw pool_error if inline string is not on pmem.
  */
-template <typename CharT, typename Traits>
-basic_inline_string<CharT, Traits> &
-basic_inline_string<CharT, Traits>::assign(basic_string_view<CharT, Traits> rhs)
+template <typename CharT, bool AllowDram, typename Traits>
+basic_inline_string_base<CharT, AllowDram, Traits> &
+basic_inline_string_base<CharT, AllowDram, Traits>::assign(
+	obj::basic_string_view<CharT, Traits> rhs)
 {
 	auto cpop = pmemobj_pool_by_ptr(this);
 	if (nullptr == cpop)
 		throw pmem::pool_error("Invalid pool handle.");
 
-	auto pop = pool_base(cpop);
+	auto pop = obj::pool_base(cpop);
 
 	if (rhs.size() > capacity())
 		throw std::out_of_range("inline_string capacity exceeded.");
@@ -392,52 +515,17 @@ basic_inline_string<CharT, Traits>::assign(basic_string_view<CharT, Traits> rhs)
 	return *this;
 }
 
-/**
- * A helper trait which calculates required memory capacity (in bytes) for a
- * type.
- *
- * All standard types require capacity equal to the sizeof of such type.
- */
-template <typename T>
-struct total_sizeof {
-	template <typename... Args>
-	static size_t
-	value(const Args &... args)
-	{
-		return sizeof(T);
-	}
-};
-
-/**
- * A helper trait which calculates required memory capacity (in bytes) for a
- * type.
- *
- * Inline_string requires capacity of sizeof(basic_inline_string<CharT>) + size
- * of the data itself.
- */
-template <typename CharT, typename Traits>
-struct total_sizeof<basic_inline_string<CharT, Traits>> {
-	static size_t
-	value(const basic_string_view<CharT, Traits> &s)
-	{
-		return sizeof(basic_inline_string<CharT, Traits>) +
-			(s.size() + 1 /* '\0' */) * sizeof(CharT);
-	}
-};
-} /* namespace experimental */
-} /* namespace obj */
-
-namespace detail
-{
-/* Check if type is pmem::obj::basic_inline_string */
+/* Check if type is pmem::obj::basic_inline_string_base */
 template <typename>
 struct is_inline_string : std::false_type {
 };
 
 template <typename CharT, typename Traits>
-struct is_inline_string<obj::experimental::basic_inline_string<CharT, Traits>>
+struct is_inline_string<
+	pmem::obj::experimental::basic_inline_string<CharT, Traits>>
     : std::true_type {
 };
+
 } /* namespace detail */
 
 } /* namespace pmem */

--- a/include/libpmemobj++/experimental/inline_string.hpp
+++ b/include/libpmemobj++/experimental/inline_string.hpp
@@ -62,7 +62,7 @@ public:
 	const_pointer data() const noexcept;
 	const_pointer cdata() const noexcept;
 
-	int compare(const basic_inline_string_base &rhs) const noexcept;
+	int compare(obj::basic_string_view<CharT, Traits> rhs) const noexcept;
 
 	reference operator[](size_type p);
 	const_reference operator[](size_type p) const noexcept;
@@ -356,7 +356,7 @@ basic_inline_string_base<CharT, AllowDram, Traits>::cdata() const noexcept
 template <typename CharT, bool AllowDram, typename Traits>
 int
 basic_inline_string_base<CharT, AllowDram, Traits>::compare(
-	const basic_inline_string_base &rhs) const noexcept
+	obj::basic_string_view<CharT, Traits> rhs) const noexcept
 {
 	return obj::basic_string_view<CharT, Traits>(data(), size())
 		.compare(rhs);

--- a/tests/inline_string/inline_string.cpp
+++ b/tests/inline_string/inline_string.cpp
@@ -247,12 +247,12 @@ test_inline_string(nvobj::pool<struct root<T>> &pop)
 	});
 }
 
-/* test if inline_string can be placed on dram */
+/* test if dram_inline_string can be placed on dram */
 template <typename T>
 void
 test_dram(nvobj::pool<struct root<T>> &pop)
 {
-	using string_type = nvobj::experimental::basic_inline_string<T>;
+	using string_type = nvobj::experimental::basic_dram_inline_string<T>;
 
 	constexpr size_t string_size = 20;
 	typename std::aligned_storage<sizeof(string_type) +


### PR DESCRIPTION
and create a separate type: baisc_dram_inline_string which
have no such limitation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1160)
<!-- Reviewable:end -->
