### PR TITLE
docker: add missing hub package

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-32
+++ b/utils/docker/images/Dockerfile.fedora-32
@@ -71,7 +71,6 @@ ARG TESTS_DEPS="\
 # Misc for our builds/CI (optional)
 ARG MISC_DEPS="\
 	clang \
-	hub \
 	perl-Text-Diff \
 	pkgconf \
 	sudo"

--- a/utils/docker/images/Dockerfile.fedora-34
+++ b/utils/docker/images/Dockerfile.fedora-34
@@ -71,6 +71,7 @@ ARG TESTS_DEPS="\
 # Misc for our builds/CI (optional)
 ARG MISC_DEPS="\
 	clang \
+	hub \
 	perl-Text-Diff \
 	pkgconf \
 	sudo"


### PR DESCRIPTION
it wasn't added into Fedora 34, while we bumped 'doc' job to use latest Fedora.

// Fixes this GHA issue: https://github.com/pmem/libpmemobj-cpp/runs/3687415718?check_suite_focus=true#step:5:27
mea culpa, I've added the `hub` package into F34, but [on master](https://github.com/pmem/libpmemobj-cpp/blob/master/utils/docker/images/Dockerfile.fedora-34#L74), yikes 😭

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1208)
<!-- Reviewable:end -->
