### PR TITLE
Fix Docker image version(s) in CI

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -48,9 +48,16 @@ jobs:
           echo "FORCE_IMAGE_ACTION=rebuild" >> $GITHUB_ENV
 
       - name: Set image version and force image action for stable branch
-        if: startsWith(github.ref, 'refs/heads/stable-')
+        # we want to set IMG_VER to e.g. '1.x' for stable branches and PRs against them
+        # for PRs we have to use 'base_ref' - this is the target branch (and we have to check that instead)
+        if:
+          startsWith(github.ref, 'refs/heads/stable-') || startsWith(github.base_ref, 'stable-')
+        # we now know we're on (or against) stable branches, so we just need to pick the version (e.g. the mentioned '1.x')
         run: |
-          echo "IMG_VER=$(echo ${GITHUB_REF#refs/heads/} | cut -d - -f 2)" >> $GITHUB_ENV
+          IMG_VER=$(echo ${GITHUB_BASE_REF} | cut -d - -f 2)
+          [ -z "${IMG_VER}" ] \
+              && echo "IMG_VER=$(echo ${GITHUB_REF#refs/heads/} | cut -d - -f 2)" >> $GITHUB_ENV \
+              || echo "IMG_VER=${IMG_VER}" >> $GITHUB_ENV
           echo "FORCE_IMAGE_ACTION=rebuild" >> $GITHUB_ENV
 
       - name: Clone the git repo

--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Get release version
         if: github.event_name == 'release'
         id: get_release_version
-        run: echo ::set-output name=VERSION::$(echo ${{ github.event.release.tag_name }} | grep -E "^[0-9]+.[0-9]+(-rc[0-9]+)?$" | cut -f 1,2 -d . | cut -f 1 -d -)
+        run: echo ::set-output name=VERSION::$(echo ${{ github.event.release.tag_name }} | awk -F '[.-]' '/^[0-9]+.[0-9]+[.0-9]*(-rc[0-9]+)?$/ {print $1 "." $2}')
 
       - name: Set image version and force image action for release
         if: github.event_name == 'release' && steps.get_release_version.outputs.VERSION != ''

--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Run the build
         run: cd $WORKDIR && ${{ matrix.CONFIG }} ./build.sh
+
   doc:
     name: build and publish docs
     runs-on: ubuntu-latest
@@ -86,6 +87,12 @@ jobs:
       matrix:
         CONFIG: ["TYPE=doc OS=fedora OS_VER=32"]
     steps:
+      - name: Set image version for stable branch
+        # doc update happens only on stable branch (not on PR), so we check only for heads ref
+        if: startsWith(github.ref, 'refs/heads/stable-')
+        run: |
+          echo "IMG_VER=$(echo ${GITHUB_REF#refs/heads/} | cut -d - -f 2)" >> $GITHUB_ENV
+
       - name: Clone the git repo
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
- the first commit fixes skipped step (https://github.com/pmem/libpmemobj-cpp/runs/3172155142?check_suite_focus=true)
- the second one fixes wrong image version (https://github.com/pmem/libpmemobj-cpp/runs/3629630210?check_suite_focus=true#step:6:39 - 'latest' instead of '1.13')
- the last one fixes our docs generation on a stable branch (https://github.com/pmem/libpmemobj-cpp/runs/3633674396?check_suite_focus=true)

all these fixes apply at the earliest to stable-1.12 branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1204)
<!-- Reviewable:end -->
