### PR TITLE
inline_string: implement copy assignment operator

### DIFF
--- a/include/libpmemobj++/experimental/inline_string.hpp
+++ b/include/libpmemobj++/experimental/inline_string.hpp
@@ -124,6 +124,14 @@ public:
 	    : basic_inline_string_base<CharT, Traits>(rhs)
 	{
 	}
+
+	basic_dram_inline_string &
+	operator=(const basic_dram_inline_string &rhs)
+	{
+		return static_cast<basic_dram_inline_string &>(this->operator=(
+			static_cast<const basic_inline_string_base<
+				CharT, Traits> &>(rhs)));
+	}
 };
 
 /**
@@ -177,6 +185,14 @@ public:
 	basic_inline_string(const basic_inline_string &rhs)
 	    : basic_inline_string_base<CharT, Traits>(check_forward(rhs))
 	{
+	}
+
+	basic_inline_string &
+	operator=(const basic_inline_string &rhs)
+	{
+		return static_cast<basic_inline_string &>(this->operator=(
+			static_cast<const basic_inline_string_base<
+				CharT, Traits> &>(rhs)));
 	}
 
 private:


### PR DESCRIPTION
Older compilers have problems with using assignment operator
from the base class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1167)
<!-- Reviewable:end -->
