### PR TITLE
utils: don't fail auto doc update if no GH token provided

### DIFF
--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -15,7 +15,7 @@ source $(dirname ${0})/prepare-for-build.sh
 if [[ -z "${DOC_UPDATE_GITHUB_TOKEN}" ]]; then
 	echo "To build documentation and upload it as a Github pull request, variable " \
 		"'DOC_UPDATE_GITHUB_TOKEN' has to be provided."
-	exit 1
+	exit 0
 fi
 
 if [[ -z "${WORKDIR}" ]]; then


### PR DESCRIPTION
master (or any push) is failing on forks, because we usually don't set this variable. On the upstream it shouldn't be a problem, because 1) we always set this variable; 2) we would see on pmem.io our docs are not updated (if the CI doc's job will silently exit after this change).