### PR TITLE
docker: update pmdk installed version to 1.12.0

### DIFF
--- a/utils/docker/images/install-pmdk.sh
+++ b/utils/docker/images/install-pmdk.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2018-2021, Intel Corporation
+# Copyright 2018-2022, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -36,10 +36,10 @@
 
 set -e
 
-PACKAGE_MANAGER=$1
+PACKAGE_MANAGER=${1}
 
-# master: 1.11.0, 02.07.2021
-PMDK_VERSION="8583fcfd68764ac6779e6f93db89b06971b26704"
+# common: 1.12.0 release, 24.05.2022
+PMDK_VERSION="73d8f958e855904dc0776a7d77d0f0d3698a65b1"
 
 if [ "${SKIP_PMDK_BUILD}" ]; then
 	echo "Variable 'SKIP_PMDK_BUILD' is set; skipping building PMDK"


### PR DESCRIPTION
we should make all stable branches work properly, this fix is needed on a few of them, so we could actually update this on all branches which have GHA enabled.

We could also pursue the opportunity and make the last patch release on this branch to close it as well.