### PR TITLE
Make index_sequence helpers compatible with std versions

### DIFF
--- a/include/libpmemobj++/detail/integer_sequence.hpp
+++ b/include/libpmemobj++/detail/integer_sequence.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2016-2020, Intel Corporation */
+/* Copyright 2016-2021, Intel Corporation */
 
 /**
  * @file
@@ -10,6 +10,7 @@
 #define LIBPMEMOBJ_CPP_INTEGER_SEQUENCE_HPP
 
 #include <cstddef>
+#include <type_traits>
 
 namespace pmem
 {
@@ -30,46 +31,49 @@ struct integer_sequence {
 template <size_t... Indices>
 using index_sequence = integer_sequence<size_t, Indices...>;
 
-/*
- * Empty base class.
- *
- * Subject of empty base optimization.
- */
-template <typename T, T I, typename... Types>
+template <typename T, T N, typename Enable, T... I>
 struct make_integer_seq_impl;
 
 /*
- * Class ending recursive variadic template peeling.
+ * Helper for make_integer_sequence, specialization for N == 0 (end of
+ * recursion).
  */
-template <typename T, T I, T... Indices>
-struct make_integer_seq_impl<T, I, integer_sequence<T, Indices...>> {
-	typedef integer_sequence<T, Indices...> type;
+template <typename T, T N, T... I>
+struct make_integer_seq_impl<T, N, typename std::enable_if<N == 0>::type,
+			     I...> {
+	using type = integer_sequence<T, I...>;
 };
 
 /*
- * Recursively create index while peeling off the types.
+ * Helper for make_integer_sequence, base case.
  */
-template <typename N, N I, N... Indices, typename T, typename... Types>
-struct make_integer_seq_impl<N, I, integer_sequence<N, Indices...>, T,
-			     Types...> {
-	typedef typename make_integer_seq_impl<
-		N, I + 1, integer_sequence<N, Indices..., I>, Types...>::type
-		type;
+template <typename T, T N, T... I>
+struct make_integer_seq_impl<T, N, typename std::enable_if<N != 0>::type,
+			     I...> {
+	using type = typename make_integer_seq_impl<T, N - 1, void, N - 1,
+						    I...>::type;
 };
 
 /*
- * Make index sequence entry point.
+ * Implementation of std::make_integer_sequence which works with C++11.
  */
-template <typename... Types>
-using make_index_sequence =
-	make_integer_seq_impl<size_t, 0, integer_sequence<size_t>, Types...>;
+template <typename T, T N>
+using make_integer_sequence = typename make_integer_seq_impl<T, N, void>::type;
 
 /*
+ * Implementation of std::make_index_sequence which works with C++11.
+ */
+template <size_t N>
+using make_index_sequence = make_integer_sequence<size_t, N>;
+
+/*
+ * Implementation of std::index_sequence_for which works with C++11.
+ *
  * A helper alias template to convert any type parameter pack into an index
- * sequence of the same length. Analog of std::index_sequence_for.
+ * sequence of the same length.
  */
 template <class... Types>
-using index_sequence_for = typename make_index_sequence<Types...>::type;
+using index_sequence_for = make_index_sequence<sizeof...(Types)>;
 
 } /* namespace detail */
 

--- a/include/libpmemobj++/detail/life.hpp
+++ b/include/libpmemobj++/detail/life.hpp
@@ -119,9 +119,9 @@ c_style_construct(void *ptr, void *arg)
 {
 	auto *arg_pack = static_cast<Tuple *>(arg);
 
-	typedef typename make_index_sequence<Args...>::type index;
 	try {
-		create_from_tuple<T>(ptr, index(), std::move(*arg_pack));
+		create_from_tuple<T>(ptr, index_sequence_for<Args...>{},
+				     std::move(*arg_pack));
 	} catch (...) {
 		return -1;
 	}

--- a/include/libpmemobj++/detail/pair.hpp
+++ b/include/libpmemobj++/detail/pair.hpp
@@ -28,9 +28,8 @@ struct pair {
 	template <typename... Args1, typename... Args2>
 	pair(std::piecewise_construct_t pc, std::tuple<Args1...> first_args,
 	     std::tuple<Args2...> second_args)
-	    : pair(pc, first_args, second_args,
-		   typename make_index_sequence<Args1...>::type{},
-		   typename make_index_sequence<Args2...>::type{})
+	    : pair(pc, first_args, second_args, index_sequence_for<Args1...>{},
+		   index_sequence_for<Args2...>{})
 	{
 	}
 

--- a/include/libpmemobj++/experimental/radix_tree.hpp
+++ b/include/libpmemobj++/experimental/radix_tree.hpp
@@ -3459,8 +3459,8 @@ radix_tree<Key, Value, BytesView, MtMode>::leaf::make(pointer_type parent)
 {
 	auto t = std::make_tuple();
 	return make(parent, std::piecewise_construct, t, t,
-		    typename detail::make_index_sequence<>::type{},
-		    typename detail::make_index_sequence<>::type{});
+		    detail::index_sequence_for<>{},
+		    detail::index_sequence_for<>{});
 }
 
 template <typename Key, typename Value, typename BytesView, bool MtMode>
@@ -3471,8 +3471,8 @@ radix_tree<Key, Value, BytesView, MtMode>::leaf::make(
 	std::tuple<Args1...> first_args, std::tuple<Args2...> second_args)
 {
 	return make(parent, pc, first_args, second_args,
-		    typename detail::make_index_sequence<Args1...>::type{},
-		    typename detail::make_index_sequence<Args2...>::type{});
+		    detail::index_sequence_for<Args1...>{},
+		    detail::index_sequence_for<Args2...>{});
 }
 
 template <typename Key, typename Value, typename BytesView, bool MtMode>


### PR DESCRIPTION
This change enables creating index_sequences from single number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1185)
<!-- Reviewable:end -->
