### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         CONFIG: ["OS=centos OS_VER=8",
+                 "OS=almalinux OS_VER=8",
                  "OS=archlinux-base OS_VER=latest",
                  "OS=debian OS_VER=testing",
                  "OS=debian OS_VER=unstable",

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -24,10 +24,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        CONFIG: ["TYPE=debug OS=ubuntu OS_VER=20.04 TESTS_ASAN=1 TESTS_PMREORDER=0",
-                 "TYPE=debug OS=ubuntu OS_VER=20.04 TESTS_UBSAN=1 TESTS_PMREORDER=0",
-                 "TYPE=debug OS=fedora OS_VER=rawhide TESTS_ASAN=1 TESTS_PMREORDER=0",
-                 "TYPE=debug OS=fedora OS_VER=rawhide TESTS_UBSAN=1 TESTS_PMREORDER=0",
+        CONFIG: ["TYPE=debug OS=ubuntu OS_VER=devel TESTS_ASAN=1 TESTS_PMREORDER=0",
+                 "TYPE=debug OS=ubuntu OS_VER=devel TESTS_UBSAN=1 TESTS_PMREORDER=0",
+                 "TYPE=debug OS=fedora OS_VER=34 TESTS_ASAN=1 TESTS_PMREORDER=0",
+                 "TYPE=debug OS=fedora OS_VER=34 TESTS_UBSAN=1 TESTS_PMREORDER=0",
                  "TYPE=valgrind OS=fedora OS_VER=rawhide TESTS_PMREORDER=0",
                  "TYPE=memcheck_drd OS=fedora OS_VER=rawhide TESTS_PMREORDER=0",
                  "TYPE=package OS=fedora OS_VER=34",

--- a/utils/docker/images/Dockerfile.almalinux-8
+++ b/utils/docker/images/Dockerfile.almalinux-8
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2016-2021, Intel Corporation
+
+#
+# Dockerfile - a 'recipe' for Docker to build an image of almalinux-based
+#              environment prepared for running libpmemobj-cpp tests.
+#
+
+# Pull base image
+FROM registry.hub.docker.com/library/almalinux:8
+MAINTAINER igor.chorazewicz@intel.com
+
+# Set required environment variables
+ENV OS almalinux
+ENV OS_VER 8
+ENV PACKAGE_MANAGER rpm
+ENV NOTTY 1
+
+# Additional parameters to build docker without building components
+ARG SKIP_VALGRIND_BUILD
+ARG SKIP_PMDK_BUILD
+
+# Base development packages
+ARG BASE_DEPS="\
+	cmake \
+	gcc \
+	gcc-c++ \
+	git \
+	make"
+
+# Dependencies for compiling libpmemobj-cpp project
+ARG LIBPMEMOBJ_CPP_DEPS="\
+	libatomic \
+	tbb-devel"
+
+# PMDK's dependencies (optional; libpmemobj-devel package may be used instead)
+ARG PMDK_DEPS="\
+	autoconf \
+	automake \
+	daxctl-devel \
+	gdb \
+	man \
+	ndctl-devel \
+	pandoc \
+	python3 \
+	rpm-build \
+	rpm-build-libs \
+	rpmdevtools \
+	which"
+
+# pmem's Valgrind dependencies (optional; valgrind-devel package may be used instead)
+ARG VALGRIND_DEPS="\
+	autoconf \
+	automake"
+
+# Examples (optional)
+ARG EXAMPLES_DEPS="\
+	ncurses-devel"
+
+# Documentation (optional)
+ARG DOC_DEPS="\
+	doxygen"
+
+# Tests (optional)
+# NOTE: glibc is installed as a separate command; see below
+ARG TESTS_DEPS="\
+	gdb \
+	libunwind-devel"
+
+# Misc for our builds/CI (optional)
+ARG MISC_DEPS="\
+	clang \
+	passwd \
+	perl-Text-Diff \
+	pkgconf \
+	sudo"
+
+# Update package repository, extend dnf's package base and install basic tools
+RUN dnf update -y \
+ && dnf install -y epel-release \
+ && dnf install -y 'dnf-command(config-manager)' \
+ && dnf config-manager --set-enabled powertools \
+ && dnf update -y \
+ && dnf install -y --nobest \
+	${BASE_DEPS} \
+	${LIBPMEMOBJ_CPP_DEPS} \
+	${PMDK_DEPS} \
+	${VALGRIND_DEPS} \
+	${EXAMPLES_DEPS} \
+	${DOC_DEPS} \
+	${TESTS_DEPS} \
+	${MISC_DEPS} \
+ && dnf debuginfo-install -y glibc \
+ && dnf clean all
+
+# Install valgrind
+COPY install-valgrind.sh install-valgrind.sh
+RUN ./install-valgrind.sh
+
+# Install pmdk
+COPY install-pmdk.sh install-pmdk.sh
+RUN ./install-pmdk.sh rpm
+
+# Add user
+ENV USER user
+ENV USERPASS pass
+RUN useradd -m $USER \
+ && echo $USERPASS | passwd $USER --stdin \
+ && gpasswd wheel -a $USER
+USER $USER

--- a/utils/docker/images/install-pmdk.sh
+++ b/utils/docker/images/install-pmdk.sh
@@ -16,8 +16,9 @@ fi
 
 PACKAGE_MANAGER=${1}
 
-# master: 1.11.0, 02.07.2021
-PMDK_VERSION="8583fcfd68764ac6779e6f93db89b06971b26704"
+# master: Merge pull request #5304 from lukaszstolarczuk/update-build-rpm-sh, 07.09.2021
+# Adds support for rpm's creation on Alma Linux
+PMDK_VERSION="75d3cd27589c7e0823d48b32353253975752666b"
 
 git clone https://github.com/pmem/pmdk
 cd pmdk


### PR DESCRIPTION
- add an image for AlmaLinux 8 (based on CentOS 8 image) and enable it in nightly build,
- add more weekly jobs,
- switch fedora jobs from Fedora Rawhide (which is currently having some hard times - [see a bug](https://bugzilla.redhat.com/show_bug.cgi?id=1988199)) to a stable Fedora release, and use Ubuntu devel instead (it suppose to be under development, similarly to rawhide).

// Done similarly to https://github.com/pmem/pmemkv/pull/1043
// It's kept as a draft, since right now Ubuntu devel is having a hard time as well 😄 (see our nightly build: https://github.com/pmem/libpmemobj-cpp/runs/3539969955?check_suite_focus=true )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1197)
<!-- Reviewable:end -->
