### PR TITLE
Atomic persistent-aware pointer

### DIFF
--- a/include/libpmemobj++/experimental/atomic_persistent_aware_ptr.hpp
+++ b/include/libpmemobj++/experimental/atomic_persistent_aware_ptr.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020-2021, Intel Corporation */
+/* Copyright 2021-2022, Intel Corporation */
 
 /**
  * @file
@@ -288,8 +288,8 @@ namespace detail
 {
 
 /**
- * pmem::detail::can_do_snapshot atomic specialization for self_relative_ptr.
- * Not thread safe.
+ * pmem::detail::can_do_snapshot atomic specialization for persistent-aware
+ * self_relative_ptr. Not thread safe.
  *
  * Use in a single-threaded environment only.
  */
@@ -302,7 +302,7 @@ struct can_do_snapshot<
 		sizeof(obj::experimental::atomic_persistent_aware_ptr<
 			T, ReadOptimized>) == sizeof(snapshot_type);
 	static_assert(value,
-		      "std::atomic<self_relative_ptr> should be the same size");
+		      "atomic_persistent_aware_ptr should be the same size");
 };
 
 } /* namespace detail */

--- a/include/libpmemobj++/experimental/atomic_persistent_aware_ptr.hpp
+++ b/include/libpmemobj++/experimental/atomic_persistent_aware_ptr.hpp
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2020-2021, Intel Corporation */
+
+/**
+ * @file
+ * Atomic specialization for persistent-ware self_relative_ptr.
+ */
+
+#ifndef LIBPMEMOBJ_CPP_ATOMIC_PERSISTENT_AWARE_PTR_HPP
+#define LIBPMEMOBJ_CPP_ATOMIC_PERSISTENT_AWARE_PTR_HPP
+
+#include <libpmemobj++/detail/common.hpp>
+#include <libpmemobj++/detail/self_relative_ptr_base_impl.hpp>
+#include <libpmemobj++/experimental/atomic_self_relative_ptr.hpp>
+#include <libpmemobj++/experimental/self_relative_ptr.hpp>
+#include <libpmemobj++/transaction.hpp>
+#include <libpmemobj++/utils.hpp>
+
+#include <atomic>
+
+namespace pmem
+{
+namespace obj
+{
+namespace experimental
+{
+
+template <typename T, typename ReadOptimized>
+struct atomic_persistent_aware_ptr {
+private:
+	using ptr_type = pmem::detail::self_relative_ptr_base_impl<
+		std::atomic<std::ptrdiff_t>>;
+	using accessor = pmem::detail::self_relative_accessor<
+		std::atomic<std::ptrdiff_t>>;
+
+	static constexpr uintptr_t IS_DIRTY = 1;
+
+public:
+	using this_type = atomic_persistent_aware_ptr;
+	using value_type = pmem::obj::experimental::self_relative_ptr<T>;
+	using difference_type = typename value_type::difference_type;
+
+	/*
+	 * Constructors
+	 */
+
+	constexpr atomic_persistent_aware_ptr() noexcept = default;
+	atomic_persistent_aware_ptr(value_type value) : ptr()
+	{
+		store(value);
+	}
+	atomic_persistent_aware_ptr(const atomic_persistent_aware_ptr &) =
+		delete;
+
+	/*
+	 * Read-optimized store do the flush in store function, and clear the
+	 * dirty marker after flush.
+	 */
+	template <typename OPT = ReadOptimized>
+	typename std::enable_if<std::is_same<OPT, std::true_type>::value>::type
+	store(value_type desired,
+	      std::memory_order order = std::memory_order_seq_cst) noexcept
+	{
+		auto dirty_desired = mark_dirty(desired);
+		ptr.store(dirty_desired, order);
+		pool_by_vptr(this).persist(&ptr, sizeof(ptr));
+		ptr.compare_exchange_strong(dirty_desired, clear_dirty(desired),
+					    order);
+	}
+
+	/*
+	 * Write-optimized store updates the ptr with the dirty flag, relies on
+	 * consequent load to do the flush.
+	 */
+	template <typename OPT = ReadOptimized>
+	typename std::enable_if<!std::is_same<OPT, std::true_type>::value>::type
+	store(value_type desired,
+	      std::memory_order order = std::memory_order_seq_cst) noexcept
+	{
+		ptr.store(mark_dirty(desired), order);
+	}
+
+	/*
+	 * Read-optimized load retries upon dirty ptr, relies on tge store
+	 * function to clear the dirty before continue.
+	 */
+	template <typename OPT = ReadOptimized>
+	typename std::enable_if<std::is_same<OPT, std::true_type>::value,
+				value_type>::type
+	load(std::memory_order order = std::memory_order_seq_cst) noexcept
+	{
+		auto val = ptr.load(order);
+		while (is_dirty(val)) {
+			std::this_thread::yield();
+			val = ptr.load(order);
+		}
+		return val;
+	}
+	/*
+	 * Write-optimized load flushes the ptr with the dirty flag, clears the
+	 * flag using CAS after flush.
+	 */
+	template <typename OPT = ReadOptimized>
+	typename std::enable_if<!std::is_same<OPT, std::true_type>::value,
+				value_type>::type
+	load(std::memory_order order = std::memory_order_seq_cst) noexcept
+	{
+		auto val = ptr.load(order);
+		while (is_dirty(val)) {
+			pool_by_vptr(this).persist(&ptr, sizeof(ptr));
+			auto clean_val = clear_dirty(val);
+			if (ptr.compare_exchange_strong(val, clean_val, order))
+				return clean_val;
+		}
+		return val;
+	}
+
+	value_type
+	exchange(value_type desired,
+		 std::memory_order order = std::memory_order_seq_cst) noexcept
+	{
+		return ptr.exchange(desired, order);
+	}
+
+	bool
+	compare_exchange_weak(value_type &expected, value_type desired,
+			      std::memory_order success,
+			      std::memory_order failure) noexcept
+	{
+		return ptr.compare_exchange_weak(expected, desired, success,
+						 failure);
+	}
+
+	bool
+	compare_exchange_weak(
+		value_type &expected, value_type desired,
+		std::memory_order order = std::memory_order_seq_cst) noexcept
+	{
+		return ptr.compare_exchange_weak(expected, desired, order);
+	}
+
+	bool
+	compare_exchange_strong(value_type &expected, value_type desired,
+				std::memory_order success,
+				std::memory_order failure) noexcept
+	{
+		return ptr.compare_exchange_strong(expected, desired, success,
+						   failure);
+	}
+
+	bool
+	compare_exchange_strong(
+		value_type &expected, value_type desired,
+		std::memory_order order = std::memory_order_seq_cst) noexcept
+	{
+		return ptr.compare_exchange_strong(expected, desired, order);
+	}
+
+	value_type
+	fetch_add(difference_type val,
+		  std::memory_order order = std::memory_order_seq_cst) noexcept
+	{
+		return ptr.fetch_add(val, order);
+	}
+
+	value_type
+	fetch_sub(difference_type val,
+		  std::memory_order order = std::memory_order_seq_cst) noexcept
+	{
+		return ptr.fetch_sub(val, order);
+	}
+
+	bool
+	is_lock_free() const noexcept
+	{
+		return ptr.is_lock_free();
+	}
+
+	/*
+	 * Operators
+	 */
+
+	operator value_type() const noexcept
+	{
+		return load();
+	}
+
+	value_type
+	operator=(value_type desired) noexcept
+	{
+		store(desired);
+		return desired;
+	}
+
+	value_type
+	operator++() noexcept
+	{
+		try {
+			return this->fetch_add(1) + 1;
+		} catch (...) {
+			/* This should never happen during normal program
+			 * execution */
+			std::terminate();
+		}
+	}
+
+	value_type
+	operator++(int) noexcept
+	{
+		return this->fetch_add(1);
+	}
+
+	value_type
+	operator--() noexcept
+	{
+		try {
+			return this->fetch_sub(1) - 1;
+		} catch (...) {
+			/* This should never happen during normal program
+			 * execution */
+			std::terminate();
+		}
+	}
+
+	value_type
+	operator--(int) noexcept
+	{
+		return this->fetch_sub(1);
+	}
+
+	value_type
+	operator+=(difference_type diff) noexcept
+	{
+		try {
+			return this->fetch_add(diff) + diff;
+		} catch (...) {
+			/* This should never happen during normal program
+			 * execution */
+			std::terminate();
+		}
+	}
+
+	value_type
+	operator-=(difference_type diff) noexcept
+	{
+		try {
+			return this->fetch_sub(diff) - diff;
+		} catch (...) {
+			/* This should never happen during normal program
+			 * execution */
+			std::terminate();
+		}
+	}
+
+private:
+	value_type
+	mark_dirty(value_type ptr) const
+	{
+		auto dirty_ptr =
+			reinterpret_cast<uintptr_t>(ptr.get()) | IS_DIRTY;
+		return value_type{reinterpret_cast<T *>(dirty_ptr)};
+	}
+
+	value_type
+	clear_dirty(value_type ptr) const
+	{
+		auto clear_ptr =
+			reinterpret_cast<uintptr_t>(ptr.get()) & ~IS_DIRTY;
+		return value_type{reinterpret_cast<T *>(clear_ptr)};
+	}
+
+	bool
+	is_dirty(value_type ptr) const
+	{
+		return reinterpret_cast<uintptr_t>(ptr.get()) & IS_DIRTY;
+	}
+
+	std::atomic<self_relative_ptr<T>> ptr;
+};
+} // namespace experimental
+} // namespace obj
+} // namespace pmem
+
+namespace pmem
+{
+
+namespace detail
+{
+
+/**
+ * pmem::detail::can_do_snapshot atomic specialization for self_relative_ptr.
+ * Not thread safe.
+ *
+ * Use in a single-threaded environment only.
+ */
+template <typename T, typename ReadOptimized>
+struct can_do_snapshot<
+	obj::experimental::atomic_persistent_aware_ptr<T, ReadOptimized>> {
+	using snapshot_type =
+		std::atomic<obj::experimental::self_relative_ptr<T>>;
+	static constexpr bool value =
+		sizeof(obj::experimental::atomic_persistent_aware_ptr<
+			T, ReadOptimized>) == sizeof(snapshot_type);
+	static_assert(value,
+		      "std::atomic<self_relative_ptr> should be the same size");
+};
+
+} /* namespace detail */
+
+} /* namespace pmem */
+
+#endif // LIBPMEMOBJ_CPP_ATOMIC_PERSISTENT_AWARE_PTR_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -318,6 +318,9 @@ if(TEST_SELF_RELATIVE_POINTER)
 
 	build_test(self_relative_ptr_atomic_pmem ptr/self_relative_ptr_atomic_pmem.cpp)
 	add_test_generic(NAME self_relative_ptr_atomic_pmem TRACERS none memcheck pmemcheck drd helgrind)
