### PR TITLE
CI: turn libunwind off by default (in CMake)

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -34,8 +34,8 @@ jobs:
                  "TYPE=debug OS=ubuntu OS_VER=20.04 COVERAGE=1",
                  "TYPE=release OS=fedora OS_VER=34",
                  "TYPE=release OS=ubuntu OS_VER=20.04",
-                 "TYPE=valgrind OS=ubuntu OS_VER=20.04 TESTS_VALGRIND_UNWIND=0",
-                 "TYPE=memcheck_drd OS=ubuntu OS_VER=20.04 TESTS_VALGRIND_UNWIND=0",
+                 "TYPE=valgrind OS=ubuntu OS_VER=20.04",
+                 "TYPE=memcheck_drd OS=ubuntu OS_VER=20.04",
                  "TYPE=package OS=fedora OS_VER=34",
                  "TYPE=package OS=ubuntu OS_VER=20.04"]
     steps:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -28,8 +28,8 @@ jobs:
                  "TYPE=debug OS=ubuntu OS_VER=20.04 TESTS_UBSAN=1 TESTS_PMREORDER=0",
                  "TYPE=debug OS=fedora OS_VER=rawhide TESTS_ASAN=1 TESTS_PMREORDER=0",
                  "TYPE=debug OS=fedora OS_VER=rawhide TESTS_UBSAN=1 TESTS_PMREORDER=0",
-                 "TYPE=valgrind OS=fedora OS_VER=rawhide TESTS_PMREORDER=0 TESTS_VALGRIND_UNWIND=0",
-                 "TYPE=memcheck_drd OS=fedora OS_VER=rawhide TESTS_PMREORDER=0 TESTS_VALGRIND_UNWIND=0",
+                 "TYPE=valgrind OS=fedora OS_VER=rawhide TESTS_PMREORDER=0",
+                 "TYPE=memcheck_drd OS=fedora OS_VER=rawhide TESTS_PMREORDER=0",
                  "TYPE=package OS=fedora OS_VER=34",
                  "TYPE=package OS=fedora OS_VER=rawhide TESTS_PMREORDER=0",
                  "TYPE=package OS=ubuntu OS_VER=devel"]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ option(CHECK_CPP_STYLE "check code style of C++ sources" OFF)
 option(TRACE_TESTS "more verbose test outputs" OFF)
 option(USE_ASAN "enable AddressSanitizer (debugging)" OFF)
 option(USE_UBSAN "enable UndefinedBehaviorSanitizer (debugging)" OFF)
-option(USE_LIBUNWIND "use libunwind for more reliable stack traces from tests (if available)" ON)
+option(USE_LIBUNWIND "use libunwind for more reliable stack traces from tests (if available)" OFF)
 option(USE_CCACHE "use ccache if it is available in the system" ON)
 
 option(TESTS_USE_FORCED_PMEM "run tests with PMEM_IS_PMEM_FORCE=1 - it speeds up tests execution on emulated pmem" OFF)

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -142,6 +142,7 @@ docker run --privileged=true --name=${CONTAINER_NAME} -i \
 	--env TESTS_VALGRIND_UNWIND=${TESTS_VALGRIND_UNWIND:-OFF} \
 	--env TEST_TIMEOUT=${TEST_TIMEOUT} \
 	--env TZ='Europe/Warsaw' \
+	--env USE_LIBUNWIND=${USE_LIBUNWIND:-ON} \
 	--shm-size=4G \
 	-v ${HOST_WORKDIR}:${WORKDIR} \
 	-v /etc/localtime:/etc/localtime \

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -23,8 +23,10 @@ TESTS_PACKAGES=${TESTS_PACKAGES:-ON}
 TESTS_USE_FORCED_PMEM=${TESTS_USE_FORCED_PMEM:-ON}
 TESTS_ASAN=${TESTS_ASAN:-OFF}
 TESTS_UBSAN=${TESTS_UBSAN:-OFF}
-TESTS_VALGRIND_UNWIND=${TESTS_VALGRIND_UNWIND:-OFF}
 TEST_TIMEOUT=${TEST_TIMEOUT:-600}
+# libunwind is switched on by default (in CI scripts), but disabled for valgrind tests
+TESTS_VALGRIND_UNWIND=${TESTS_VALGRIND_UNWIND:-OFF}
+USE_LIBUNWIND=${USE_LIBUNWIND:-ON}
 
 export PMREORDER_STACKTRACE_DEPTH=20
 
@@ -54,7 +56,8 @@ function tests_clang_debug_cpp17_no_valgrind() {
 		-DTESTS_COMPATIBILITY=1 \
 		-DTESTS_CONCURRENT_GDB=1 \
 		-DUSE_ASAN=${TESTS_ASAN} \
-		-DUSE_UBSAN=${TESTS_UBSAN}
+		-DUSE_UBSAN=${TESTS_UBSAN} \
+		-DUSE_LIBUNWIND=${USE_LIBUNWIND}
 
 	make -j$(nproc)
 	ctest --output-on-failure -E "_pmreorder" --timeout ${TEST_TIMEOUT}
@@ -91,7 +94,8 @@ function tests_clang_release_cpp11_no_valgrind() {
 		-DTESTS_COMPATIBILITY=1 \
 		-DTESTS_CONCURRENT_GDB=1 \
 		-DUSE_ASAN=${TESTS_ASAN} \
-		-DUSE_UBSAN=${TESTS_UBSAN}
+		-DUSE_UBSAN=${TESTS_UBSAN} \
+		-DUSE_LIBUNWIND=${USE_LIBUNWIND}
 
 	make -j$(nproc)
 	ctest --output-on-failure -E "_pmreorder" --timeout ${TEST_TIMEOUT}
@@ -107,7 +111,7 @@ function tests_clang_release_cpp11_no_valgrind() {
 # BUILD build_gcc_debug_cpp14 (no tests)
 ###############################################################################
 function build_gcc_debug_cpp14() {
-	VALGRIND_UNWIND=${1:-ON}
+	VALGRIND_UNWIND=${1:-${USE_LIBUNWIND}}
 	mkdir build
 	cd build
 
@@ -198,7 +202,8 @@ function tests_gcc_release_cpp17_no_valgrind() {
 		-DTESTS_USE_FORCED_PMEM=${TESTS_USE_FORCED_PMEM} \
 		-DTESTS_CONCURRENT_GDB=1 \
 		-DUSE_ASAN=${TESTS_ASAN} \
-		-DUSE_UBSAN=${TESTS_UBSAN}
+		-DUSE_UBSAN=${TESTS_UBSAN} \
+		-DUSE_LIBUNWIND=${USE_LIBUNWIND}
 
 	make -j$(nproc)
 	ctest --output-on-failure --timeout ${TEST_TIMEOUT}
@@ -240,7 +245,8 @@ function tests_clang_release_cpp20_no_valgrind() {
 		-DTESTS_COMPATIBILITY=0 \
 		-DTESTS_CONCURRENT_GDB=1 \
 		-DUSE_ASAN=${TESTS_USAN} \
-		-DUSE_UBSAN=${TESTS_UBSAN}
+		-DUSE_UBSAN=${TESTS_UBSAN} \
+		-DUSE_LIBUNWIND=${USE_LIBUNWIND}
 
 	make -j$(nproc)
 	ctest --output-on-failure -E "_pmreorder" --timeout ${TEST_TIMEOUT}


### PR DESCRIPTION
we only enable libunwind usage in our CI scripts and simultaneously disable it for valgrind tests (only in CI scripts).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1224)
<!-- Reviewable:end -->
