### PR TITLE
docs: fix docstring

### DIFF
--- a/include/libpmemobj++/persistent_ptr.hpp
+++ b/include/libpmemobj++/persistent_ptr.hpp
@@ -380,7 +380,7 @@ public:
 		return *this;
 	}
 
-	/*
+	/**
 	 * Bool conversion operator.
 	 */
 	explicit operator bool() const noexcept


### PR DESCRIPTION
The docstring for `pmem::obj::persistent_ptr::operator bool()` is not picked by oxygen. 

See https://pmem.io/libpmemobj-cpp/master/doxygen/classpmem_1_1obj_1_1persistent__ptr.html#a3c83f8de97e8d3b48133c997ac487a43.

This PR fixes this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1202)
<!-- Reviewable:end -->
