### PR TITLE
utils: fix permissions for auto doc updates

### DIFF
--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -10,6 +10,8 @@
 
 set -e
 
+source $(dirname ${0})/prepare-for-build.sh
+
 if [[ -z "${DOC_UPDATE_GITHUB_TOKEN}" ]]; then
 	echo "To build documentation and upload it as a Github pull request, variable " \
 		"'DOC_UPDATE_GITHUB_TOKEN' has to be provided."


### PR DESCRIPTION
it's required to change owner of the WORKDIR with the help of 'prepare-for-build.sh' script.

Fixes CI issue: https://github.com/pmem/libpmemobj-cpp/runs/8113898448?check_suite_focus=true#step:3:69

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libpmemobj-cpp/1278)
<!-- Reviewable:end -->
