### PR TITLE
cmake: check if tests are built before test-related warning/fatal error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2021, Intel Corporation
+# Copyright 2018-2022, Intel Corporation
 
 cmake_minimum_required(VERSION 3.3)
 
@@ -150,10 +150,8 @@ if(VALGRIND_FOUND)
 	if(VALGRIND_PMEMCHECK_FOUND)
 		add_flag(-DLIBPMEMOBJ_CPP_VG_PMEMCHECK_ENABLED=1)
 	endif()
-elseif(NOT VALGRIND_FOUND AND TESTS_USE_VALGRIND)
-	message(FATAL_ERROR "Valgrind not found, but flag TESTS_USE_VALGRIND was set.")
-elseif(NOT VALGRIND_FOUND)
-	message(WARNING "Valgrind not found. Valgrind tests will not be performed.")
+else()
+	message(STATUS "Valgrind not found.")
 endif()
 
 if(BUILD_TESTS OR BUILD_EXAMPLES OR BUILD_BENCHMARKS)

--- a/cmake/check_compiling_issues.cmake
+++ b/cmake/check_compiling_issues.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2019-2020, Intel Corporation
+# Copyright 2019-2022, Intel Corporation
 
 # This helper cmake file includes various tests for known compilers issues.
 
@@ -43,19 +43,6 @@ if(NOT MSVC_VERSION)
 			return 0;
 		}"
 		NO_GCC_VARIADIC_TEMPLATE_BUG)
-
-	if(NOT NO_GCC_VARIADIC_TEMPLATE_BUG)
-		if(TEST_ARRAY OR TEST_VECTOR OR TEST_STRING OR TEST_CONCURRENT_HASHMAP OR TEST_SEGMENT_VECTOR_ARRAY_EXPSIZE OR TEST_SEGMENT_VECTOR_VECTOR_EXPSIZE OR TEST_SEGMENT_VECTOR_VECTOR_FIXEDSIZE OR TEST_ENUMERABLE_THREAD_SPECIFIC)
-			message(FATAL_ERROR
-				"Compiler does not support expanding variadic template variables in lambda expressions. "
-				"For more information about compiler requirements, check README.md.")
-		elseif()
-			message(WARNING
-				"Compiler does not support expanding variadic template variables in lambda expressions. "
-				"Some tests will be skipped and some functionalities won't be installed. "
-				"For more information about compiler requirements, check README.md.")
-		endif()
-	endif()
 
 	# Check for issues with older gcc compilers if "inline" aggregate initialization
 	# works for array class members https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65815

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2021, Intel Corporation
+# Copyright 2018-2022, Intel Corporation
 
 include(ctest_helpers.cmake)
 
@@ -71,6 +71,16 @@ endif()
 
 if(COVERAGE)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -coverage")
+endif()
+
+if(NOT VALGRIND_FOUND AND TESTS_USE_VALGRIND)
+	message(FATAL_ERROR "Valgrind not found, but flag TESTS_USE_VALGRIND was set.")
+endif()
+
+if(NOT NO_GCC_VARIADIC_TEMPLATE_BUG AND (TEST_ARRAY OR TEST_VECTOR OR TEST_STRING OR TEST_CONCURRENT_HASHMAP OR TEST_SEGMENT_VECTOR_ARRAY_EXPSIZE OR TEST_SEGMENT_VECTOR_VECTOR_EXPSIZE OR TEST_SEGMENT_VECTOR_VECTOR_FIXEDSIZE OR TEST_ENUMERABLE_THREAD_SPECIFIC))
+	message(FATAL_ERROR
+		"Compiler does not support expanding variadic template variables in lambda expressions. "
+		"For more information about compiler requirements, check README.md.")
 endif()
 
 # Prepare additional libraries/executables and find packages required for tests


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1249)
<!-- Reviewable:end -->
