### PR TITLE
disable 'maybe-uninitialized' compiler flag

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -15,6 +15,7 @@ add_flag(-Wmissing-variable-declarations)
 add_flag(-fno-common)
 add_flag(-Wunused-macros)
 add_flag(-Wsign-conversion)
+add_flag(-Wno-maybe-uninitialized)
 
 add_flag(-ggdb DEBUG)
 add_flag(-DDEBUG DEBUG)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,6 +24,7 @@ add_flag(-Wsign-compare)
 add_flag(-Wunreachable-code-return)
 add_flag(-Wmissing-variable-declarations)
 add_flag(-fno-common)
+add_flag(-Wno-maybe-uninitialized)
 #add_flag(-Wunused-macros)
 #add_flag(-Wsign-conversion)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ add_flag(-Wsign-compare)
 add_flag(-Wunreachable-code-return)
 add_flag(-Wmissing-variable-declarations)
 add_flag(-fno-common)
+add_flag(-Wno-maybe-uninitialized)
 
 add_flag(-ggdb DEBUG)
 add_flag(-DDEBUG DEBUG)


### PR DESCRIPTION
in tests, examples and benchmarks - it produces many false-positives.

// preview on new OSes: https://github.com/lukaszstolarczuk/libpmemobj-cpp/actions/runs/1059810305

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1175)
<!-- Reviewable:end -->