+
+	build_test(atomic_persistent_aware_ptr_pmem ptr/atomic_persistent_aware_ptr_pmem.cpp)
+	add_test_generic(NAME atomic_persistent_aware_ptr_pmem TRACERS none memcheck pmemcheck drd helgrind)
 endif()
 
 add_subdirectory(external)

--- a/tests/ptr/atomic_persistent_aware_ptr_pmem.cpp
+++ b/tests/ptr/atomic_persistent_aware_ptr_pmem.cpp
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2020, Intel Corporation */
+
+#include "thread_helpers.hpp"
+#include "unittest.hpp"
+
+#include <libpmemobj++/experimental/atomic_persistent_aware_ptr.hpp>
+#include <libpmemobj++/experimental/self_relative_ptr.hpp>
+#include <libpmemobj++/make_persistent.hpp>
+#include <libpmemobj++/make_persistent_array_atomic.hpp>
+#include <libpmemobj++/make_persistent_atomic.hpp>
+#include <libpmemobj++/p.hpp>
+#include <libpmemobj++/persistent_ptr.hpp>
+#include <libpmemobj++/persistent_ptr_base.hpp>
+#include <libpmemobj++/pool.hpp>
+#include <libpmemobj++/transaction.hpp>
+
+#define LAYOUT "cpp"
+
+namespace nvobj = pmem::obj;
+
+template <typename T>
+using self_relative_ptr = pmem::obj::experimental::self_relative_ptr<T>;
+template <typename T, typename ReadOptimized>
+using atomic_ptr =
+	pmem::obj::experimental::atomic_persistent_aware_ptr<T, ReadOptimized>;
+
+constexpr int ARR_SIZE = 10000;
+
+template <typename ReadOptimized>
+struct root {
+	atomic_ptr<nvobj::p<int>[ARR_SIZE], ReadOptimized> parr;
+	atomic_ptr<int, ReadOptimized> ptr;
+};
+
+namespace
+{
+
+template <typename ReadOptimized>
+void
+test_ptr_transactional(nvobj::pool<root<ReadOptimized>> &pop)
+{
+	auto r = pop.root();
+	try {
+		nvobj::transaction::run(pop, [&] {
+			UT_ASSERT(r->ptr.load() == nullptr);
+			nvobj::transaction::snapshot<
+				atomic_ptr<int, ReadOptimized>>(&r->ptr);
+			r->ptr = nvobj::make_persistent<int>();
+		});
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+
+	UT_ASSERT(r->ptr.load() != nullptr);
+
+	try {
+		nvobj::transaction::run(pop, [&] {
+			nvobj::delete_persistent<int>(r->ptr.load());
+			nvobj::transaction::snapshot<
+				atomic_ptr<int, ReadOptimized>>(&r->ptr);
+			r->ptr.store(nullptr);
+		});
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+
+	UT_ASSERT(r->ptr.load() == nullptr);
+}
+
+} /* namespace */
+
+inline const char *const
+BoolToString(bool b)
+{
+	return b ? "_readopt" : "_writeopt";
+}
+
+template <typename ReadOptimized>
+static void
+test(int argc, char *argv[])
+{
+	if (argc != 2)
+		UT_FATAL("usage: %s file-name", argv[0]);
+
+	char path[100];
+	strcpy(path, argv[1]);
+	strcat(path, BoolToString(ReadOptimized::value));
+
+	nvobj::pool<root<ReadOptimized>> pop;
+
+	try {
+		pop = nvobj::pool<root<ReadOptimized>>::create(
+			path, LAYOUT, PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR);
+	} catch (pmem::pool_error &pe) {
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
+	}
+
+	test_ptr_transactional(pop);
+
+	pop.close();
+}
+
+int
+main(int argc, char *argv[])
+{
+	auto ret_writeopt =
+		run_test([&] { test<std::false_type>(argc, argv); });
+	auto ret_readopt = run_test([&] { test<std::true_type>(argc, argv); });
+	return (ret_writeopt && ret_readopt);
+}


### PR DESCRIPTION
Hi @igchor ,
As we discussed, I created a new PR related to the implementation of `atomic_persistent_aware_ptr` only.
It contains two different options, read or write-optimized, for this ptr.
I added one UT based on the existing `self_relative_ptr_atomic_pmem`.
After this is merged, I'll implement a swmr_skip_list based on this with another PR.

Thanks a lot!
Best rgds,
Jun Yang