### PR TITLE
CI: rename 'gh-pages' branch to 'docs'

### DIFF
--- a/doc/RELEASE_STEPS.md
+++ b/doc/RELEASE_STEPS.md
@@ -34,8 +34,10 @@ Publish package and make it official:
 - announce the release on pmem group and on pmem slack channel(s)
 
 Later, for major/minor release:
-- update library version in [vcpkg](https://github.com/microsoft/vcpkg/blob/master/ports/libpmemobj-cpp) - file an inssue for their maintainers
+- update library version in [vcpkg](https://github.com/microsoft/vcpkg/blob/master/ports/libpmemobj-cpp) - file an issue for their maintainers
 - add new compatibility tests (for new version) in tests/compatibility/CMakeLists.txt, on stable-$VER branch
-- once gh-pages contains new documentation:
+
+<!-- XXX: re-write this paragraph when transition to pmem.io is done -->
+- once 'docs' branch contains new documentation:
  - add there (in index.md) v.$VER section in Doxygen docs links
  - update "Releases' support status" table (older releases' statuses as well, if needed)

--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2021, Intel Corporation
+# Copyright 2018-2022, Intel Corporation
 
 #
 # run-doc-update.sh - is called inside a Docker container,
 #		to build docs for 'valid branches' and to create
-#		a pull request with and update of doxygen files (on gh-pages).
+#		a pull request with and update of doxygen files (on 'docs' branch).
 #
 
 set -e
@@ -26,7 +26,7 @@ REPO_DIR=$(mktemp -d -t libpmemobjcpp-XXX)
 ARTIFACTS_DIR=$(mktemp -d -t ARTIFACTS-XXX)
 LOCAL_REPO=$(git rev-parse --show-toplevel)
 
-# Only 'master' or 'stable-*' branches are valid; determine docs location dir on gh-pages branch
+# Only 'master' or 'stable-*' branches are valid; determine docs location dir on 'docs' branch
 TARGET_BRANCH=${CI_BRANCH}
 if [[ "${TARGET_BRANCH}" == "master" ]]; then
 	TARGET_DOCS_DIR="master"
@@ -69,9 +69,9 @@ cp -r ${REPO_DIR}/build/doc/cpp_html ${ARTIFACTS_DIR}/
 
 cd ${REPO_DIR}
 
-# Checkout gh-pages and copy docs
-GH_PAGES_NAME="${TARGET_DOCS_DIR}-gh-pages-update"
-git checkout -B ${GH_PAGES_NAME} upstream/gh-pages
+# Checkout 'docs' and copy generated documentation
+DOCS_BRANCH_NAME="${TARGET_DOCS_DIR}-docs-update"
+git checkout -B ${DOCS_BRANCH_NAME} upstream/docs
 git clean -dfx
 
 # Clean old content, since some files might have been deleted
@@ -85,12 +85,12 @@ echo "Add and push changes:"
 # In that case we want to force push anyway (there might be open pull request with
 # changes which were reverted).
 git add -A
-git commit -m "doc: automatic gh-pages docs update" && true
-git push -f ${ORIGIN} ${GH_PAGES_NAME}
+git commit -m "doc: automatic docs update for ${TARGET_BRANCH}" && true
+git push -f ${ORIGIN} ${DOCS_BRANCH_NAME}
 
 echo "Make or update pull request:"
 # When there is already an open PR or there are no changes an error is thrown, which we ignore.
-hub pull-request -f -b ${DOC_REPO_OWNER}:gh-pages -h ${BOT_NAME}:${GH_PAGES_NAME} \
-	-m "doc: automatic gh-pages update for ${TARGET_BRANCH}" && true
+hub pull-request -f -b ${DOC_REPO_OWNER}:docs -h ${BOT_NAME}:${DOCS_BRANCH_NAME} \
+	-m "doc: automatic docs update for ${TARGET_BRANCH}" && true
 
 popd


### PR DESCRIPTION
We've begun the process of moving the gh-pages content - generated docs -
into pmem/pmem.github.io repository. It's now required to remove gh-pages
branch here because its content conflicts with pmem.github.io's content.

- [ ] before merging this change we have to actually update the name of the branch (gh-pages -> docs)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1245)
<!-- Reviewable:end -->
