### PR TITLE
tests: remove Testcase1 object before exiting from test.

### DIFF
--- a/tests/external/libcxx/array/array.tuple/get_const_rv.pass.cpp
+++ b/tests/external/libcxx/array/array.tuple/get_const_rv.pass.cpp
@@ -55,6 +55,11 @@ run(pmem::obj::pool<root> &pop)
 
 		pmem::obj::transaction::run(pop,
 					    [&] { pop.root()->r1->run(); });
+
+		pmem::obj::transaction::run(pop, [&] {
+			pmem::obj::delete_persistent<Testcase1>(pop.root()->r1);
+		});
+
 	} catch (...) {
 		UT_ASSERT(0);
 	}


### PR DESCRIPTION
To avoid memory leak (reported by ASAN)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1162)
<!-- Reviewable:end -->
